### PR TITLE
[IMP] stock_picking_delivery_rate: Add reference & cancellation

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,6 +1,8 @@
 # list the OCA project dependencies, one per line
 # add a github url if you need a forked version
 partner-contact
+# https://github.com/OCA/purchase-workflow/pull/474
+purchase-workflow https://github.com/LasLabs/purchase-workflow.git release/10.0/purchase_line_reference
 server-tools
 stock-logistics-workflow
 webkit-tools

--- a/stock_picking_delivery_rate/__manifest__.py
+++ b/stock_picking_delivery_rate/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Picking Delivery Rate",
     "summary": "Adds a concept of rate quotes for stock pickings",
-    "version": "10.0.1.0.0",
+    "version": "10.0.2.0.0",
     "category": "Inventory, Logistics, Warehousing",
     "website": "https://laslabs.com/",
     "author": "LasLabs, Odoo Community Association (OCA)",
@@ -15,13 +15,15 @@
     "depends": [
         "stock",
         "delivery",
-        'purchase',
+        'purchase_line_reference',
     ],
     "data": [
+        "data/res_request_link_data.xml",
         "security/ir.model.access.csv",
         "views/delivery_carrier_view.xml",
         "views/stock_picking_view.xml",
         "views/stock_picking_rate_view.xml",
+        "wizards/stock_picking_rate_cancel_view.xml",
         'wizards/stock_picking_rate_purchase_view.xml',
     ],
 }

--- a/stock_picking_delivery_rate/data/res_request_link_data.xml
+++ b/stock_picking_delivery_rate/data/res_request_link_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright 2017 LasLabs Inc.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html). -->
+
+<odoo>
+
+    <record id="res_request_link_dispatch_rate" model="res.request.link">
+        <field name="name">Dispatch Rate</field>
+        <field name="object">stock.picking.rate</field>
+    </record>
+
+</odoo>

--- a/stock_picking_delivery_rate/tests/test_stock_picking_rate_purchase.py
+++ b/stock_picking_delivery_rate/tests/test_stock_picking_rate_purchase.py
@@ -103,27 +103,18 @@ class TestStockPickingRate(TestHelper):
         res_action_show_wizard = rec_id.action_show_wizard()
         model_obj = self.env['ir.model.data']
         _prefix = 'stock_picking_delivery_rate.stock_picking_rate_purchase'
-        form_id = model_obj.xmlid_to_object(
-            '%s_view_form' % _prefix,
-        )
         action_id = model_obj.xmlid_to_object(
             '%s_action' % _prefix,
         )
         exp_keys = {
-            'name': action_id.name,
-            'help': action_id.help,
             'type': action_id.type,
             'view_mode': 'form',
-            'view_id': form_id.id,
+            'views': [(False, 'form')],
             'target': 'new',
             'context': rec_id._context.copy(),
             'res_model': action_id.res_model,
             'res_id': rec_id.id,
         }
-        self.assertEquals(
-            res_action_show_wizard['views'][0][0],
-            form_id.id,
-        )
         for key in exp_keys:
             res = res_action_show_wizard[key]
             exp = exp_keys[key]

--- a/stock_picking_delivery_rate/views/stock_picking_rate_view.xml
+++ b/stock_picking_delivery_rate/views/stock_picking_rate_view.xml
@@ -22,6 +22,7 @@
                             <field name="date_generated" />
                             <field name="date_purchased" />
                             <field name="picking_id" />
+                            <field name="package_id" />
                         </group>
                     </group>
                     <group>

--- a/stock_picking_delivery_rate/views/stock_picking_view.xml
+++ b/stock_picking_delivery_rate/views/stock_picking_view.xml
@@ -19,6 +19,7 @@
                         <tree>
                             <field name="partner_id" />
                             <field name="service_id" />
+                            <field name="state" invisible="1" />
                             <field name="rate"
                                    widget="monetary"
                                    options="{'currency_field': 'rate_currency_id'}"

--- a/stock_picking_delivery_rate/views/stock_picking_view.xml
+++ b/stock_picking_delivery_rate/views/stock_picking_view.xml
@@ -19,7 +19,7 @@
                         <tree>
                             <field name="partner_id" />
                             <field name="service_id" />
-                            <field name="state" invisible="1" />
+                            <field name="state" />
                             <field name="rate"
                                    widget="monetary"
                                    options="{'currency_field': 'rate_currency_id'}"
@@ -28,13 +28,13 @@
                                     type="object"
                                     icon="kanban-stop"
                                     string="Cancel"
