### PR TITLE
[ADD] delivery_auto_refresh: Auto-refresh delivery price in sales orders

### DIFF
--- a/delivery_auto_refresh/README.rst
+++ b/delivery_auto_refresh/README.rst
@@ -1,0 +1,81 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===========================================
+Auto-refresh delivery price in sales orders
+===========================================
+
+This module automates the delivery price handling for the following cases:
+
+* If you change any line in your draft sales order (SO), when saving, the
+  delivery price will be adjusted without having to click on "→ Set price".
+* If specified in the system parameter, the delivery line can be also
+  auto-added when creating/saving.
+* If you deliver a different quantity than the ordered one, the delivery price
+  is adjusted on the linked SO when the picking is transferred.
+
+Configuration
+=============
+
+* Activate developer mode.
+* Go to *Settings > Technical > Parameters > System Parameters*.
+* Locate the setting with key "delivery_auto_refresh.auto_add_delivery_line"
+  or create a new one if not exists.
+* Put a non Falsy value (1, True...) if you want to add automatically the
+  delivery line on save.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/99/10.0
+
+Known issues / Roadmap
+======================
+
+* After confirming the sales order, the price of the delivery line (if exists)
+  will be only updated after the picking is transferred, but not when you
+  might modify the order lines.
+* There can be some duplicate delivery unset/set for assuring that the refresh
+  is done on all cases.
+* On multiple deliveries, second and successive pickings update the delivery
+  price, but you can't invoice the new delivery price.
+* This is only working from user interface, as there's no way of making
+  compatible the auto-refresh intercepting create/write methods from sale order
+  lines.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/delivery-carrier/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Tecnativa <https://www.tecnativa.com>:
+  * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/delivery_auto_refresh/__init__.py
+++ b/delivery_auto_refresh/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/delivery_auto_refresh/__manifest__.py
+++ b/delivery_auto_refresh/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Auto-refresh delivery",
+    "summary": "Auto-refresh delivery price in sales orders",
+    "version": "10.0.1.0.0",
+    "category": "Delivery",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "author": "Tecnativa, "
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "delivery",
+    ],
+    "data": [
+        'data/ir_config_parameter.xml',
+    ],
+}

--- a/delivery_auto_refresh/data/ir_config_parameter.xml
+++ b/delivery_auto_refresh/data/ir_config_parameter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo noupdate="1">
+
+    <record id="default" model="ir.config_parameter">
+        <field name="key">delivery_auto_refresh.auto_add_delivery_line</field>
+        <field name="value">0</field>
+    </record>
+
+</odoo>

--- a/delivery_auto_refresh/models/__init__.py
+++ b/delivery_auto_refresh/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import sale_order
+from . import stock_picking

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+from odoo.tools import safe_eval
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _auto_refresh_delivery(self, force=False):
+        self.ensure_one()
+        # Avoid infinite recursion
+        if self.env.context.get('force_delivery_set'):  # pragma: no cover
+            return self
+        get_param = self.env['ir.config_parameter'].sudo().get_param
+        param = 'delivery_auto_refresh.auto_add_delivery_line'
+        if (force or safe_eval(get_param(param, '0'))) and self.carrier_id:
+            if (self.state in {'draft', 'sent'} or
+                    self.invoice_shipping_on_delivery):
+                self.with_context(force_delivery_set=True).delivery_set()
+
+    def write(self, vals):
+        """Refresh delivery price after saving."""
+        res = super(SaleOrder, self).write(vals)
+        for order in self:
+            force = order.order_line.filtered('is_delivery')
+            # Make sure that if you have removed the carrier, the line is gone
+            if order.state in {'draft', 'sent'}:
+                order._delivery_unset()
+            order._auto_refresh_delivery(force=force)
+        return res

--- a/delivery_auto_refresh/models/stock_picking.py
+++ b/delivery_auto_refresh/models/stock_picking.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _add_delivery_cost_to_so(self):
+        """Update delivery price in SO from picking data."""
+        res = super(StockPicking, self)._add_delivery_cost_to_so()
+        self.ensure_one()
+        sale_order = self.sale_id
+        if not sale_order or not self.carrier_id:  # pragma: no cover
+            return res
+        total = weight = volume = quantity = 0
+        for packop in self.pack_operation_ids.filtered('qty_done'):
+            if not packop.product_id:
+                continue
+            move = packop.linked_move_operation_ids[:1].move_id
+            qty = move.product_uom._compute_quantity(
+                packop.qty_done, packop.product_id.uom_id,
+            )
+            weight += (packop.product_id.weight or 0.0) * qty
+            volume += (packop.product_id.volume or 0.0) * qty
+            quantity += qty
+            total += move.procurement_id.sale_line_id.price_unit * qty
+        total = sale_order.currency_id.with_context(
+            date=sale_order.date_order
+        ).compute(total, sale_order.company_id.currency_id)
+        so_line = sale_order.order_line.filtered(lambda x: x.is_delivery)[:1]
+        if so_line:
+            so_line.price_unit = self.carrier_id.get_price_from_picking(
+                total, weight, volume, quantity,
+            )
+        return res

