### PR TITLE
ADD module base_delivery_carrier_label_direct_print

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
+      - cups
+      - libcups2-dev
       - wkhtmltopdf
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
+  - pip install pycups==1.9.66
   - pip install PyPDF2==1.18
   - pip install unidecode
   - pip install pycountry

--- a/base_delivery_carrier_label_direct_print/README.rst
+++ b/base_delivery_carrier_label_direct_print/README.rst
@@ -23,7 +23,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/delivery-carrier/10.0
+   :target: https://runbot.odoo-community.org/runbot/99/10.0
 
 
 Known issues / Roadmap
@@ -35,7 +35,7 @@ Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues
-<https://github.com/OCA/99/issues>`_. In case of trouble, please
+<https://github.com/OCA/delivery-carrier/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
 help us smash it by providing detailed and welcomed feedback.
 

--- a/base_delivery_carrier_label_direct_print/README.rst
+++ b/base_delivery_carrier_label_direct_print/README.rst
@@ -6,7 +6,7 @@
 Delivery Carrier Labels Direct Print
 ====================================
 
-This module extends the functionality of delivery carrier labes to support direct print.
+This module extends the functionality of delivery carrier labels to support direct print.
 
 
 Configuration
@@ -23,7 +23,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/99/10.0
+   :target: https://runbot.odoo-community.org/runbot/delivery-carrier/10.0
 
 
 Known issues / Roadmap

--- a/base_delivery_carrier_label_direct_print/README.rst
+++ b/base_delivery_carrier_label_direct_print/README.rst
@@ -1,0 +1,68 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+====================================
+Delivery Carrier Labels Direct Print
+====================================
+
+This module extends the functionality of delivery carrier labes to support direct print.
+
+
+Configuration
+=============
+
+To configure this module, you need to go to delivery carrier and set printing options on 'Labels' sheet.
+
+* Set 'Direct Print' to direct send to printer label when you generate it on picking.
+* Set 'No Attach' for only print and no attach file.
+* Set 'Printer' as default printer for this labels.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/99/10.0
+
+
+Known issues / Roadmap
+======================
+
+* If no printer as setted for a carrier could be better to use user printer.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/99/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Angel Moya <angel.moya@pesol.es>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_delivery_carrier_label_direct_print/__init__.py
+++ b/base_delivery_carrier_label_direct_print/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2017 Angel Moya (PESOL)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models

--- a/base_delivery_carrier_label_direct_print/__manifest__.py
+++ b/base_delivery_carrier_label_direct_print/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2017 Angel Moya (PESOL)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{'name': 'Delivery Carrier Labels Direct Print',
+ 'version': '10.0.1.0.0',
+ 'author': "PESOL,Odoo Community Association (OCA)",
+ 'maintainer': 'PESOL',
+ 'website': 'http://www.pesol.es',
+ 'category': 'Delivery',
+ 'depends': [
+     'base_delivery_carrier_label',
+     'base_report_to_printer'],
+ 'data': [
+     'views/delivery.xml', ],
+ 'installable': True,
+ 'auto_install': False,
+ 'license': 'AGPL-3',
+ }

