### PR TITLE
IMP add a dedicate tree view to deposit.slip picking_ids field

### DIFF
--- a/delivery_carrier_deposit/stock_view.xml
+++ b/delivery_carrier_deposit/stock_view.xml
@@ -76,7 +76,18 @@
                     <field name="number_of_packages"/>
                 </group>
                 <group name="pickings">
-                    <field name="picking_ids" nolabel="1" widget="many2many"/>
+                    <field name="picking_ids" nolabel="1" widget="many2many">
+                        <tree>
+                            <field name="name"/>
+                            <field name="partner_id"/>
+                            <field name="number_of_packages"/>
+                            <field name="weight"/>
+                            <field name="origin"/>
+                            <field name="backorder_id"/>
+                            <field name="date_done"/>
+                            <field name="state" invisible="1"/>
+                        </tree>
+                    </field>
                 </group>
             </sheet>
             <div class="oe_chatter">


### PR DESCRIPTION

## Old view
![av](https://cloud.githubusercontent.com/assets/1853434/20237441/cc66ebfa-a8d2-11e6-9f34-b6438f531d18.png)
No weight or package here 

## New view
![af](https://cloud.githubusercontent.com/assets/1853434/20237440/caa497d6-a8d2-11e6-9a46-a9e7d1067976.png)

User now focus on main info

ping @yvaucher @alexis-via @hparfr @guewen 