### PR TITLE
[12.0][base_delivery_carrier_label] Wait data encoded in base64 / write tracking number on package

### DIFF
--- a/base_delivery_carrier_label/models/shipping_label.py
+++ b/base_delivery_carrier_label/models/shipping_label.py
@@ -2,7 +2,7 @@
 # Copyright 2014 Akretion <http://www.akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ShippingLabel(models.Model):
@@ -12,16 +12,7 @@ class ShippingLabel(models.Model):
     _inherits = {'ir.attachment': 'attachment_id'}
     _description = "Shipping Label"
 
-    @api.model
-    def _selection_file_type(self):
-        """ To inherit to add file type """
-        return [
-            ('pdf', 'PDF'),
-            ('zpl2', 'ZPL2'),
-        ]
-
-    file_type = fields.Selection(
-        selection='_selection_file_type',
+    file_type = fields.Char(
         string='File type',
         default='pdf',
     )

--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -2,7 +2,6 @@
 # Copyright 2013-2016 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-import base64
 import logging
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -48,7 +47,7 @@ class StockPicking(models.Model):
 
         :return: list of dict containing
            name: name to give to the attachement
-           file: file as string
+           file: file as base64
            file_type: string of file type like 'PDF'
            (optional)
            tracking_number: tracking id defined by your carrier
@@ -70,7 +69,7 @@ class StockPicking(models.Model):
             'datas_fname': label.get('filename', label['name']),
             'res_id': self.id,
             'res_model': 'stock.picking',
-            'datas': base64.b64encode(label['file']),
+            'datas': label['file'],
             'file_type': label['file_type'],
         }
 
@@ -101,6 +100,7 @@ class StockPicking(models.Model):
         Packages are mandatory in this case
 
         """
+        package_obj = self.env['stock.quant.package']
         for pick in self:
             pick._set_a_default_package()
             shipping_labels = pick.generate_shipping_labels()
@@ -108,6 +108,9 @@ class StockPicking(models.Model):
                 data = pick.get_shipping_label_values(label)
                 if label.get('package_id'):
                     data['package_id'] = label['package_id']
+                    if label.get('tracking_number'):
+                        package_obj.browse(label['package_id']).write(
+                            {'parcel_tracking': label.get('tracking_number')})
                 context_attachment = self.env.context.copy()
                 # remove default_type setted for stock_picking
                 # as it would try to define default value of attachement


### PR DESCRIPTION
As there are no submodules migrated yet, I'd like to propose some small improvements in the module.

- Wait label file as base64 instead of encoding it.
=> Most of the time when using carrier webservice, we already receive base64. So it forces us to decode it, before sending it and the base_delivery_carrier_label encode it in base64 once more...
Example here : https://github.com/OCA/delivery-carrier/blob/10.0/delivery_carrier_label_postlogistics/models/stock.py#L87
It is not very good. If a carrier submodule have not-base64 data, it can easily encode it and it seems cleaner this way.

- Transform the field "file_type" on shipping labels from selection field to char field.
=> I am not sure this field is very usefull... But I think it should not be a selection field anyway.
Indeed, depending on the carrier, a lot of different format may be managed, and the selection fields force us to override the selection on each module to add the possible format.
Since the field is not even in any view, and it is always filled by a module, never in the UI, a char field seems fine, and more flexible.

- Write the tracking number on the package. 
Indeed, there is a field with this goal and when we have the information of package and tracking number, we should write it. It is also something done in every carrier submodules which could be done here. example : https://github.com/OCA/delivery-carrier/blob/10.0/delivery_carrier_label_postlogistics/models/stock.py#L111

@bealdav @hparfr @yvaucher @Timo17100-c2c 
Thanks for your feedback

