### PR TITLE
Add index on shipping_label.tracking_id

### DIFF
--- a/base_delivery_carrier_label/stock.py
+++ b/base_delivery_carrier_label/stock.py
@@ -455,7 +455,7 @@ class ShippingLabel(orm.Model):
 
     _columns = {
         'file_type': fields.selection(__get_file_type_selection, 'File type'),
-        'tracking_id': fields.many2one('stock.tracking', 'Pack'),
+        'tracking_id': fields.many2one('stock.tracking', 'Pack', select=True),
     }
 
     _defaults = {


### PR DESCRIPTION
Because this field is used for lookups.
Got an index scan of 0.033ms instead of a seq scan of 83.557ms.