-                                    attrs="{'invisible': [('state', '!=', 'purchase')]}"
+                                    attrs="{'disabled': [('state', 'not in', ['purchase'])]}"
                                     />
                             <button name="action_purchase"
                                     type="object"
                                     icon="kanban-apply"
                                     string="Purchase"
-                                    attrs="{'invisible': [('state', '=', 'purchase')]}"
+                                    attrs="{'disabled': [('state', 'not in', ['new'])]}"
                                     />
                         </tree>
                     </field>

--- a/stock_picking_delivery_rate/views/stock_picking_view.xml
+++ b/stock_picking_delivery_rate/views/stock_picking_view.xml
@@ -23,10 +23,17 @@
                                    widget="monetary"
                                    options="{'currency_field': 'rate_currency_id'}"
                                    />
+                            <button name="action_cancel"
+                                    type="object"
+                                    icon="kanban-stop"
+                                    string="Cancel"
+                                    attrs="{'invisible': [('state', '!=', 'purchase')]}"
+                                    />
                             <button name="action_purchase"
                                     type="object"
                                     icon="kanban-apply"
                                     string="Purchase"
+                                    attrs="{'invisible': [('state', '=', 'purchase')]}"
                                     />
                         </tree>
                     </field>

--- a/stock_picking_delivery_rate/wizards/__init__.py
+++ b/stock_picking_delivery_rate/wizards/__init__.py
@@ -2,4 +2,7 @@
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+from . import stock_picking_rate_wizard_abstract
+
+from . import stock_picking_rate_cancel
 from . import stock_picking_rate_purchase

--- a/stock_picking_delivery_rate/wizards/stock_picking_rate_cancel.py
+++ b/stock_picking_delivery_rate/wizards/stock_picking_rate_cancel.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class StockPickingRateCancel(models.TransientModel):
+    """Cancel a set of stock rates."""
+
+    _name = "stock.picking.rate.cancel"
+    _inherit = 'stock.picking.rate.wizard.abstract'
+    _description = 'Stock Picking Dispatch Rate Cancel'
+
+    @api.multi
+    def action_cancel(self):
+        """Cancel rate quotes."""
+
+        self.ensure_one()
+
+        search_for = ['stock.picking.rate,%d' % r.id for r in self.rate_ids]
+        purchase_orders = self.env['purchase.order'].search([
+            ('order_line.reference', 'in', search_for),
+        ])
+        purchase_orders.button_cancel()
+
+        return self.action_show_purchases(purchase_orders)

--- a/stock_picking_delivery_rate/wizards/stock_picking_rate_cancel_view.xml
+++ b/stock_picking_delivery_rate/wizards/stock_picking_rate_cancel_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+
+<odoo>
+
+    <record id="stock_picking_rate_cancel_view_form" model="ir.ui.view">
+        <field name="name">stock.picking.rate.cancel.view.form</field>
+        <field name="model">stock.picking.rate.cancel</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group string="Cancel Rates">
+                        <field name="rate_ids" />
+                    </group>
+                </sheet>
+                <footer>
+                    <button special="cancel"
+                            string="Back"
+                            />
+                    or
+                    <button name="action_cancel"
+                            type="object"
+                            string="Process Cancellation"
+                            class="oe_highlight"
+                            />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="stock_picking_rate_cancel_action" model="ir.actions.act_window">
+        <field name="name">Cancel Rate</field>
+        <field name="res_model">stock.picking.rate.cancel</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="stock_picking_rate_cancel_view_form"/>
+    </record>
+
+</odoo>

--- a/stock_picking_delivery_rate/wizards/stock_picking_rate_purchase.py
+++ b/stock_picking_delivery_rate/wizards/stock_picking_rate_purchase.py
@@ -2,6 +2,8 @@
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+from collections import defaultdict
+
 from odoo import api, models, fields
 
 
@@ -36,25 +38,22 @@ class StockPickingRatePurchase(models.TransientModel):
 
         self.ensure_one()
 
-        purchase_rates = {}
-        for rate_id in self.rate_ids:
+        purchase_rates = defaultdict(self.env['stock.picking.rate'].browse)
+        for rate in self.rate_ids:
             group_map = {
-                'none': rate_id.id,
-                'commercial': rate_id.partner_id.commercial_partner_id.id,
-                'carrier': rate_id.partner_id.id,
-                'service': rate_id.service_id.id,
+                'none': rate.id,
+                'commercial': rate.partner_id.commercial_partner_id.id,
+                'carrier': rate.partner_id.id,
+                'service': rate.service_id.id,
             }
             po_id = group_map[self.group_by]
