### PR TITLE
[13.0] Add delivery_carrier_pricelist

### DIFF
--- a/delivery_carrier_pricelist/__init__.py
+++ b/delivery_carrier_pricelist/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/delivery_carrier_pricelist/__manifest__.py
+++ b/delivery_carrier_pricelist/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Shipping Method Pricelist",
+    "summary": "Compute method method fees based on the product's pricelist.",
+    "version": "13.0.1.0.0",
+    "category": "Delivery",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "installable": True,
+    "license": "AGPL-3",
+    "depends": ["delivery"],
+    "data": [],
+}

--- a/delivery_carrier_pricelist/models/__init__.py
+++ b/delivery_carrier_pricelist/models/__init__.py
@@ -1,0 +1,2 @@
+from . import delivery_carrier
+from . import stock_picking

--- a/delivery_carrier_pricelist/models/delivery_carrier.py
+++ b/delivery_carrier_pricelist/models/delivery_carrier.py
@@ -1,0 +1,157 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+
+from odoo import _, fields, models
+from odoo.osv import expression
+from odoo.tools.safe_eval import safe_eval
+
+from odoo.addons.base.models.ir_ui_view import (
+    transfer_modifiers_to_node,
+    transfer_node_to_modifiers,
+)
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    delivery_type = fields.Selection(
+        selection_add=[("pricelist", "Based on Product Pricelist")]
+    )
+    invoice_policy = fields.Selection(
+        selection_add=[("pricelist", "Pricelist Cost")],
+        help="Estimated Cost: the customer will be invoiced the estimated"
+        " cost of the shipping.\n"
+        "Real Cost: the customer will be invoiced the real cost of the"
+        " shipping, the cost of the shipping will be updated on the"
+        " SO after the delivery.\n"
+        "Pricelist Cost: the customer will be invoiced the price of the "
+        "product based on the pricelist of the sales order. The provider's "
+        "cost is ignored.",
+    )
+
+    def rate_shipment(self, order):
+        if self.invoice_policy == "pricelist":
+            current_type = self.delivery_type
+            # force computation from pricelist when the invoicing policy says
+            # so
+            self.delivery_type = "pricelist"
+            result = super().rate_shipment(order)
+            self.delivery_type = current_type
+            return result
+        else:
+            return super().rate_shipment(order)
+
+    def send_shipping(self, pickings):
+        result = super().send_shipping(pickings)
+        if self.invoice_policy == "pricelist":
+            # force computation from pricelist when the invoicing policy says
+            # so
+            rates = self.pricelist_send_shipping(pickings)
+            for index, rate in enumerate(rates):
+                result[index]["exact_price"] = rate["exact_price"]
+        return result
+
+    def _pricelist_get_price(self, order):
+        product = self.product_id.with_context(
+            pricelist=order.pricelist_id.id,
+            partner=order.partner_id,
+            quantity=1,
+            date=order.date_order,
+            uom=self.product_id.uom_id.id,
+        )
+        price = order.currency_id._convert(
+            product.price,
+            order.company_id.currency_id,
+            order.company_id,
+            order.date_order or fields.Date.today(),
+        )
+        return price
+
+    def pricelist_rate_shipment(self, order):
+        carrier = self._match_address(order.partner_shipping_id)
+        if not carrier:
+            return {
+                "success": False,
+                "price": 0.0,
+                "error_message": _(
+                    "Error: this delivery method is not available for this address."
+                ),
+                "warning_message": False,
+            }
+        price = self._pricelist_get_price(order)
+        return {
+            "success": True,
+            "price": price,
+            "error_message": False,
+            "warning_message": False,
+        }
+
+    def pricelist_send_shipping(self, pickings):
+        res = []
+        for picking in pickings:
+            carrier = picking.carrier_id
+            sale = picking.sale_id
+            price = carrier._pricelist_get_price(sale) if sale else 0.0
+            res = res + [{"exact_price": price, "tracking_number": False}]
+        return res
+
+    def pricelist_get_tracking_link(self, picking):
+        return False
+
+    def pricelist_cancel_shipment(self, pickings):
+        raise NotImplementedError()
+
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        result = super().fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
+        )
+        if result["name"] == "delivery.carrier.form":
+            result["arch"] = self._fields_view_get_adapt_attrs(result["arch"])
+        return result
+
+    def _add_pricelist_domain(
+        self,
+        doc,
+        xpath_expr,
+        attrs_key,
+        domain_operator=expression.OR,
+        field_operator="=",
+    ):
+        """Add the delivery type domain for 'pricelist' in attrs"""
+        nodes = doc.xpath(xpath_expr)
+        for field in nodes:
+            attrs = safe_eval(field.attrib.get("attrs", "{}"))
+            if not attrs[attrs_key]:
+                continue
+
+            invisible_domain = domain_operator(
+                [attrs[attrs_key], [("delivery_type", field_operator, "pricelist")]]
+            )
+            attrs[attrs_key] = invisible_domain
+            field.set("attrs", str(attrs))
+            modifiers = {}
+            transfer_node_to_modifiers(
+                field, modifiers, self.env.context, in_tree_view=True
+            )
+            transfer_modifiers_to_node(modifiers, field)
+
+    def _fields_view_get_adapt_attrs(self, view_arch):
+        """Adapt the attrs of elements in the view with 'pricelist' delivery type"""
+        doc = etree.XML(view_arch)
+        # hide all these fields and buttons for delivery providers which have already
+        # an attrs with a domain we can't extend...
+        self._add_pricelist_domain(
+            doc, "//button[@name='toggle_prod_environment']", "invisible"
+        )
+        self._add_pricelist_domain(doc, "//button[@name='toggle_debug']", "invisible")
+        self._add_pricelist_domain(
+            doc, "//field[@name='integration_level']", "invisible"
+        )
+        self._add_pricelist_domain(doc, "//field[@name='invoice_policy']", "invisible")
+
+        new_view = etree.tostring(doc, encoding="unicode")
+        return new_view

