### PR TITLE
Add try/catch on pycountry import

### DIFF
--- a/delivery_carrier_label_gls/report/label.py
+++ b/delivery_carrier_label_gls/report/label.py
@@ -19,15 +19,14 @@
 #
 ###############################################################################
 
+import logging
 from mako.template import Template
 from mako.exceptions import RichTraceback
 from .label_helper import AbstractLabel
 from .exception_helper import (InvalidAccountNumber)
 import httplib
 from unidecode import unidecode
-import logging
 import os
-import pycountry
 
 REPORT_CODING = 'cp1252'
 ERROR_BEHAVIOR = 'backslashreplace'
@@ -36,8 +35,6 @@ GLS_PORT = 80
 WEB_SERVICE_CODING = 'ISO-8859-1'
 LABEL_FILE_NAME = 'gls'
 
-logger = logging.getLogger(__name__)
-
 URL_PROD = "http://www.gls-france.com/cgi-bin/glsboxGI.cgi"
 URL_TEST = "http://www.gls-france.com/cgi-bin/glsboxGITest.cgi"
 
@@ -45,18 +42,25 @@ URL_TEST = "http://www.gls-france.com/cgi-bin/glsboxGITest.cgi"
 class InvalidDataForMako(Exception):
     ""
 
+logger = logging.getLogger(__name__)
+try:
+    import pycountry
 
-def GLS_countries_prefix():
-    """For GLS carrier 'Serbie Montenegro' is 'CS' and for wikipedia it's 'ME'
-    We have to do a quick replacement
-    """
-    GLS_prefix = []
-    for elm in pycountry.countries:
-        GLS_prefix.append(str(elm.alpha2))
-    GLS_prefix[GLS_prefix.index('ME')] = 'CS'
-    return GLS_prefix
+    def GLS_countries_prefix():
+        """For GLS carrier 'Serbie Montenegro' is 'CS'
+        and for wikipedia it's 'ME'
+        We have to do a quick replacement
+        """
+        GLS_prefix = []
+        for elm in pycountry.countries:
+            GLS_prefix.append(str(elm.alpha2))
+        GLS_prefix[GLS_prefix.index('ME')] = 'CS'
+        return GLS_prefix
 
-GLS_COUNTRIES_PREFIX = GLS_countries_prefix()
+    GLS_COUNTRIES_PREFIX = GLS_countries_prefix()
+except ImportError:
+    logger.warn('Please install python lib pycountry')
+    GLS_COUNTRIES_PREFIX = []
 
 EUROPEAN_COUNTRIES = [
     'AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'ES', 'EE', 'FI', 'GR',

--- a/delivery_carrier_label_gls/stock.py
+++ b/delivery_carrier_label_gls/stock.py
@@ -19,6 +19,7 @@
 #
 ###############################################################################
 
+import logging
 from openerp.osv import orm
 from openerp.tools.translate import _
 from .report.label import GLSLabel, InvalidDataForMako
@@ -29,8 +30,14 @@ from .report.label_helper import (
     InvalidType,)
 from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from datetime import datetime
-import pycountry
 from operator import attrgetter
+
+
+logger = logging.getLogger(__name__)
+try:
+    import pycountry
+except ImportError:
+    logger.warn('Please install python lib pycountry')
 
 
 EXCEPT_TITLE = "GLS Library Exception"


### PR DESCRIPTION
Even if the module is not installed, the code from `delivery_carrier_label_gls` is called when the server is launched. I added some try/catches so that `import pycountry` does not fail if the egg is not present.