--- a/base_delivery_carrier_label_direct_print/__manifest__.py
+++ b/base_delivery_carrier_label_direct_print/__manifest__.py
@@ -4,7 +4,6 @@
 {'name': 'Delivery Carrier Labels Direct Print',
  'version': '10.0.1.0.0',
  'author': "PESOL,Odoo Community Association (OCA)",
- 'maintainer': 'PESOL',
  'website': 'http://www.pesol.es',
  'category': 'Delivery',
  'depends': [

--- a/base_delivery_carrier_label_direct_print/models/__init__.py
+++ b/base_delivery_carrier_label_direct_print/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2017 Angel Moya (PESOL)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import delivery_carrier
+from . import shipping_label
+from . import stock_picking

--- a/base_delivery_carrier_label_direct_print/models/delivery_carrier.py
+++ b/base_delivery_carrier_label_direct_print/models/delivery_carrier.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2017 Angel Moya (PESOL)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models, _
-from openerp.exceptions import ValidationError
+from odoo import api, fields, models
 
 
 class DeliveryCarrier(models.Model):
@@ -19,10 +18,3 @@ class DeliveryCarrier(models.Model):
     @api.onchange('direct_print')
     def _onchange_direct_print(self):
         self.no_attach = self.direct_print and self.no_attach
-
-    @api.constrains('direct_print', 'no_attach')
-    def _check_field(self):
-        if self.no_attach and not self.direct_print:
-            raise ValidationError(_(
-                "You can not set 'No Attach' and not set 'Direct Print'"
-            ))

--- a/base_delivery_carrier_label_direct_print/models/delivery_carrier.py
+++ b/base_delivery_carrier_label_direct_print/models/delivery_carrier.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# © 2017 Angel Moya (PESOL)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models, _
+from openerp.exceptions import ValidationError
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    direct_print = fields.Boolean(
+        string='Direct Print')
+    no_attach = fields.Boolean(
+        string='No Attach')
+    printer_id = fields.Many2one(
+        comodel_name='printing.printer',
+        string='Printer')
+
+    @api.onchange('direct_print')
+    def _onchange_direct_print(self):
+        self.no_attach = self.direct_print and self.no_attach
+
+    @api.constrains('direct_print', 'no_attach')
+    def _check_field(self):
+        if self.no_attach and not self.direct_print:
+            raise ValidationError(_(
+                "You can not set 'No Attach' and not set 'Direct Print'"
+            ))

--- a/base_delivery_carrier_label_direct_print/models/shipping_label.py
+++ b/base_delivery_carrier_label_direct_print/models/shipping_label.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2017 Angel Moya (PESOL)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, models
+import base64
+
+
+class ShippingLabel(models.Model):
+
+    _inherit = 'shipping.label'
+
+    @api.model
+    def create(self, values):
+        if values.get('direct_print') and values.get('datas'):
+            printer = values.get('printer_id') or \
+                self.env['printing.printer'].get_default()
+            printer.print_document(
+                None, base64.b64decode(values.get('datas')), 'raw')
+            values.pop('direct_print')
+            values.pop('printer_id')
+        if values.get('no_attach'):
+            return True
+        return super(ShippingLabel, self).create(values)

--- a/base_delivery_carrier_label_direct_print/models/stock_picking.py
+++ b/base_delivery_carrier_label_direct_print/models/stock_picking.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# © 2017 Angel Moya (PESOL)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import models, api
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.multi
+    def get_shipping_label_values(self, label):
+        result = super(StockPicking, self).get_shipping_label_values(label)
+        if self.carrier_id:
+            result.update({'direct_print': self.carrier_id.direct_print,
+                           'no_attach': self.carrier_id.no_attach,
+                           'printer_id': self.carrier_id.printer_id})
+        return result

--- a/base_delivery_carrier_label_direct_print/views/delivery.xml
+++ b/base_delivery_carrier_label_direct_print/views/delivery.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_delivery_carrier_form" model="ir.ui.view">
+        <field name="name">delivery_base.delivery.carrier.view_form</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Labels">
+                    <group string="Print">
+                        <field name="direct_print"/>
+                        <field name="printer_id" attrs="{'invisible':[('direct_print','=', False)]}"/>
+                        <field name="no_attach" attrs="{'invisible':[('direct_print','=', False)]}"/>
+                    </group>
+                </page>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -4,3 +4,4 @@ partner-contact
 server-tools
 stock-logistics-workflow
 webkit-tools
+report-print-send


### PR DESCRIPTION
Adds suport to direct print delivery carrier labels

Check before:
base_delivery_carrier_label MIG 10.0 - https://github.com/OCA/delivery-carrier/pull/124
base_report_to_printer IMP format - https://github.com/OCA/report-print-send/pull/84