### PR TITLE
[11.0][FIX] delivery_carrier_label_default: Print one label per page

### DIFF
--- a/delivery_carrier_label_default/__manifest__.py
+++ b/delivery_carrier_label_default/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Default label for carrier labels",
     "summary": "This module defines a basic label to print "
                "when no specific carrier is selected.",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "development_status": "Production/Stable",
     "category": "Delivery",
     "website": "https://github.com/OCA/delivery-carrier",

--- a/delivery_carrier_label_default/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_label_default/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
 * Sébastien Alix <sebastien.alix@camptocamp.com>
+* Sergio Teruel <sergio.teruel@tecnativa.com>

--- a/delivery_carrier_label_default/views/report_default_label.xml
+++ b/delivery_carrier_label_default/views/report_default_label.xml
@@ -1,16 +1,16 @@
 <odoo>
 <template id="report_default_label">
-  <t t-call="web.basic_layout">
     <t t-foreach="docs" t-as="o">
-      <div class="page">
-        <div class="address">
-          <div class="recipient">
-            <address t-field="o.partner_id"
-              t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}' />
-          </div>
-        </div>
-      </div>
-     </t>
-  </t>
+        <t t-call="web.basic_layout">
+            <div class="page">
+                <div class="address">
+                    <div class="recipient">
+                        <address t-field="o.partner_id"
+                                 t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}' />
+                    </div>
+                </div>
+            </div>
+        </t>
+    </t>
 </template>
 </odoo>


### PR DESCRIPTION
Hi, when you select more than one picking to print the shipping label, there is no break por page.

Before this PR:
![Selección_252](https://user-images.githubusercontent.com/7689807/58965801-7695ca00-87b1-11e9-83e7-c883dce2e00f.png)

After this PR:
![Selección_253](https://user-images.githubusercontent.com/7689807/58965813-7d244180-87b1-11e9-97d5-17e30d4174d1.png)
 
cc @Tecnativa