-            try:
-                purchase_rates[po_id].append(rate_id)
-            except KeyError:
-                purchase_rates[po_id] = [rate_id]
-            rate_id.buy()
+            purchase_rates[po_id] += rate
+            rate.buy()
 
         purchase_orders = self.env['purchase.order']
-        for rate_ids in purchase_rates.values():
+        for rates in purchase_rates.values():
             purchase_orders += purchase_orders.create(
-                self._get_purchase_order_vals(rate_ids)
+                self._get_purchase_order_vals(rates)
             )
 
         self.rate_ids._expire_other_rates()
@@ -62,20 +61,20 @@ class StockPickingRatePurchase(models.TransientModel):
         return self.action_show_purchases(purchase_orders)
 
     @api.multi
-    def _get_purchase_line_vals(self, rate_id):
+    def _get_purchase_line_vals(self, rate):
         """ Get values used for purchasing dispatch rates
         This will be useful for classes requiring custom purchase logic,
         such as external carrier connectors
         """
         return {
-            'product_id': rate_id.service_id.product_id.id,
-            'name': rate_id.display_name,
+            'product_id': rate.service_id.product_id.id,
+            'name': rate.display_name,
             'date_planned': self.date_po,
             'product_qty': 1,
             'product_uom': self.env.ref('product.product_uom_unit').id,
-            'price_unit': rate_id.rate,
-            'currency_id': rate_id.rate_currency_id.id,
-            'reference': rate_id,
+            'price_unit': rate.rate,
+            'currency_id': rate.rate_currency_id.id,
+            'reference': '%s,%d' % (rate._name, rate.id),
         }
 
     @api.multi

--- a/stock_picking_delivery_rate/wizards/stock_picking_rate_purchase.py
+++ b/stock_picking_delivery_rate/wizards/stock_picking_rate_purchase.py
@@ -9,15 +9,9 @@ class StockPickingRatePurchase(models.TransientModel):
     """ Purchase a set of stock rates """
 
     _name = "stock.picking.rate.purchase"
+    _inherit = 'stock.picking.rate.wizard.abstract'
     _description = 'Stock Picking Dispatch Rate Purchase'
 
-    rate_ids = fields.Many2many(
-        string='Rates',
-        readonly=True,
-        comodel_name='stock.picking.rate',
-        relation='stock_picking_rate_purchase_rel',
-        default=lambda s: s._default_rate_ids(),
-    )
     date_po = fields.Datetime(
         string='Purchase Order Date',
         required=True,
@@ -35,13 +29,6 @@ class StockPickingRatePurchase(models.TransientModel):
         help='When creating purchase orders, this will be used to determine'
              ' the rates that go on each order.',
     )
-
-    @api.model
-    def _default_rate_ids(self):
-        model = 'stock.picking.rate.purchase'
-        if self.env.context.get('active_model') != model:
-            return None
-        return [(6, 0, self.env.context.get('active_ids'))]
 
     @api.multi
     def action_purchase(self):
@@ -64,71 +51,15 @@ class StockPickingRatePurchase(models.TransientModel):
                 purchase_rates[po_id] = [rate_id]
             rate_id.buy()
 
-        po_id_ints = []
+        purchase_orders = self.env['purchase.order']
         for rate_ids in purchase_rates.values():
-            po_id = self.env['purchase.order'].create(
+            purchase_orders += purchase_orders.create(
                 self._get_purchase_order_vals(rate_ids)
             )
-            po_id_ints.append(po_id.id)
 
         self.rate_ids._expire_other_rates()
 
-        model_obj = self.env['ir.model.data']
-        form_id = model_obj.xmlid_to_object(
-            'purchase.purchase_order_form'
-        )
-        tree_id = model_obj.xmlid_to_object(
-            'purchase.purchase_order_tree'
-        )
-        action_id = model_obj.xmlid_to_object(
-            'purchase.purchase_form_action'
-        )
-        return {
-            'name': action_id.name,
-            'help': action_id.help,
-            'type': action_id.type,
-            'view_mode': 'tree',
-            'view_id': tree_id.id,
-            'views': [
-                (tree_id.id, 'tree'),
-                (form_id.id, 'form'),
-            ],
-            'target': 'current',
-            'context': self.env.context,
-            'res_model': action_id.res_model,
-            'res_ids': po_id_ints,
-            'domain': [('id', 'in', po_id_ints)],
-        }
-
-    @api.multi
-    def action_show_wizard(self):
-        """ Utility method to show the wizard
-        Returns:
-            Wizard action for completion of delivery packing
-        """
-        self.ensure_one()
-        model_obj = self.env['ir.model.data']
-        _prefix = 'stock_picking_delivery_rate.stock_picking_rate_purchase'
-        form_id = model_obj.xmlid_to_object(
-            '%s_view_form' % _prefix,
-        )
-        action_id = model_obj.xmlid_to_object(
-            '%s_action' % _prefix,
-        )
-        return {
-            'name': action_id.name,
-            'help': action_id.help,
-            'type': action_id.type,
-            'view_mode': 'form',
-            'view_id': form_id.id,
-            'views': [
-                (form_id.id, 'form'),
-            ],
-            'target': 'new',
-            'context': self.env.context,
-            'res_model': action_id.res_model,
-            'res_id': self.id,
-        }
+        return self.action_show_purchases(purchase_orders)
 
     @api.multi
     def _get_purchase_line_vals(self, rate_id):
@@ -144,6 +75,7 @@ class StockPickingRatePurchase(models.TransientModel):
             'product_uom': self.env.ref('product.product_uom_unit').id,
             'price_unit': rate_id.rate,
             'currency_id': rate_id.rate_currency_id.id,
+            'reference': rate_id,
         }
 
     @api.multi

