### PR TITLE
[FIX] section titles not allowed in readme fragments

### DIFF
--- a/delivery_carrier_label_postlogistics/readme/CONFIGURE.rst
+++ b/delivery_carrier_label_postlogistics/readme/CONFIGURE.rst
@@ -24,8 +24,7 @@ Now you can create a carrier method for PostLogistics WebService:
 
 .. _Log in: https://account.post.ch/selfadmin/?login&lang=en
 
-Technical references
---------------------
+*Technical references*
 
 `"Barcode" web service documentation`_
 


### PR DESCRIPTION
@grindtildeath 

This generates an inconsistent section structure in the README.