### PR TITLE
[11.0][FIX] partner_delivery_zone: Get delivery zone from partner when a picking is created and no sale line is linked (pick-pack...)

### DIFF
--- a/partner_delivery_zone/__manifest__.py
+++ b/partner_delivery_zone/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Partner Delivery Zone',
     'summary': 'Set on partners a zone for delivery goods',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'development_status': 'Beta',
     'category': 'Delivery',
     'website': 'https://github.com/OCA/delivery-carrier',

--- a/partner_delivery_zone/models/stock_move.py
+++ b/partner_delivery_zone/models/stock_move.py
@@ -6,10 +6,16 @@ from odoo import models
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
+    def get_original_move(self):
+        if self.move_dest_ids:
+            return self.move_dest_ids.get_original_move()
+        return self
+
     def _get_new_picking_values(self):
         vals = super()._get_new_picking_values()
-        zone_id = self.sale_line_id.order_id.delivery_zone_id.id
-        if not self.sale_line_id:
+        original_move = self.get_original_move()
+        zone_id = original_move.sale_line_id.order_id.delivery_zone_id.id
+        if not zone_id:
             zone_id = self.env['res.partner'].browse(
                 vals.get('partner_id', False)).delivery_zone_id.id
         vals['delivery_zone_id'] = zone_id

--- a/partner_delivery_zone/models/stock_move.py
+++ b/partner_delivery_zone/models/stock_move.py
@@ -8,6 +8,9 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super()._get_new_picking_values()
-        vals['delivery_zone_id'] =\
-            self.sale_line_id.order_id.delivery_zone_id.id
+        zone_id = self.sale_line_id.order_id.delivery_zone_id.id
+        if not self.sale_line_id:
+            zone_id = self.env['res.partner'].browse(
+                vals.get('partner_id', False)).delivery_zone_id.id
+        vals['delivery_zone_id'] = zone_id
         return vals

--- a/partner_delivery_zone/tests/test_partner_delivery_zone.py
+++ b/partner_delivery_zone/tests/test_partner_delivery_zone.py
@@ -11,6 +11,7 @@ class TestPartnerDeliveryZone(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.warehouse = cls.env.ref('stock.warehouse0')
         cls.delivery_zone_a = cls.env['partner.delivery.zone'].create({
             'name': 'Delivery Zone A',
             'code': '10',
@@ -97,3 +98,22 @@ class TestPartnerDeliveryZone(SavepointCase):
         res = self.partner.fields_view_get(view_id=view.id, view_type='form')
         ctx = self._get_ctx_from_view(res)
         self.assertTrue('default_delivery_zone_id' in ctx)
+
+    def test_wharehouse_three_steps(self):
+        self.warehouse.delivery_steps = 'pick_pack_ship'
+        self.order.action_confirm()
+        for picking in self.order.picking_ids:
+            self.assertEqual(
+                picking.delivery_zone_id, self.order.delivery_zone_id)
+
+    def test_wharehouse_three_steps_so_wo_delivery_zone(self):
+        # If SO has not delivery zone, all pickings obtains the delivery zone
+        # from shipping partner
+        self.warehouse.delivery_steps = 'pick_pack_ship'
+        self.order.delivery_zone_id = False
+        self.order.action_confirm()
+        for picking in self.order.picking_ids:
+            self.assertEqual(
+                picking.delivery_zone_id,
+                self.order.partner_shipping_id.delivery_zone_id
+            )


### PR DESCRIPTION
cc @Tecnativa