### PR TITLE
[12.0][FIX+IMP] delivery_multi_destination: View + available carriers + shipping

### DIFF
--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -2,7 +2,8 @@
 # Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class DeliveryCarrier(models.Model):
@@ -70,3 +71,35 @@ class DeliveryCarrier(models.Model):
                     return super(
                         DeliveryCarrier, subcarrier,
                     ).rate_shipment(order)
+
+    def send_shipping(self, pickings):
+        """We have to override this method for redirecting the result to the
+        proper "child" carrier.
+        """
+        if self.destination_type == 'one':
+            return super().send_shipping(pickings)
+        else:
+            carrier = self.with_context(show_children_carriers=True)
+            res = []
+            for p in pickings:
+                picking_res = False
+                for subcarrier in carrier.child_ids:
+                    if subcarrier.delivery_type == 'fixed':
+                        if subcarrier._match_address(p.partner_id):
+                            picking_res = [{
+                                'exact_price': subcarrier.fixed_price,
+                                'tracking_number': False}]
+                            break
+                    else:
+                        try:
+                            picking_res = super(
+                                DeliveryCarrier, subcarrier,
+                            ).send_shipping(pickings)
+                            break
+                        except Exception:
+                            pass
+                if not picking_res:
+                    raise ValidationError(
+                        _('There is no matching delivery rule.'))
+                res += picking_res
+            return res

--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Tecnativa - Pedro M. Baeza
+# Copyright 2016-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
@@ -45,17 +45,17 @@ class DeliveryCarrier(models.Model):
         )
 
     def available_carriers(self, partner):
-        """Add childrens on the possible list to select carriers. This is
-        used on `website_sale_delivery` module.
-        """
-        candidates = self.env['delivery.carrier']
+        """If the carrier is multi, we test the availability on children."""
+        available = self.env['delivery.carrier']
         for carrier in self:
             if carrier.destination_type == 'one':
-                candidates |= carrier
+                candidates = carrier
             else:
                 carrier = carrier.with_context(show_children_carriers=True)
-                candidates |= carrier.child_ids
-        return super(DeliveryCarrier, candidates).available_carriers(partner)
+                candidates = carrier.child_ids
+            if super(DeliveryCarrier, candidates).available_carriers(partner):
+                available |= carrier
+        return available
 
     def rate_shipment(self, order):
         """We have to override this method for getting the proper price

--- a/delivery_multi_destination/tests/test_delivery_multi_destination.py
+++ b/delivery_multi_destination/tests/test_delivery_multi_destination.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
-# Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2019-2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.tests import common
@@ -132,7 +132,5 @@ class TestDeliveryMultiDestination(common.SavepointCase):
     def test_available_carriers(self):
         self.assertEqual(
             self.carrier_multi.available_carriers(self.partner_2),
-            self.carrier_multi.with_context(
-                show_children_carriers=True,
-            ).child_ids[0],
+            self.carrier_multi,
         )

--- a/delivery_multi_destination/views/delivery_carrier_view.xml
+++ b/delivery_multi_destination/views/delivery_carrier_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2016-2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+<!-- Copyright 2016-2020 Tecnativa - Pedro M. Baeza
      Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 
@@ -9,10 +9,27 @@
         <field name="model">delivery.carrier</field>
         <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
         <field name="arch" type="xml">
-            <field name="delivery_type" position="before">
-                <field name="destination_type"
-                       invisible="context.get('show_children_fields', False)"
-                />
+            <xpath expr="//field[@name='delivery_type']/../../.." position="before">
+                <group name="group_destination_type">
+                    <field name="destination_type"
+                        invisible="context.get('show_children_fields', False)"
+                    />
+                </group>
+            </xpath>
+            <xpath expr="//field[@name='delivery_type']/../.." position="attributes">
+                <attribute name="attrs">{'invisible': [('destination_type', '=', 'multi')]}</attribute>
+            </xpath>
+            <label for="margin" position="attributes">
+                <attribute name="attrs">{'invisible': [('destination_type', '=', 'multi')]}</attribute>
+            </label>
+            <xpath expr="//field[@name='margin']/.." position="attributes">
+                <attribute name="attrs">{'invisible': [('destination_type', '=', 'multi')]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='free_over']/.." position="attributes">
+                <attribute name="attrs">{'invisible': [('destination_type', '=', 'multi')]}</attribute>
+            </xpath>
+            <field name="amount" position="attributes">
+                <attribute name="attrs">{'required':[('free_over','!=', False)], 'invisible':['|', ('free_over','=', False), ('destination_type', '=', 'multi')]}</attribute>
             </field>
             <xpath expr="//field[@name='fixed_price']/ancestor::page"
                    position="attributes">


### PR DESCRIPTION
* [IMP] Improve view for hiding undesired elements

  On a multi-destination carrier, that fields shouldn't be shown.

* [FIX] available carriers must return the main one
   
  When testing available carriers, we must return the main one if one of the children matches, not returning the children itself.

* [FIX] Make delivery shipping properly

  Handle the step of sending the shipping (triggered on picking validation) for multi destination delivery. This means to manually check for fixing prices (as the implementation doesn't check this part and always take the main carrier price, not the subcarrier one.

  Test for this use case done, although the rest of the cases are not covered by tests yet.

cc @Tecnativa TT22325