### PR TITLE
[10.0][delivery_carrier_label_postlogistics] Street1 printed before S…

### DIFF
--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -166,15 +166,15 @@ class PostlogisticsWebService(object):
         partner_name = partner.name or partner.parent_id.name
         recipient = {
             'Name1': partner_name,
-            'Street': partner.street,
+            'Street': partner.street2 or partner.street,
             'ZIP': partner.zip,
             'City': partner.city,
             'Country': partner.country_id.code,
             'EMail': partner.email or None,
         }
 
-        if partner.street2:
-            recipient['AddressSuffix'] = partner.street2
+        if partner.street2 and partner.street:
+            recipient['AddressSuffix'] = partner.street
 
         if partner.parent_id and partner.parent_id.name != partner_name:
             recipient['Name2'] = partner.parent_id.name


### PR DESCRIPTION
Street1 printed before Stree2

This PR intends to fix error message introduced by the following PR:
https://github.com/OCA/delivery-carrier/pull/269

"[E2001] A valid recipient address must be stated."

This happens when `Street` is send with empty string.