### PR TITLE
s/tracking/package in docstring of generate_labels

### DIFF
--- a/base_delivery_carrier_label/stock.py
+++ b/base_delivery_carrier_label/stock.py
@@ -222,7 +222,7 @@ class StockPicking(models.Model):
     def generate_labels(self, package_ids=None):
         """ Generate the labels.
 
-        A list of tracking ids can be given, in that case it will generate
+        A list of package ids can be given, in that case it will generate
         the labels only of these packages.
 
         """


### PR DESCRIPTION
Fix a small error in the docs of generate_label
