### PR TITLE
[11.0][FIX] Remove occurences of carrier type

### DIFF
--- a/base_delivery_carrier_label/__manifest__.py
+++ b/base_delivery_carrier_label/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2015 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {'name': 'Base module for carrier labels',
- 'version': '11.0.1.0.0',
+ 'version': '11.0.1.0.1',
  'author': "Camptocamp,Akretion,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'category': 'Delivery',

--- a/base_delivery_carrier_label/models/carrier_account.py
+++ b/base_delivery_carrier_label/models/carrier_account.py
@@ -10,11 +10,6 @@ class CarrierAccount(models.Model):
     _description = 'Base account datas'
 
     @api.model
-    def _selection_carrier_type(self):
-        """ To inherit to add carrier type like Chronopost, Postlogistics..."""
-        return []
-
-    @api.model
     def _selection_file_format(self):
         """ To inherit to add label file types"""
         return [('PDF', 'PDF'),
@@ -28,11 +23,4 @@ class CarrierAccount(models.Model):
         selection='_selection_file_format',
         string='File Format',
         help="Default format of the carrier's label you want to print"
-    )
-    carrier_type = fields.Selection(
-        selection='_selection_carrier_type',
-        oldname='type',
-        required=True,
-        help="In case of several carriers, help to know which "
-             "account belong to which carrier",
     )

--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -8,17 +8,6 @@ from odoo import api, fields, models
 class DeliveryCarrier(models.Model):
     _inherit = 'delivery.carrier'
 
-    @api.model
-    def _selection_carrier_type(self):
-        """ To inherit to add carrier type """
-        return []
-
-    carrier_type = fields.Selection(
-        selection='_selection_carrier_type',
-        string='Type',
-        help="Carrier type (combines several delivery methods)",
-        oldname='type',
-    )
     code = fields.Char(
         help="Delivery Method Code (according to carrier)",
     )

--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -8,6 +8,7 @@ from odoo import api, fields, models
 class DeliveryCarrier(models.Model):
     _inherit = 'delivery.carrier'
 
+    delivery_type = fields.Selection(oldname='carrier_type')
     code = fields.Char(
         help="Delivery Method Code (according to carrier)",
     )

--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -15,9 +15,9 @@ class StockPicking(models.Model):
         string='Carrier',
         states={'done': [('readonly', True)]},
     )
-    carrier_type = fields.Selection(
-        related='carrier_id.carrier_type',
-        string='Carrier Type',
+    delivery_type = fields.Selection(
+        related='carrier_id.delivery_type',
+        string='Delivery Type',
         readonly=True,
     )
     carrier_code = fields.Char(
@@ -135,7 +135,7 @@ class StockPicking(models.Model):
         # depending of the type or the code
         carrier = self.carrier_id
         self.update({
-            'carrier_type': carrier.carrier_type,
+            'delivery_type': carrier.delivery_type,
             'carrier_code': carrier.code,
         })
         default_options = carrier.default_options()

--- a/base_delivery_carrier_label/tests/test_manifest_wizard.py
+++ b/base_delivery_carrier_label/tests/test_manifest_wizard.py
@@ -17,6 +17,5 @@ class ManifestWizardCase(TransactionCase):
             'carrier_id': self.free_delivery.id,
             'from_date': fields.Date.today()
         })
-        self.assertFalse(wizard.carrier_type)
         with self.assertRaises(NotImplementedError):
             wizard.get_manifest_file()

--- a/base_delivery_carrier_label/views/delivery.xml
+++ b/base_delivery_carrier_label/views/delivery.xml
@@ -70,7 +70,6 @@
 
       <xpath expr="//h1" position="after">
         <group>
-          <field name="carrier_type"/>
           <field name="code"/>
         </group>
       </xpath>
@@ -93,7 +92,6 @@
     <field name="inherit_id" ref="delivery.view_delivery_carrier_tree"/>
     <field name="arch" type="xml">
       <field name="name" position="after">
-        <field name="carrier_type"/>
         <field name="code"/>
       </field>
     </field>

--- a/base_delivery_carrier_label/views/stock.xml
+++ b/base_delivery_carrier_label/views/stock.xml
@@ -12,7 +12,6 @@
           string="Create Shipping Label" type="object"/>
       </field>
       <xpath expr="//page//field[@name='carrier_id']" position="after">
-        <field name="carrier_type"/>
         <field name="carrier_code"/>
       </xpath>
       <xpath expr="//page//group[@name='carrier_data']/.." position="after">

--- a/base_delivery_carrier_label/wizard/manifest_wizard.py
+++ b/base_delivery_carrier_label/wizard/manifest_wizard.py
@@ -9,22 +9,11 @@ class ManifestWizard(models.TransientModel):
     _name = 'manifest.wizard'
     _description = 'Delivery carrier manifest wizard'
 
-    @api.model
-    def _selection_carrier_type(self):
-        carrier_obj = self.env['delivery.carrier']
-        return carrier_obj._get_carrier_type_selection()
-
     carrier_id = fields.Many2one(
         comodel_name='delivery.carrier',
         string='Carrier',
         states={'done': [('readonly', True)]},
         required=True
-    )
-    carrier_type = fields.Selection(
-        selection='_selection_carrier_type',
-        related='carrier_id.carrier_type',
-        string='Carrier Type',
-        readonly=True,
     )
     from_date = fields.Datetime('From Date', required=True)
     to_date = fields.Datetime('To Date')
@@ -39,5 +28,6 @@ class ManifestWizard(models.TransientModel):
 
     @api.one
     def get_manifest_file(self):
-        raise NotImplementedError(_("Manifest not implemented for '%s' "
-                                    "carrier type.") % self.carrier_type)
+        raise NotImplementedError(_(
+            "Manifest not implemented for '%s' carrier.") %
+            self.carrier_id.delivery_type)

--- a/base_delivery_carrier_label/wizard/manifest_wizard_view.xml
+++ b/base_delivery_carrier_label/wizard/manifest_wizard_view.xml
@@ -9,7 +9,6 @@
                 <field name="state" invisible="1"/>
                 <group attrs="{'invisible': [('state', '!=', 'init')]}">
                     <field name="carrier_id"/>
-                    <field name="carrier_type"/>
                     <field name="from_date"/>
                     <field name="to_date"/>
                 </group>


### PR DESCRIPTION
Field carrier_type was originally type and was used to differentiate delivery carriers.
However odoo did implement delivery_type since v9 with this exact goal :
https://github.com/odoo/odoo/blob/11.0/addons/delivery/models/delivery_carrier.py#L22
This is also the field used in the implementation of enterprise modules for carriers.
Therefore we should use it instead of redefining a new one..

BTW Would be great to backport this to 10.0 and 9.0.