### PR TITLE
[12.0][FIX] stock_picking_delivery_info_computation: Take into account reserved qty

### DIFF
--- a/stock_picking_delivery_info_computation/tests/test_stock_picking_info_computation.py
+++ b/stock_picking_delivery_info_computation/tests/test_stock_picking_info_computation.py
@@ -1,5 +1,5 @@
 # Copyright 2019 Tecnativa - Victor M.M. Torres
-# Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2019-2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.addons.sale.tests.test_sale_common import TestSale
@@ -12,7 +12,7 @@ class TestStockPickingInfoComputation(TestSale):
         self.product_pricelist_0 = self.env.ref('product.list0')
         self.product_a = self.env['product.product'].create({
             'name': 'Test product A',
-            'type': 'consu',
+            'type': 'product',
             'weight': 0.3,
             'volume': 0.02,
         })
@@ -46,29 +46,39 @@ class TestStockPickingInfoComputation(TestSale):
             'picking_policy': 'direct',
         })
 
-    def test_weight_volume_initial(self):
-        # Test weight and volume funtcion
-        # over an stock.picking with pack operation to do
-        # self.sale_test.action_confirm()
+    def test_weight_volume_with_done_qty(self):
         self.sale_test.action_confirm()
         picking = self.sale_test.picking_ids
-        self.assertAlmostEqual(picking.volume, 0.19)
-        self.assertAlmostEqual(picking.weight, 1.85)
-
-    def test_weight_volume_with_reserved_qty(self):
-        # Test weight and volume funtcion over an stock.picking
-        # with just one pack operation done qty
-        self.sale_test.action_confirm()
-        picking = self.sale_test.picking_ids
-        packop = picking.move_ids_without_package.filtered(
+        self.assertAlmostEqual(picking.weight, 1.25)  # Prod. B - 0.25 * 5
+        self.assertAlmostEqual(picking.volume, 0.15)  # Prod. B - 0.03 * 5
+        move = picking.move_ids_without_package.filtered(
             lambda x: x.product_id == self.product_a
         )
         # Needed for creating backorder
-        packop.write({'quantity_done': 1})
-        self.assertAlmostEqual(picking.weight, 0.3)
+        move.write({'quantity_done': 1})
+        self.assertAlmostEqual(picking.weight, 0.3)  # Prod. A - 0.3 * 1
         picking.action_calculate_volume()
-        self.assertAlmostEqual(picking.volume, 0.02)
+        self.assertAlmostEqual(picking.volume, 0.02)  # Prod. A - 0.02 * 1
         # Confirm and create backorder
         picking.action_done()
         backorder = self.sale_test.picking_ids - picking
-        self.assertAlmostEqual(backorder.volume, 0.17)
+        self.assertAlmostEqual(backorder.weight, 1.25)  # Prod. B - 0.25 * 5
+        self.assertAlmostEqual(backorder.volume, 0.15)  # Prod. B - 0.03 * 5
+        backorder.do_unreserve()
+        backorder.action_calculate_volume()
+        self.assertAlmostEqual(backorder.weight, 1.55)  # 0.3 * 1 + 0.25 * 5
+        self.assertAlmostEqual(backorder.volume, 0.17)  # 0.02 * 1 + 0.03 * 5
+
+    def test_weight_volume_with_reserved_qty(self):
+        # Add stock quantity
+        self.env['stock.quant'].create({
+            'product_id': self.product_a.id,
+            'location_id': self.sale_test.warehouse_id.lot_stock_id.id,
+            'quantity': 1,
+        })
+        self.sale_test.action_confirm()
+        picking = self.sale_test.picking_ids
+        picking.action_assign()
+        self.assertAlmostEqual(picking.weight, 1.55)  # 0.3 * 1 + 0.25 * 5
+        picking.action_calculate_volume()
+        self.assertAlmostEqual(picking.volume, 0.17)  # 0.02 * 1 + 0.03 * 5


### PR DESCRIPTION
In v10, pack operation exists if there's reserved quantity. Now with the switch to moves, this option was not covered, so information varies between v10 and v12.

Includes tests for avoiding regressions.

cc @Tecnativa TT21418