### PR TITLE
[9.0] Use correct syntax to add options with onchange on stock picking

### DIFF
--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -135,7 +135,8 @@ class StockPicking(models.Model):
         carrier = self.carrier_id
         self.carrier_type = carrier.carrier_type
         self.carrier_code = carrier.code
-        self.option_ids = carrier.default_options()
+        default_options = carrier.default_options()
+        self.option_ids = [(6, 0, default_options.ids)]
         result = {
             'domain': {
                 'option_ids': [('id', 'in', carrier.available_option_ids.ids)],


### PR DESCRIPTION
Small fix for an issue I found : if the carrier is edited manually on a stock picking, the values given to the one2many field "option_ids" are a RecordSet.

It works fine when editing, but afterwards, when the picking is written, the values are with the format `{'option_ids': [(1, <ID of the option>, <value of the option>)]}`, not `{'option_ids': [(6, False, [<ID of the option>])]}`, which leads to the values not being written in the picking.