### PR TITLE
[FIX] carrier type is not the same that delivery type

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -8,7 +8,9 @@ from odoo import api, fields, models
 class DeliveryCarrier(models.Model):
     _inherit = 'delivery.carrier'
 
-    delivery_type = fields.Selection(oldname='carrier_type')
+    carrier_type = fields.Selection(
+        string='Type',
+    )
     code = fields.Char(
         help="Delivery Method Code (according to carrier)",
     )


### PR DESCRIPTION
In OCA Sprint Code we was checking the migration to versión 12.0, and we think that it was a mistake in migration to version 11.0.

In version 10.0 we  have carrier_type field, it define the carrier company, and how to comunicate to send data and get labels.

In versión 11.0 we have delivery_type field, it define how to compute prices, it not the same scope.

In #155 we check that postlogistic is added to delivery_type, but I think that could be better if you can define postlogistic in carrier_type and delivery_type regardless.

It is usual to have delivery method with diferent sale price than purchase price, so if you habe two fields you can send data to your carrier but mantain fixed prices.