### PR TITLE
[FIX] delivery_auto_refresh: cost calculation on fixed carrier_type

### DIFF
--- a/delivery_auto_refresh/i18n/de.po
+++ b/delivery_auto_refresh/i18n/de.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-03-13 03:45+0000\n"
 "PO-Revision-Date: 2018-03-13 03:45+0000\n"

--- a/delivery_auto_refresh/models/stock_picking.py
+++ b/delivery_auto_refresh/models/stock_picking.py
@@ -37,7 +37,10 @@ class StockPicking(models.Model):
         total = sale_order.currency_id._convert(
             total, sale_order.company_id.currency_id, sale_order.company_id,
             sale_order.date_order)
-        so_line.price_unit = self.carrier_id._get_price_from_picking(
-            total, weight, volume, quantity,
-        )
+        if self.carrier_id.carrier_type == "fixed":
+            so_line.price_unit = self.carrier_id.fixed_price
+        else:
+            so_line.price_unit = self.carrier_id._get_price_from_picking(
+                total, weight, volume, quantity,
+            )
         return res

--- a/delivery_auto_refresh/models/stock_picking.py
+++ b/delivery_auto_refresh/models/stock_picking.py
@@ -37,7 +37,7 @@ class StockPicking(models.Model):
         total = sale_order.currency_id._convert(
             total, sale_order.company_id.currency_id, sale_order.company_id,
             sale_order.date_order)
-        if self.carrier_id.carrier_type == "fixed":
+        if self.carrier_id.delivery_type == "fixed":
             so_line.price_unit = self.carrier_id.fixed_price
         else:
             so_line.price_unit = self.carrier_id._get_price_from_picking(

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -18,6 +18,10 @@ class TestDeliveryAutoRefresh(common.HttpCase):
             'name': 'Service Test',
             'type': 'service',
         })
+        service_fixed = self.env['product.product'].create({
+            'name': 'Service Test Fixed',
+            'type': 'service',
+        })
         self.carrier = self.env['delivery.carrier'].create({
             'name': 'Test carrier',
             'delivery_type': 'base_on_rule',
@@ -47,14 +51,29 @@ class TestDeliveryAutoRefresh(common.HttpCase):
                 }),
             ]
         })
+        self.carrier_fixed = self.env['delivery.carrier'].create({
+            'name': 'Test carrier fixed',
+            'delivery_type': 'fixed',
+            'product_id': service_fixed.id,
+            'fixed_price': 10.0,
+        })
         self.product = self.env['product.product'].create({
             'name': 'Test product',
+            'weight': 10,
+            'list_price': 20,
+        })
+        self.product_fixed = self.env['product.product'].create({
+            'name': 'Test product fixed',
             'weight': 10,
             'list_price': 20,
         })
         self.partner = self.env['res.partner'].create({
             'name': 'Test partner',
             'property_delivery_carrier_id': self.carrier.id,
+        })
+        self.partner_fixed = self.env['res.partner'].create({
+            'name': 'Test partner fixed delivery',
+            'property_delivery_carrier_id': self.carrier_fixed.id,
         })
         self.param_name1 = 'delivery_auto_refresh.auto_add_delivery_line'
         self.param_name2 = 'delivery_auto_refresh.refresh_after_picking'
@@ -67,9 +86,21 @@ class TestDeliveryAutoRefresh(common.HttpCase):
                 })
             ]
         })
+        order_fixed = self.env['sale.order'].new({
+            'partner_id': self.partner_fixed.id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': self.product_fixed.id,
+                    'product_uom_qty': 2,
+                })
+            ]
+        })
         _execute_onchanges(order, 'partner_id')
         _execute_onchanges(order.order_line, 'product_id')
         self.order = order.create(order._convert_to_write(order._cache))
+        _execute_onchanges(order_fixed, 'partner_id')
+        _execute_onchanges(order_fixed.order_line, 'product_id')
+        self.order_fixed = order_fixed.create(order_fixed._convert_to_write(order_fixed._cache))
 
     def test_auto_refresh_so(self):
         self.assertFalse(self.order.order_line.filtered('is_delivery'))
