### PR TITLE
[10.0][IMP] stock_picking_delivery_info_computation: Allow to edit/compute volume on done pickings

### DIFF
--- a/stock_picking_delivery_info_computation/README.rst
+++ b/stock_picking_delivery_info_computation/README.rst
@@ -38,11 +38,10 @@ quantities, unles you introduce anything in *done* quantity, switching to this
 column in that case.
 
 The volume is auto-computed when the picking is generated from a sales order,
-or a backorder is created from original picking, but remains editable while
-the picking is not validated for any possible manual edition.
+or a backorder is created from original picking, but remains editable for any
+possible manual edition.
 
-You also have a button available while the picking is not validated for
-recomputing volume with current data.
+You also have a button available for recomputing volume with current data.
 
 **Table of contents**
 

--- a/stock_picking_delivery_info_computation/readme/DESCRIPTION.rst
+++ b/stock_picking_delivery_info_computation/readme/DESCRIPTION.rst
@@ -11,8 +11,7 @@ quantities, unles you introduce anything in *done* quantity, switching to this
 column in that case.
 
 The volume is auto-computed when the picking is generated from a sales order,
-or a backorder is created from original picking, but remains editable while
-the picking is not validated for any possible manual edition.
+or a backorder is created from original picking, but remains editable for any
+possible manual edition.
 
-You also have a button available while the picking is not validated for
-recomputing volume with current data.
+You also have a button available for recomputing volume with current data.

--- a/stock_picking_delivery_info_computation/static/description/index.html
+++ b/stock_picking_delivery_info_computation/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.14: http://docutils.sourceforge.net/" />
 <title>Stock Picking Delivery Info Computation</title>
 <style type="text/css">
 
@@ -378,10 +378,9 @@ In this case, the computation of the weight and volume is based in <em>to do</em
 quantities, unles you introduce anything in <em>done</em> quantity, switching to this
 column in that case.</p>
 <p>The volume is auto-computed when the picking is generated from a sales order,
-or a backorder is created from original picking, but remains editable while
-the picking is not validated for any possible manual edition.</p>
-<p>You also have a button available while the picking is not validated for
-recomputing volume with current data.</p>
+or a backorder is created from original picking, but remains editable for any
+possible manual edition.</p>
+<p>You also have a button available for recomputing volume with current data.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/stock_picking_delivery_info_computation/views/delivery_view.xml
+++ b/stock_picking_delivery_info_computation/views/delivery_view.xml
@@ -7,13 +7,12 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='number_of_packages']" position="after">
                 <label for="volume"/>
-                <field name="volume" attrs="{'readonly': [('state', '=', 'done')]}" class="oe_inline" nolabel="1"/>
+                <field name="volume" class="oe_inline" nolabel="1"/>
                 <button
                     name="action_calculate_volume"
                     type="object"
                     icon='fa-truck'
                     string="Re-calculate Volume"
-                    attrs="{'invisible': [('state', '=', 'done')]}"
                     class="oe_inline"
                     colspan="4"
                 />


### PR DESCRIPTION
As this information remains isolated, you have both possibilities of recomputing or manually editing the field in any state.

cc @Tecnativa