--- a/stock_picking_delivery_rate/wizards/stock_picking_rate_wizard_abstract.py
+++ b/stock_picking_delivery_rate/wizards/stock_picking_rate_wizard_abstract.py
@@ -15,7 +15,6 @@ class StockPickingRateWizardAbstract(models.TransientModel):
         string='Rates',
         readonly=True,
         comodel_name='stock.picking.rate',
-        relation='stock_picking_rate_purchase_rel',
         default=lambda s: s._default_rate_ids(),
     )
 
@@ -30,7 +29,11 @@ class StockPickingRateWizardAbstract(models.TransientModel):
     def action_show_wizard(self):
         """Utility method to show the wizard."""
         self.ensure_one()
-        return self.get_formview_action()
+        action = self.get_formview_action()
+        action.update({
+            'target': 'new',
+        })
+        return action
 
     @api.multi
     def action_show_purchases(self, purchase_orders):

--- a/stock_picking_delivery_rate/wizards/stock_picking_rate_wizard_abstract.py
+++ b/stock_picking_delivery_rate/wizards/stock_picking_rate_wizard_abstract.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models, fields
+
+
+class StockPickingRateWizardAbstract(models.TransientModel):
+    """ Purchase a set of stock rates """
+
+    _name = "stock.picking.rate.wizard.abstract"
+    _description = 'Stock Picking Dispatch Rate Wizard (Abstract)'
+
+    rate_ids = fields.Many2many(
+        string='Rates',
+        readonly=True,
+        comodel_name='stock.picking.rate',
+        relation='stock_picking_rate_purchase_rel',
+        default=lambda s: s._default_rate_ids(),
+    )
+
+    @api.model
+    def _default_rate_ids(self):
+        model = 'stock.picking.rate.purchase'
+        if self.env.context.get('active_model') != model:
+            return None
+        return [(6, 0, self.env.context.get('active_ids'))]
+
+    @api.multi
+    def action_show_wizard(self):
+        """Utility method to show the wizard."""
+        self.ensure_one()
+        return self.get_formview_action()
+
+    @api.multi
+    def action_show_purchases(self, purchase_orders):
+        """Utility method to show the purchase order action."""
+        model_obj = self.env['ir.model.data']
+        form_id = model_obj.xmlid_to_object(
+            'purchase.purchase_order_form'
+        )
+        tree_id = model_obj.xmlid_to_object(
+            'purchase.purchase_order_tree'
+        )
+        action_id = model_obj.xmlid_to_object(
+            'purchase.purchase_form_action'
+        )
+        return {
+            'name': action_id.name,
+            'help': action_id.help,
+            'type': action_id.type,
+            'view_mode': 'tree',
+            'view_id': tree_id.id,
+            'views': [
+                (tree_id.id, 'tree'),
+                (form_id.id, 'form'),
+            ],
+            'target': 'current',
+            'context': self.env.context,
+            'res_model': action_id.res_model,
+            'res_ids': purchase_orders.ids,
+            'domain': [('id', 'in', purchase_orders.ids)],
+        }


### PR DESCRIPTION
This PR adds a few features to `stock_picking_delivery_rate`
* Add a reference to the associated rate on the purchase order lines
* Add a process for the cancellation of rates and their related purchase orders
* Add an optional m2o to link a rate with a quant package

At the moment, cancellation is at the purchase order level. I don't think this is totally ideal, but I'm not sure of a good strategy of processing a cancellation for just one purchase order line item. Open to ideas 😄 

Depends on:
- [ ] https://github.com/OCA/purchase-workflow/pull/474