### PR TITLE
define context if not set in stock.py

### DIFF
--- a/base_delivery_carrier_label/stock.py
+++ b/base_delivery_carrier_label/stock.py
@@ -110,6 +110,8 @@ class stock_picking(orm.Model):
         the labels only of these trackings.
 
         """
+        if context is None:
+            context = {}
         shipping_label_obj = self.pool.get('shipping.label')
 
         pickings = self.browse(cr, uid, ids, context=context)


### PR DESCRIPTION
define context in generate_labels().
In some case ie errpeek you send model('stock.picking.out').generate_labels([my_id]) and context is not passed
and it breaks at context_attachment = context.copy()
