### PR TITLE
Do not return duplicate packages when several moves have the same one

### DIFF
--- a/base_delivery_carrier_label/stock.py
+++ b/base_delivery_carrier_label/stock.py
@@ -229,7 +229,7 @@ class StockPicking(models.Model):
         for operation in operations:
             # Take the destination package. If empty, the package is
             # moved so take the source one.
-            packages += operation.result_package_id or operation.package_id
+            packages |= operation.result_package_id or operation.package_id
         return packages
 
     @api.multi


### PR DESCRIPTION
Because it will print several labels for the same package.
