### PR TITLE
[7.0][IMP] Allow inherits on get_type_selection

### DIFF
--- a/base_delivery_carrier_files/carrier_file.py
+++ b/base_delivery_carrier_files/carrier_file.py
@@ -44,7 +44,9 @@ class CarrierFile(orm.Model):
 
     _columns = {
         'name': fields.char('Name', size=64, required=True),
-        'type': fields.selection(get_type_selection, 'Type', required=True),
+        'type': fields.selection(
+            selection=lambda s, cr, uid, context=None: s.get_type_selection(
+                cr, uid, context=context)),
         'group_pickings': fields.boolean('Group all pickings in one file',
                                          help='All the pickings will be '
                                               'grouped in the same file. '


### PR DESCRIPTION
Change the "type" field definition to allow other modules to inherit the method and add other delivery types