### PR TITLE
Rename field type to carrier_type in delivery.carrier

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -13,10 +13,11 @@ class DeliveryCarrier(models.Model):
         """ To inherit to add carrier type """
         return []
 
-    type = fields.Selection(
+    carrier_type = fields.Selection(
         selection='_get_carrier_type_selection',
         string='Type',
         help="Carrier type (combines several delivery methods)",
+        oldname='type',
     )
     code = fields.Char(
         help="Delivery Method Code (according to carrier)",

--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -20,7 +20,7 @@ class StockPicking(models.Model):
         states={'done': [('readonly', True)]},
     )
     carrier_type = fields.Selection(
-        related='carrier_id.type',
+        related='carrier_id.carrier_type',
         string='Carrier Type',
         readonly=True,
     )
@@ -133,7 +133,7 @@ class StockPicking(models.Model):
         # module that depend of delivery base can hide some field
         # depending of the type or the code
         carrier = self.carrier_id
-        self.carrier_type = carrier.type
+        self.carrier_type = carrier.carrier_type
         self.carrier_code = carrier.code
         self.option_ids = carrier.default_options()
         result = {

--- a/base_delivery_carrier_label/views/delivery.xml
+++ b/base_delivery_carrier_label/views/delivery.xml
@@ -70,7 +70,7 @@
 
       <xpath expr="//h1" position="after">
         <group>
-          <field name="type"/>
+          <field name="carrier_type"/>
           <field name="code"/>
         </group>
       </xpath>
@@ -93,7 +93,7 @@
     <field name="inherit_id" ref="delivery.view_delivery_carrier_tree"/>
     <field name="arch" type="xml">
       <field name="name" position="after">
-        <field name="type"/>
+        <field name="carrier_type"/>
         <field name="code"/>
       </field>
     </field>

--- a/delivery_carrier_label_postlogistics/models/stock.py
+++ b/delivery_carrier_label_postlogistics/models/stock.py
@@ -105,7 +105,7 @@ class StockPicking(models.Model):
     def generate_shipping_labels(self, package_ids=None):
         """ Add label generation for Postlogistics """
         self.ensure_one()
-        if self.carrier_id.type == 'postlogistics':
+        if self.carrier_id.carrier_type == 'postlogistics':
             return self._generate_postlogistics_label(package_ids=package_ids)
         _super = super(StockPicking, self)
         return _super.generate_shipping_labels(package_ids=package_ids)

--- a/delivery_carrier_label_postlogistics/tests/test_postlogistics.py
+++ b/delivery_carrier_label_postlogistics/tests/test_postlogistics.py
@@ -41,7 +41,7 @@ class TestPostlogistics(common.TransactionCase):
         partner_xmlid = 'delivery_carrier_label_postlogistics.postlogistics'
         self.carrier = self.env['delivery.carrier'].create({
             'name': 'Postlogistics',
-            'type': 'postlogistics',
+            'carrier_type': 'postlogistics',
             'product_id': Product.create({'name': 'Shipping'}).id,
             'partner_id': self.env.ref(partner_xmlid).id,
         })

--- a/delivery_carrier_label_postlogistics/views/delivery.xml
+++ b/delivery_carrier_label_postlogistics/views/delivery.xml
@@ -42,9 +42,9 @@
     <field name="model">delivery.carrier</field>
     <field name="inherit_id" ref="base_delivery_carrier_label.view_delivery_carrier_form" />
     <field name="arch" type="xml">
-      <field name="type" position="after">
-        <field name="postlogistics_service_group_id" attrs="{'invisible': [('type', '!=', 'postlogistics')], 'required': [('type', '=', 'postlogistics')]}"/>
-        <field name="postlogistics_license_id" attrs="{'invisible': [('type', '!=', 'postlogistics')]}"/>
+      <field name="carrier_type" position="after">
+        <field name="postlogistics_service_group_id" attrs="{'invisible': [('carrier_type', '!=', 'postlogistics')], 'required': [('carrier_type', '=', 'postlogistics')]}"/>
+        <field name="postlogistics_license_id" attrs="{'invisible': [('carrier_type', '!=', 'postlogistics')]}"/>
         <field name="allowed_option_ids" invisible="1"/>
       </field>
       <field name="available_option_ids" position="attributes">


### PR DESCRIPTION
Because delivery.carrier is an inherits of product.product which already as a field 'type' so it's impossible to fill value for product.type.
