### PR TITLE
[IMP] Add class CarrierAccount, so the specifics carriers modules use al...

### DIFF
--- a/base_delivery_carrier_label/delivery.py
+++ b/base_delivery_carrier_label/delivery.py
@@ -96,3 +96,41 @@ class DeliveryCarrier(orm.Model):
             'delivery.carrier.option',
             'carrier_id', 'Option'),
     }
+
+
+class CarrierAccount(orm.Model):
+    _name = 'carrier.account'
+    _description = 'Base account datas'
+
+    def _get_carrier_type(self, cr, uid, context=None):
+        """ To inherit to add carrier type like Chronopost, Postlogistics..."""
+        return []
+
+    def __get_carrier_type(self, cr, uid, context=None):
+        """ Wrapper to preserve inheritance for selection field """
+        return self._get_carrier_type(cr, uid, context=context)
+
+    def _get_file_format(self, cr, uid, context=None):
+        """ To inherit to add label file types"""
+        return [('PDF', 'PDF'),
+                ('SPD', 'SPD'),
+                ('PPR', 'PPR'),
+                ('THE', 'THE'),
+                ('ZPL', 'ZPL'),
+                ('XML', 'XML')]
+
+    def __get_file_format(self, cr, uid, context=None):
+        """ Wrapper to preserve inheritance for selection field """
+        return self._get_file_format(cr, uid, context=context)
+
+    _columns = {
+        'name': fields.char('Name', size=64, required=True),
+        'account': fields.char('Account Number', size=32, required=True),
+        'password': fields.char('Account Password', size=32, required=True),
+        'file_format': fields.selection(__get_file_format, 'File Format',
+            help="Default format of the carrier's label you want to print"),
+        'type': fields.selection(__get_carrier_type, 'Type', required=True,
+            help="In case of several carriers, help to know which account belong to which carrier"),
+    }
+
+

--- a/base_delivery_carrier_label/delivery.py
+++ b/base_delivery_carrier_label/delivery.py
@@ -124,13 +124,16 @@ class CarrierAccount(orm.Model):
         return self._get_file_format(cr, uid, context=context)
 
     _columns = {
-        'name': fields.char('Name', size=64, required=True),
-        'account': fields.char('Account Number', size=32, required=True),
-        'password': fields.char('Account Password', size=32, required=True),
-        'file_format': fields.selection(__get_file_format, 'File Format',
+        'name': fields.char('Name', required=True),
+        'account': fields.char('Account Number', required=True),
+        'password': fields.char('Account Password', required=True),
+        'file_format': fields.selection(
+            __get_file_format, 'File Format',
             help="Default format of the carrier's label you want to print"),
-        'type': fields.selection(__get_carrier_type, 'Type', required=True,
-            help="In case of several carriers, help to know which account belong to which carrier"),
+        'type': fields.selection(
+            __get_carrier_type, 'Type', required=True,
+            help="In case of several carriers, help to know which "
+                 "account belong to which carrier"),
     }
 
 

--- a/base_delivery_carrier_label/security/ir.model.access.csv
+++ b/base_delivery_carrier_label/security/ir.model.access.csv
@@ -5,3 +5,5 @@ access_delivery_carrier_template_option_salesman,delivery.carrier.relation.optio
 access_delivery_carrier_template_option_sales_manager,delivery.carrier.relation.option.sale.manager,model_delivery_carrier_template_option,base.group_sale_manager,1,1,1,1
 access_shipping_label_user,shipping.label user,model_shipping_label,stock.group_stock_user,1,1,1,0
 access_shipping_label_manager,shipping.label manager,model_shipping_label,stock.group_stock_manager,1,1,1,1
+access_carrier_account_salesman,carrier.account.salesman,model_carrier_account,base.group_sale_salesman,1,0,0,0
+access_carrier_account_sale_manager,carrier.account.sale.manager,model_carrier_account,base.group_sale_manager,1,1,1,1

--- a/base_delivery_carrier_label/stock.py
+++ b/base_delivery_carrier_label/stock.py
@@ -359,6 +359,7 @@ class stock_picking_out(orm.Model):
         """ On each carrier label module you need to define
             which is the sender of the parcel.
             The most common case is 'picking.company_id.partner_id'
+            and then choose the contact which has the type 'delivery'
             which is suitable for each delivery carrier label module.
             But your client might want to customize sender address
             if he has several brands and/or shops in his company.
@@ -371,7 +372,16 @@ class stock_picking_out(orm.Model):
             can manage specific needs by inherit this method in module like :
             delivery_carrier_label_yourcarrier_yourproject.
         """
-        return picking.company_id.partner_id
+        partner_obj = self.pool['res.partner']
+        partner = picking.company_id.partner_id
+        delivery_address = partner_obj.search(cr, uid, [
+                                             ('parent_id', '=', partner.id),
+                                             ('type', '=', 'delivery')])
+        if delivery_address:
+            partner = delivery.browse(cr, uid, 
+                                      [delivery_address[0]], 
+                                      context=context)
+        return partner
 
     def carrier_id_change(self, cr, uid, ids, carrier_id, context=None):
         """ Inherit this method in your module """


### PR DESCRIPTION
Add a new class to configure the specific Carrier Accounts.
The purpose of this class is to be inherited by specific carrier modules so they add their specificities.

You can find an example of use here (the module is still work in progress)

http://bazaar.launchpad.net/~florian-dacosta/+junk/delivery_carrier_chronopost/view/head:/delivery_carrier_chronopost/config.py

Original proposal on Launchpad : https://code.launchpad.net/~akretion-team/carriers-deliveries/7-add-base-class-for-carrier-configs/+merge/224598
