### PR TITLE
[9.0] Fix delivery_carrier_deposit : Make picking removal possible again in deposit slip

### DIFF
--- a/delivery_carrier_deposit/views/stock_view.xml
+++ b/delivery_carrier_deposit/views/stock_view.xml
@@ -76,7 +76,7 @@
                     <field name="number_of_packages"/>
                 </group>
                 <group name="pickings">
-                    <field name="picking_ids" nolabel="1" widget="many2many"/>
+                    <field name="picking_ids" nolabel="1" widget="many2many" options="{'not_delete': True}"/>
                 </group>
             </sheet>
             <div class="oe_chatter">


### PR DESCRIPTION
In version 9.0, we can't remove picking from deposit slip, because Odoo try to delete it.
In version 8.0 and before it was possible, I guess the many2many widget on one2many field was doing the job.

In version 9.0 and after, we need to add an option so Odoo just remove the link with the picking and does not try to delete the picking.

@bealdav @hparfr @EBII 