--- a/delivery_carrier_pricelist/models/stock_picking.py
+++ b/delivery_carrier_pricelist/models/stock_picking.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from lxml import etree
+
+from odoo import models
+from odoo.osv import expression
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        result = super().fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
+        )
+        if result.get("name") == "stock.picking.form":
+            result["arch"] = self._fields_view_get_adapt_attrs(result["arch"])
+        return result
+
+    def _fields_view_get_adapt_attrs(self, view_arch):
+        doc = etree.XML(view_arch)
+        # hide all these fields and buttons for delivery providers which have already
+        # an attrs with a domain we can't extend...
+        self.env["delivery.carrier"]._add_pricelist_domain(
+            doc, "//button[@name='cancel_shipment']", "invisible"
+        )
+        self.env["delivery.carrier"]._add_pricelist_domain(
+            doc, "//button[@name='send_to_shipper']", "invisible"
+        )
+        self.env["delivery.carrier"]._add_pricelist_domain(
+            doc,
+            "//field[@name='partner_id']",
+            "required",
+            domain_operator=expression.AND,
+            field_operator="!=",
+        )
+        return etree.tostring(doc, encoding="unicode")

--- a/delivery_carrier_pricelist/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_pricelist/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/delivery_carrier_pricelist/readme/DESCRIPTION.rst
+++ b/delivery_carrier_pricelist/readme/DESCRIPTION.rst
@@ -1,0 +1,13 @@
+Compute shipping methods fees based on Product Pricelists.
+
+It allows to have different pricing per customer, prices depending on dates, ...
+The pricelist based cost is computed from the shipping method's product and the
+sales order's pricelist.
+
+It supports the following use cases:
+
+* When no "external" provider (e.g. DHL, UPS, ...) is used, a new provider
+  "Based on Product Pricelist" is available.
+* When an external provider is used, a new option in the "Invoice Policy"
+  selection, named "Pricelist Cost", overrides the provider's cost by the
+  pricelist based cost.

--- a/delivery_carrier_pricelist/tests/__init__.py
+++ b/delivery_carrier_pricelist/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_delivery_pricelist

