### PR TITLE
do not choose weight instead of weight_net

### DIFF
--- a/base_delivery_carrier_label/stock.py
+++ b/base_delivery_carrier_label/stock.py
@@ -64,8 +64,8 @@ class StockPackOperation(models.Model):
                     'Type conversion not implemented for product %s' %
                     product.id)
                 cant_calc_total = True
-
-            operation.weight = (product.weight * operation.product_qty)
+            weight = product.weight or product.weight_net
+            operation.weight = (weight * operation.product_qty)
 
             total_weight += operation.weight
 


### PR DESCRIPTION
in base_delivery_carrier_label

There is no way to the user to know which field is taken account, then we should take both.
If think it's better than `max(weight, weight_net)`
