### PR TITLE
[FIX] delivery_auto_refresh: Avoid error when confirming sales order

### DIFF
--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -11,8 +11,6 @@ def _execute_onchanges(records, field_name):
             onchange(record)
 
 
-@common.at_install(False)
-@common.post_install(True)
 class TestDeliveryAutoRefresh(common.HttpCase):
     def setUp(self):
         super(TestDeliveryAutoRefresh, self).setUp()


### PR DESCRIPTION
As the used method now has a check for not being used when the order is confirmed, so it collapses when you want to add the delivery line in that moment.

@Tecnativa TT20031