### PR TITLE
[9][base_delivery_carrier_label]Fix package view

### DIFF
--- a/base_delivery_carrier_label/views/stock.xml
+++ b/base_delivery_carrier_label/views/stock.xml
@@ -38,7 +38,6 @@
     <field name="arch" type="xml">
       <field name="packaging_id" position="before">
         <field name="parcel_tracking"/>
-        <field name="weight"/>
       </field>
     </field>
   </record>


### PR DESCRIPTION
The weight field is already added in delivery module so it is duplicated in the view.
https://github.com/OCA/OCB/blob/9.0/addons/delivery/views/delivery_view.xml#L224