### PR TITLE
[10.0][delivery_carrier_label_postlogistics] Street1 printed before S…

### DIFF
--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -166,7 +166,7 @@ class PostlogisticsWebService(object):
         partner_name = partner.name or partner.parent_id.name
         recipient = {
             'Name1': partner_name,
-            'Street': partner.street,
+            'Street': partner.street2 or partner.street,
             'ZIP': partner.zip,
             'City': partner.city,
             'Country': partner.country_id.code,
@@ -174,7 +174,8 @@ class PostlogisticsWebService(object):
         }
 
         if partner.street2:
-            recipient['AddressSuffix'] = partner.street2
+            recipient['Street'] = partner.street2
+            recipient['AddressSuffix'] = partner.street
 
         if partner.parent_id and partner.parent_id.name != partner_name:
             recipient['Name2'] = partner.parent_id.name


### PR DESCRIPTION
…treet2

Impacting module: delivery_carrier_label_postlogistics

Aim of this PR is to print street1 before street2 on shipping label. To do that, keys in a recipient dictionary inside __prepare_recipient_() method were exchanged.

partner:
![image](https://user-images.githubusercontent.com/59824990/85276577-569b7c00-b482-11ea-83c1-c5d6be7616a5.png)

Result:
[shipping_label.pdf](https://github.com/OCA/delivery-carrier/files/4812624/shipping_label.pdf)
