### PR TITLE
[10.0][IMP] delivery_carrier_label_postlogistics: Consider parent partner name

### DIFF
--- a/delivery_carrier_label_postlogistics/__manifest__.py
+++ b/delivery_carrier_label_postlogistics/__manifest__.py
@@ -2,7 +2,7 @@
 # © 2013-2016 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {'name': 'PostLogistics Labels WebService',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'summary': 'Print postlogistics shipping labels',

--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -163,8 +163,9 @@ class PostlogisticsWebService(object):
         """
         partner = picking.partner_id
 
+        partner_name = partner.name or partner.parent_id.name
         recipient = {
-            'Name1': partner.name,
+            'Name1': partner_name,
             'Street': partner.street,
             'ZIP': partner.zip,
             'City': partner.city,
@@ -175,7 +176,7 @@ class PostlogisticsWebService(object):
         if partner.street2:
             recipient['AddressSuffix'] = partner.street2
 
-        if partner.parent_id:
+        if partner.parent_id and partner.parent_id.name != partner_name:
             recipient['Name2'] = partner.parent_id.name
             recipient['PersonallyAddressed'] = False
 


### PR DESCRIPTION
Consider parent partner name if partner name is empty .
When using a specific partner contact (e.g. shipping address) as recipient,
the name of the partner can be empty. In such case, the name of its parent
must be used.