### PR TITLE
[9.0][FIX] delivery_carrier_label_postlogistics: fix integration WSDL file

### DIFF
--- a/delivery_carrier_label_postlogistics/data/integration/barcode_v2_2_wsbc.wsdl
+++ b/delivery_carrier_label_postlogistics/data/integration/barcode_v2_2_wsbc.wsdl
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?><!-- Published by JAX-WS RI at http://jax-ws.dev.java.net. RI's version is JAX-WS RI 2.1.7-b01-. --><definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="https://www.mypostbusiness.ch/wsbc/barcode/v2_2" xmlns:barcode="https://www.mypostbusiness.ch/wsbc/barcode/v2_2/types" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" name="Barcode" targetNamespace="https://www.mypostbusiness.ch/wsbc/barcode/v2_2">
   <types>
     <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-      <xsd:import namespace="https://www.mypostbusiness.ch/wsbc/barcode/v2_2/types" schemaLocation="https://int.wsbc.post.ch:443/wsbc/barcode/v2_2?xsd=1" />
+      <xsd:import namespace="https://www.mypostbusiness.ch/wsbc/barcode/v2_2/types" schemaLocation="barcode_v2_2_wsbc.xsd" />
     </xsd:schema>
   </types>
 


### PR DESCRIPTION
The XSD schema can't be found at the specified URL, but the schema is
stored locally next to the WSDL file (like in the 'production' folder).