### PR TITLE
[9.0][IMP] delivery_carrier_label_batch: ZPL2 single images

### DIFF
--- a/delivery_carrier_label_batch/README.rst
+++ b/delivery_carrier_label_batch/README.rst
@@ -14,6 +14,13 @@ put in a pack before the labels can be printed.
 
 If you don't define your pack it will be considered a picking is a single pack.
 
+Configure
+=========
+
+If using ZPL2 file format, multiple *.zpl can be merged either "as is" or with
+"single image definition" to spare file size.
+Single image definition can be used by defining `ir.config_parameter` with name
+`zpl2.assembler.single.images` to `True`.
 
 Usage
 =====

--- a/delivery_carrier_label_batch/__openerp__.py
+++ b/delivery_carrier_label_batch/__openerp__.py
@@ -11,6 +11,7 @@
     'depends': ['base_delivery_carrier_label', 'stock_batch_picking'],
     'website': 'http://www.camptocamp.com/',
     'data': [
+        'data/ir.config_parameter.xml',
         'views/stock_batch_picking.xml',
         'wizard/generate_labels_view.xml',
         'wizard/apply_carrier_view.xml',

--- a/delivery_carrier_label_batch/data/ir.config_parameter.xml
+++ b/delivery_carrier_label_batch/data/ir.config_parameter.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-    <record id="zpl2_assembler_single_images" model="ir.config_parameter">
-        <field name="key">zpl2.assembler.single.images</field>
-        <field name="value">False</field>
-    </record>
-</odoo>
+<openerp>
+    <data>
+        <record id="zpl2_assembler_single_images" model="ir.config_parameter">
+            <field name="key">zpl2.assembler.single.images</field>
+            <field name="value">False</field>
+        </record>
+    </data>
+</openerp>

--- a/delivery_carrier_label_batch/data/ir.config_parameter.xml
+++ b/delivery_carrier_label_batch/data/ir.config_parameter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="zpl2_assembler_single_images" model="ir.config_parameter">
+        <field name="name">zpl2.assembler.single.images</field>
+        <field name="value">False</field>
+    </record>
+</odoo>

--- a/delivery_carrier_label_batch/data/ir.config_parameter.xml
+++ b/delivery_carrier_label_batch/data/ir.config_parameter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <record id="zpl2_assembler_single_images" model="ir.config_parameter">
-        <field name="name">zpl2.assembler.single.images</field>
+        <field name="key">zpl2.assembler.single.images</field>
         <field name="value">False</field>
     </record>
 </odoo>

--- a/delivery_carrier_label_batch/data/ir.config_parameter.xml
+++ b/delivery_carrier_label_batch/data/ir.config_parameter.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
-    <data>
+    <data noupdate="1">
         <record id="zpl2_assembler_single_images" model="ir.config_parameter">
             <field name="key">zpl2.assembler.single.images</field>
             <field name="value">False</field>
         </record>
+        <record id="zpl2_batch_merge" model="ir.config_parameter">
+            <field name="key">zpl2.batch.merge</field>
+            <field name="value">False</field>
+        </record>
+
     </data>
 </openerp>

--- a/delivery_carrier_label_batch/wizard/generate_labels.py
+++ b/delivery_carrier_label_batch/wizard/generate_labels.py
@@ -210,10 +210,11 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
                 picking = operations[0].picking_id
                 if pack:
                     label = self_env._find_pack_label(pack)
-                    label_name = pack.name
+                    label_name = pack.parcel_tracking or pack.name
+
                 else:
                     label = self_env._find_picking_label(picking)
-                    label_name = picking.name
+                    label_name = picking.carrier_tracking_ref or picking.name
                 if not label:
                     continue
                 labels.append((label.file_type,

--- a/delivery_carrier_label_batch/wizard/generate_labels.py
+++ b/delivery_carrier_label_batch/wizard/generate_labels.py
@@ -10,7 +10,7 @@ from itertools import groupby
 from openerp import _, api, exceptions, fields, models, tools
 
 from ..pdf_utils import assemble_pdf
-from ..zpl_utils import assemble_zpl2
+from ..zpl_utils import assemble_zpl2, assemble_zpl2_single_images
 
 _logger = logging.getLogger(__name__)
 
@@ -277,6 +277,12 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
         if file_type == 'pdf':
             return assemble_pdf(files)
         if file_type == 'zpl2':
-            return assemble_zpl2(files)
+            zpl2_single_images = self.env['ir.config_parameter'].get_param(
+                'zpl2.assembler.single.images'
+            )
+            if zpl2_single_images:
+                return assemble_zpl2_single_images(files)
+            else:
+                return assemble_zpl2(files)
         # Merging files of `file_type` not supported, we return nothing
         return

--- a/delivery_carrier_label_batch/wizard/generate_labels.py
+++ b/delivery_carrier_label_batch/wizard/generate_labels.py
@@ -8,6 +8,7 @@ import threading
 from contextlib import contextmanager
 from itertools import groupby
 from openerp import _, api, exceptions, fields, models, tools
+from openerp.tools.safe_eval import safe_eval
 
 from ..pdf_utils import assemble_pdf
 from ..zpl_utils import assemble_zpl2, assemble_zpl2_single_images
@@ -277,8 +278,10 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
         if file_type == 'pdf':
             return assemble_pdf(files)
         if file_type == 'zpl2':
-            zpl2_single_images = self.env['ir.config_parameter'].get_param(
-                'zpl2.assembler.single.images'
+            zpl2_single_images = safe_eval(
+                self.env['ir.config_parameter'].get_param(
+                    'zpl2.assembler.single.images'
+                )
             )
             if zpl2_single_images:
                 return assemble_zpl2_single_images(files)

--- a/delivery_carrier_label_batch/zpl_utils.py
+++ b/delivery_carrier_label_batch/zpl_utils.py
@@ -3,6 +3,77 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 
+def assemble_zpl2_single_images(files):
+    """Assemble a list of ZPL2 files with single image definition."""
+    zpl_images = dict()
+    zpl_labels = dict()
+    # Extract all the images and labels from different files
+    for file_nr, zpl_file in enumerate(files):
+        # ^XA stands for label start
+        images_def, label_def = zpl_file.split("^XA")
+        label_def = "^XA%s" % label_def
+        zpl_labels[file_nr] = label_def
+        # ~DGR:IMGx stands for image start
+        split_images = images_def.split("~DGR:IMG")
+        # Remove header "^FXJob Header^FS" from image
+        header = split_images.pop(0)
+        # Add all the images for this file in zplimages
+        if split_images:
+            file_images = list()
+            for img in split_images:
+                zpl_image = "~DGR:IMG%s" % img
+                file_images.append(zpl_image)
+            zpl_images[file_nr] = file_images
+    # Check images definition to avoid different images using the same ref
+    # There are three cases to cover here:
+    #  1. No existing image with this ref > keep image as it is
+    #  2. Existing image with this ref is the same image > Nothing to do
+    #  3. Existing image with this ref is not the same image > Change the ref
+    #     for image and update refs in related label
+    #  4. There is a same existing image with different ref > Update the refs
+    #     in related label
+    to_add_images = dict()
+    for file_nr, file_zpl_images in zpl_images.items():
+        for zpl_img in file_zpl_images:
+            img_header, img_content = zpl_img.split(".GRF")
+            img_number = img_header.lstrip("~DGR:")
+            if img_content not in to_add_images.keys():
+                if img_number not in to_add_images.values():
+                    # Case 1. Keep image as it is
+                    to_add_images[img_content] = img_number
+                else:
+                    # Case 3.
+                    # Handle different image for same image numbers
+                    max_img_number = max(to_add_images.values())
+                    # Remove IMG form max_number_name in order to increment
+                    img_prefix = max_img_number[:3]
+                    digit = max_img_number[3:]
+                    # Define new img number
+                    new_digit = str(int(digit + 1))
+                    new_img_number = img_prefix + new_digit
+                    # change img number reference in label
+                    to_add_images[img_content] = new_img_number
+                    file_label = zpl_labels.get(file_nr)
+                    file_label.replace(img_number, new_img_number)
+                    zpl_labels[file_nr] = file_label
+            elif img_number != to_add_images.get(img_content):
+                # Case 4
+                # Handle different image numbers for same image
+                file_label = zpl_labels.get(file_nr)
+                file_label.replace(img_number, to_add_images.get(img_content))
+                zpl_labels[file_nr] = file_label
+    # Construct final result
+    res = header
+    # Add all the images with their ref
+    for img_to_add, img_number in to_add_images.items():
+        res += "~DGR:%s.GRF%s" % (img_number, img_to_add)
+    # Add all the updated labels
+    for label in zpl_labels.values():
+        res += header
+        res += label
+    return res
+
+
 def assemble_zpl2(files):
     """Assemble a list of ZPL2 files."""
     return "".join(files)

--- a/delivery_carrier_label_batch/zpl_utils.py
+++ b/delivery_carrier_label_batch/zpl_utils.py
@@ -37,7 +37,7 @@ def assemble_zpl2_single_images(files):
         for zpl_img in file_zpl_images:
             img_header, img_content = zpl_img.split(".GRF")
             img_number = img_header.lstrip("~DGR:")
-            if img_content not in to_add_images.keys():
+            if img_content not in to_add_images:
                 if img_number not in to_add_images.values():
                     # Case 1. Keep image as it is
                     to_add_images[img_content] = img_number
@@ -49,11 +49,11 @@ def assemble_zpl2_single_images(files):
                     img_prefix = max_img_number[:3]
                     digit = max_img_number[3:]
                     # Define new img number
-                    new_digit = str(int(digit + 1))
+                    new_digit = str(int(digit) + 1)
                     new_img_number = img_prefix + new_digit
                     # change img number reference in label
                     to_add_images[img_content] = new_img_number
-                    file_label = zpl_labels.get(file_nr)
+                    file_label = zpl_labels[file_nr]
                     file_label.replace(img_number, new_img_number)
                     zpl_labels[file_nr] = file_label
             elif img_number != to_add_images.get(img_content):

--- a/delivery_carrier_label_batch/zpl_utils.py
+++ b/delivery_carrier_label_batch/zpl_utils.py
@@ -60,7 +60,7 @@ def assemble_zpl2_single_images(files):
                 # Case 4
                 # Handle different image numbers for same image
                 file_label = zpl_labels.get(file_nr)
-                file_label.replace(img_number, to_add_images.get(img_content))
+                file_label.replace(img_number, to_add_images[img_content])
                 zpl_labels[file_nr] = file_label
     # Construct final result
     res = header


### PR DESCRIPTION
If using ZPL2 file format, multiple *.zpl can be merged either "as is" or with
"single image definition" to spare file size.
Single image definition can be used by defining `ir.config_parameter` with name
`zpl2.assembler.single.images` to `True`.