### PR TITLE
[12.0][base_delivery_carrier_label] Add delivery type on carrier acount

### DIFF
--- a/base_delivery_carrier_label/models/carrier_account.py
+++ b/base_delivery_carrier_label/models/carrier_account.py
@@ -17,6 +17,10 @@ class CarrierAccount(models.Model):
                 ('XML', 'XML')]
 
     name = fields.Char(required=True)
+    delivery_type = fields.Selection(
+        selection=lambda self: self.env["delivery.carrier"]
+        ._fields["delivery_type"].selection,
+        help="This field may be used to link an account to a carrier")
     account = fields.Char(string='Account Number', required=True)
     password = fields.Char(string='Account Password', required=True)
     company_id = fields.Many2one(comodel_name="res.company", string="Company")

--- a/base_delivery_carrier_label/views/carrier_account.xml
+++ b/base_delivery_carrier_label/views/carrier_account.xml
@@ -20,11 +20,10 @@
         <sheet>
           <div class="oe_title">
               <h1><field name="name"/></h1>
-              <!-- To be able to link a carrier account with a delivery method 
-                   we need of this convention -->
-              <div>Name must match with one of the value of Provider field (delivery_type) of your delivery methods</div>
           </div>
           <group>
+              <!-- To be able to link a carrier account with a delivery method -->
+            <field name="delivery_type"/>
             <field name="account"/>
             <field name="password" password="True"/>
             <field name="file_format"/>


### PR DESCRIPTION
The goal is to be able to link a carrier account with a type of carrier.
Indeed, now we can only do this link with the name of the account if we put the same value than the delivery_type of the carrier, but it is not so intuitive and also too restrictive.
Indeed, we may need to have a unique name for carrier (for it to work with carrier_environment for instance) and this make it impossible to have multiple accounts for a carrier.

@bealdav @yvaucher @rousseldenis 
