### PR TITLE
[7.0] Correctly check for no tracking

### DIFF
--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -276,9 +276,18 @@ class PostlogisticsWebService(object):
 
     def _prepare_item_list(self, picking, recipient, attributes, trackings):
         """ Return a list of item made from the pickings """
+
+        # Check for an empty list (no packs) => use the picking
+        if not trackings:
+            return [{'ItemID': self._get_itemid(picking, picking.name),
+                     'Recipient': recipient,
+                     'Attributes': attributes,
+                     }]
+
+        # Otherwise, create an item per pack
         item_list = []
         for pack in trackings:
-            name = pack.name if pack else picking.name
+            name = pack.name
             itemid = self._get_itemid(picking, name)
             item = {
                 'ItemID': itemid,


### PR DESCRIPTION
Issue: a picking with multiple move lines, but no tracking/packs at all, will not return a label or an error.

The issue was due to the fact that `trackings = sorted(set(line.tracking_id for line in picking.move_lines), key=attrgetter('name'))` did not return `[False]` as expected in the mentioned case, but `[browse_null(<memory address 1>), browse_null(<memory address 2>)]`. This leads to the final check on all trackings to fail silently since `len(trackings) > 1`.

To avoid passing `[False]`, I decided to instead remove all null packs from the tracking list, and then check for an empty list instead.
