### PR TITLE
[FIX] prevent create deposit slip in tree/form view

### DIFF
--- a/delivery_carrier_deposit/stock_view.xml
+++ b/delivery_carrier_deposit/stock_view.xml
@@ -41,7 +41,7 @@
 <record id="view_deposit_slip_tree" model="ir.ui.view">
     <field name="model">deposit.slip</field>
     <field name="arch" type="xml">
-    <tree string="Deposit" colors="blue:state=='draft'">
+    <tree string="Deposit" colors="blue:state=='draft'" create="0">
         <field name="name"/>
         <field name="carrier_type"/>
         <field name="create_date"/>
@@ -55,7 +55,7 @@
 <record id="view_deposit_slip_form" model="ir.ui.view">
     <field name="model">deposit.slip</field>
     <field name="arch" type="xml">
-        <form string="Deposit">
+        <form string="Deposit" create="0">
             <header>
                 <button name="validate_deposit" string="Confirm" type="object"
                         attrs="{'invisible' : ['|', ('state','!=','draft'), ('carrier_type', '=', False)]}"


### PR DESCRIPTION
There is a wizard to create deposit.slip, so it improve usability.

Before this PR, it's error prone.
