### PR TITLE
Use the boolean fields instead of the state field

### DIFF
--- a/delivery_carrier_label_dispatch/picking_dispatch.py
+++ b/delivery_carrier_label_dispatch/picking_dispatch.py
@@ -74,7 +74,7 @@ class PickingDispatch(Model):
             available_option_ids = []
             for available_option in carrier.available_option_ids:
                 available_option_ids.append(available_option.id)
-                if available_option.state in ['default_option', 'mandatory']:
+                if available_option.mandatory or available_option.by_default:
                     default_option_ids.append(available_option.id)
             res = {
                 'value': {'carrier_type': carrier.type,
@@ -94,7 +94,7 @@ class PickingDispatch(Model):
             return res
         carrier = carrier_obj.browse(cr, uid, carrier_id, context=context)
         for available_option in carrier.available_option_ids:
-            if (available_option.state == 'mandatory'
+            if (available_option.mandatory
                     and available_option.id not in option_ids[0][2]):
                 res['warning'] = {
                     'title': _('User Error !'),

--- a/delivery_carrier_label_postlogistics/delivery.py
+++ b/delivery_carrier_label_postlogistics/delivery.py
@@ -215,7 +215,7 @@ class DeliveryCarrier(orm.Model):
                 opt.tmpl_option_id.postlogistics_type
                 for opt in carrier.available_option_ids
                 if opt.postlogistics_type in single_option_types
-                and opt.state in ['mandatory']]
+                and opt.mandatory]
             if selected_single_options != single_option_types:
                 service_ids = option_template_obj.search(
                     cr, uid,


### PR DESCRIPTION
Following https://github.com/OCA/carrier-delivery/commit/59038bd27aee9a7f8b65740103bfa1826e62a6da,
the 'state' field has been replaced by boolean fields.

Closes #43