--- a/delivery_auto_refresh/tests/__init__.py
+++ b/delivery_auto_refresh/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_delivery_auto_refresh

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+def _execute_onchanges(records, field_name):
+    """Helper methods that executes all onchanges associated to a field."""
+    for onchange in records._onchange_methods.get(field_name, []):
+        for record in records:
+            onchange(record)
+
+
+@common.at_install(False)
+@common.post_install(True)
+class TestDeliveryAutoRefresh(common.HttpCase):
+    def setUp(self):
+        super(TestDeliveryAutoRefresh, self).setUp()
+        self.carrier = self.env['delivery.carrier'].create({
+            'name': 'Test carrier',
+            'delivery_type': 'base_on_rule',
+            'price_rule_ids': [
+                (0, 0, {
+                    'variable': 'weight',
+                    'operator': '<=',
+                    'max_value': 20,
+                    'list_base_price': 50,
+                }),
+                (0, 0, {
+                    'variable': 'weight',
+                    'operator': '<=',
+                    'max_value': 40,
+                    'list_base_price': 30,
+                    'list_price': 1,
+                    'variable_factor': 'weight',
+                }),
+                (0, 0, {
+                    'variable': 'weight',
+                    'operator': '>',
+                    'max_value': 40,
+                    'list_base_price': 20,
+                    'list_price': 1.5,
+                    'variable_factor': 'weight',
+                }),
+            ]
+        })
+        self.product = self.env['product.product'].create({
+            'name': 'Test product',
+            'weight': 10,
+            'list_price': 20,
+        })
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test partner',
+            'property_delivery_carrier_id': self.carrier.id,
+        })
+        self.param_name = 'delivery_auto_refresh.auto_add_delivery_line'
+        order = self.env['sale.order'].new({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': self.product.id,
+                    'product_uom_qty': 2,
+                })
+            ]
+        })
+        _execute_onchanges(order, 'partner_id')
+        _execute_onchanges(order.order_line, 'product_id')
+        self.order = order.create(order._convert_to_write(order._cache))
+
+    def test_auto_refresh_so(self):
+        self.assertFalse(self.order.order_line.filtered('is_delivery'))
+        self.env['ir.config_parameter'].sudo().set_param(self.param_name, 1)
+        order2 = self.order.copy({})
+        self.assertTrue(order2.order_line.filtered('is_delivery'))
+        self.order.write({
+            'order_line': [
+                (1, self.order.order_line.id, {'product_uom_qty': 3}),
+            ],
+        })
+        line_delivery = self.order.order_line.filtered('is_delivery')
+        self.assertEqual(line_delivery.price_unit, 60)
+        line2 = self.order.order_line.new({
+            'order_id': self.order.id,
+            'product_id': self.product.id,
+            'product_uom_qty': 2,
+        })
+        _execute_onchanges(line2, 'product_id')
+        vals = line2._convert_to_write(line2._cache)
+        del vals['order_id']
+        self.order.write({'order_line': [(0, 0, vals)]})
+        line_delivery = self.order.order_line.filtered('is_delivery')
+        self.assertEqual(line_delivery.price_unit, 95)
+
+    def test_auto_refresh_picking(self):
+        self.order.order_line.product_uom_qty = 3
+        self.order.action_confirm()
+        picking = self.order.picking_ids
+        picking.force_assign()
+        picking.pack_operation_ids[0].qty_done = 2
+        picking.do_transfer()
+        line_delivery = self.order.order_line.filtered('is_delivery')
+        self.assertEqual(line_delivery.price_unit, 50)


### PR DESCRIPTION
Auto-refresh delivery price in sales orders
===========================================

This module automates the delivery price handling for the following cases:

* If you change any line in your draft sales order (SO), when saving, the delivery price will be adjusted without having to click on "→ Set price".
* If specified in the system parameter, the delivery line can be also auto-added when creating/saving.
* If you deliver a different quantity than the ordered one, the delivery price is adjusted on the linked SO when the picking is transferred.

Configuration
=============

* Activate developer mode.
* Go to *Settings > Technical > Parameters > System Parameters*.
* Locate the setting with key "delivery_auto_refresh.auto_add_delivery_line" or create a new one if not exists.
* Put a non Falsy value (1, True...) if you want to add automatically the delivery line on save.

Known issues / Roadmap
======================

* After confirming the sales order, the price of the delivery line (if exists) will be only updated after the picking is transferred, but not when you might modify the order lines.
* There can be some duplicate delivery unset/set for assuring that the refresh is done on all cases.
* On multiple deliveries, second and successive pickings update the delivery price, but you can't invoice the new delivery price.

cc @Tecnativa