@@ -114,3 +145,57 @@ class TestDeliveryAutoRefresh(common.HttpCase):
         picking.action_done()
         line_delivery = self.order.order_line.filtered('is_delivery')
         self.assertEqual(line_delivery.price_unit, 60)
+
+    def test_auto_refresh_so_fixed(self):
+        self.assertFalse(self.order_fixed.order_line.filtered('is_delivery'))
+        self.env['ir.config_parameter'].sudo().set_param(self.param_name1, 1)
+        self.order_fixed.write({
+            'order_line': [
+                (1, self.order_fixed.order_line.id, {'product_uom_qty': 3}),
+            ],
+        })
+        line_delivery = self.order_fixed.order_line.filtered('is_delivery')
+        self.assertEqual(line_delivery.price_unit, 10)
+        line2 = self.order_fixed.order_line.new({
+            'order_id': self.order_fixed.id,
+            'product_id': self.product_fixed.id,
+            'product_uom_qty': 2,
+        })
+        _execute_onchanges(line2, 'product_id')
+        vals = line2._convert_to_write(line2._cache)
+        del vals['order_id']
+        self.order_fixed.write({'order_line': [(0, 0, vals)]})
+        line_delivery = self.order_fixed.order_line.filtered('is_delivery')
+        self.assertEqual(line_delivery.price_unit, 10)
+
+    def test_auto_refresh_picking_fixed(self):
+        self.env['ir.config_parameter'].sudo().set_param(self.param_name2, 1)
+        self.order_fixed.order_line.create({
+            'order_id': self.order_fixed.id,
+            'product_id': self.product_fixed.id,
+            'product_uom_qty': 2,
+        })
+        self.order_fixed.order_line.product_uom_qty = 3
+        self.order_fixed.action_confirm()
+        picking = self.order_fixed.picking_ids
+        picking.action_assign()
+        picking.move_line_ids[0].qty_done = 2
+        picking.action_done()
+        line_delivery = self.order_fixed.order_line.filtered('is_delivery')
+        self.assertEqual(line_delivery.price_unit, 10)
+
+    def test_no_auto_refresh_picking_fixed(self):
+        self.env['ir.config_parameter'].sudo().set_param(self.param_name2, "0")
+        self.order_fixed.order_line.create({
+            'order_id': self.order_fixed.id,
+            'product_id': self.product_fixed.id,
+            'product_uom_qty': 2,
+        })
+        self.order_fixed.order_line.product_uom_qty = 3
+        self.order_fixed.action_confirm()
+        picking = self.order_fixed.picking_ids
+        picking.action_assign()
+        picking.move_line_ids[0].qty_done = 2
+        picking.action_done()
+        line_delivery = self.order_fixed.order_line.filtered('is_delivery')
+        self.assertEqual(line_delivery.price_unit, 10)

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -100,7 +100,9 @@ class TestDeliveryAutoRefresh(common.HttpCase):
         self.order = order.create(order._convert_to_write(order._cache))
         _execute_onchanges(order_fixed, 'partner_id')
         _execute_onchanges(order_fixed.order_line, 'product_id')
-        self.order_fixed = order_fixed.create(order_fixed._convert_to_write(order_fixed._cache))
+        self.order_fixed = order_fixed.create(
+            order_fixed._convert_to_write(order_fixed._cache)
+        )
 
     def test_auto_refresh_so(self):
         self.assertFalse(self.order.order_line.filtered('is_delivery'))


### PR DESCRIPTION
When module `delivery_auto_refresh` ist installed and you try to confirm a stock picking with a fixed price carrier you'll get the following message:` "No price rule matching this order; delivery cost cannot be computed."`

This happens because `_get_price_from_picking` can only get costs if there are rules defined in the carrier. Fixed cost carriers don't have any rules hence cost calculation will fail.

So before getting costs via rules it should check if this is a fixed type carrier - if it's the case we can simply write  the `fixed_price` to `so_line`.