--- a/delivery_carrier_pricelist/tests/test_delivery_pricelist.py
+++ b/delivery_carrier_pricelist/tests/test_delivery_pricelist.py
@@ -1,0 +1,64 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests.common import Form, SavepointCase
+
+
+class TestRoutePutaway(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner_18 = cls.env.ref("base.res_partner_18")
+        cls.product_4 = cls.env.ref("product.product_product_4")
+        cls.product_uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.pricelist = cls.env.ref("product.list0")
+        cls.sale_normal_delivery_charges = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner_18.id,
+                "partner_invoice_id": cls.partner_18.id,
+                "partner_shipping_id": cls.partner_18.id,
+                "pricelist_id": cls.pricelist.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "PC Assamble + 2GB RAM",
+                            "product_id": cls.product_4.id,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_uom_unit.id,
+                            "price_unit": 750.00,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.fee_product = cls.env["product.product"].create(
+            {"name": "Fee", "type": "service"}
+        )
+        cls.carrier_pricelist = cls.env["delivery.carrier"].create(
+            {
+                "name": "Pricelist Based",
+                "delivery_type": "pricelist",
+                "product_id": cls.fee_product.id,
+            }
+        )
+
+    def test_wizard_price(self):
+        price = 13.0
+        self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "product_id": self.fee_product.id,
+                "applied_on": "0_product_variant",
+                "fixed_price": price,
+            }
+        )
+
+        delivery_wizard = Form(
+            self.env["choose.delivery.carrier"].with_context(
+                {"default_order_id": self.sale_normal_delivery_charges.id}
+            )
+        )
+        delivery_wizard.carrier_id = self.carrier_pricelist
+        self.assertEqual(delivery_wizard.display_price, price)

--- a/delivery_carrier_pricelist/wizards/__init__.py
+++ b/delivery_carrier_pricelist/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import choose_delivery_carrier

--- a/delivery_carrier_pricelist/wizards/choose_delivery_carrier.py
+++ b/delivery_carrier_pricelist/wizards/choose_delivery_carrier.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+
+from odoo import api, fields, models
+
+
+class ChooseDeliveryCarrier(models.TransientModel):
+    _inherit = "choose.delivery.carrier"
+
+    invoice_policy = fields.Selection(related="carrier_id.invoice_policy")
+
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        result = super().fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
+        )
+        if result.get("type") == "form":
+            result["arch"] = self._fields_view_get_adapt_attrs(result["arch"])
+        return result
+
+    def _fields_view_get_adapt_attrs(self, view_arch):
+        doc = etree.XML(view_arch)
+        # hide this button for delivery providers which have already
+        # an attrs with a domain we can't extend...
+        self.env["delivery.carrier"]._add_pricelist_domain(
+            doc, "//button[@name='update_price']", "invisible"
+        )
+        return etree.tostring(doc, encoding="unicode")
+
+    @api.onchange("carrier_id")
+    def _onchange_carrier_id(self):
+        self.delivery_message = False
+        if "pricelist" in (self.delivery_type, self.invoice_policy):
+            vals = self._get_shipment_rate()
+            if vals.get("error_message"):
+                return {"error": vals["error_message"]}
+        else:
+            return super()._onchange_carrier_id()
+
+    @api.onchange("order_id")
+    def _onchange_order_id(self):
+        # pricelist delivery price will be computed on each carrier change so
+        # no need to recompute here
+        if "pricelist" not in (self.delivery_type, self.invoice_policy):
+            return super()._onchange_order_id()

--- a/setup/delivery_carrier_pricelist/odoo/addons/delivery_carrier_pricelist
+++ b/setup/delivery_carrier_pricelist/odoo/addons/delivery_carrier_pricelist
@@ -1,0 +1,1 @@
+../../../../delivery_carrier_pricelist

--- a/setup/delivery_carrier_pricelist/setup.py
+++ b/setup/delivery_carrier_pricelist/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
New module allowing to compute a delivery cost based on the sales order
pricelist.

It allows to have different pricing per customer, prices depending on dates, ...
The pricelist based cost is computed from the shipping method's product and the
sales order's pricelist.

It supports the following use cases:

* When no "external" provider (e.g. DHL, UPS, ...) is used, a new provider
  "Based on Product Pricelist" is available.
* When an external provider is used, a new option in the "Invoice Policy"
  selection, named "Pricelist Cost", overrides the provider's cost by the
  pricelist based cost.

