### PR TITLE
[13.0] Add delivery_package_fee

### DIFF
--- a/delivery_package_fee/__init__.py
+++ b/delivery_package_fee/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_package_fee/__manifest__.py
+++ b/delivery_package_fee/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Delivery Package Fees",
+    "summary": "Add fees on delivered packages on shipping methods",
+    "version": "13.0.1.0.0",
+    "category": "Delivery",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "installable": True,
+    "license": "AGPL-3",
+    "depends": ["delivery"],
+    "data": ["views/delivery_carrier_views.xml", "security/ir.model.access.csv"],
+}

--- a/delivery_package_fee/models/__init__.py
+++ b/delivery_package_fee/models/__init__.py
@@ -1,0 +1,5 @@
+from . import delivery_carrier
+from . import delivery_package_fee
+from . import sale_order
+from . import sale_order_line
+from . import stock_picking

--- a/delivery_package_fee/models/delivery_carrier.py
+++ b/delivery_package_fee/models/delivery_carrier.py
@@ -1,0 +1,11 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    package_fee_ids = fields.One2many(
+        comodel_name="delivery.package.fee", inverse_name="carrier_id",
+    )

--- a/delivery_package_fee/models/delivery_package_fee.py
+++ b/delivery_package_fee/models/delivery_package_fee.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class DeliveryPackageFee(models.Model):
+    _name = "delivery.package.fee"
+    _description = "Delivery Package Fees"
+
+    carrier_id = fields.Many2one(
+        comodel_name="delivery.carrier", required=True, ondelete="cascade",
+    )
+    product_id = fields.Many2one(
+        comodel_name="product.product", required=True, ondelete="restrict",
+    )

--- a/delivery_package_fee/models/sale_order.py
+++ b/delivery_package_fee/models/sale_order.py
@@ -6,12 +6,22 @@ from odoo import fields, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    def _get_fee_line_qty_from_out_package(self, package_fee, picking, package):
+        """Compute the fee qty for the package to deliver.
+
+        Return 1 by default.
+        """
+        return 1
+
     def _package_fee_line_qty_and_price(self, package_fee, picking):
         fee_product = package_fee.product_id
 
         # line units
         out_packages = picking.mapped("move_line_ids.result_package_id")
-        qty = len(out_packages)
+        qty = sum(
+            self._get_fee_line_qty_from_out_package(package_fee, picking, package)
+            for package in out_packages
+        )
         if not qty:
             return 0, 0.0
 

--- a/delivery_package_fee/models/sale_order.py
+++ b/delivery_package_fee/models/sale_order.py
@@ -1,0 +1,96 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _package_fee_line_qty_and_price(self, package_fee, picking):
+        fee_product = package_fee.product_id
+
+        # line units
+        out_packages = picking.mapped("move_line_ids.result_package_id")
+        qty = len(out_packages)
+        if not qty:
+            return 0, 0.0
+
+        # amount
+        product = fee_product.with_context(
+            pricelist=self.pricelist_id.id,
+            partner=self.partner_id,
+            quantity=qty,
+            date=self.date_order,
+            uom=fee_product.uom_id.id,
+        )
+        price_unit = self.currency_id._convert(
+            product.price,
+            self.company_id.currency_id,
+            self.company_id,
+            self.date_order or fields.Date.today(),
+        )
+        return qty, price_unit
+
+    def _prepare_package_fee_line(self, package_fee, picking, qty, price_unit):
+        # read fees details in the customer language
+        package_fee = package_fee.with_context(lang=self.partner_id.lang)
+        fee_product = package_fee.product_id
+
+        # Apply fiscal position
+        taxes = fee_product.taxes_id.filtered(
+            lambda t: t.company_id.id == self.company_id.id
+        )
+        taxes_ids = taxes.ids
+        if self.partner_id and self.fiscal_position_id:
+            taxes_ids = self.fiscal_position_id.map_tax(
+                taxes, fee_product, self.partner_id
+            ).ids
+
+        # line description
+        if fee_product.description_sale:
+            so_description = "{}: {}".format(
+                fee_product.name, fee_product.description_sale
+            )
+        else:
+            so_description = fee_product.name
+        so_description = "{} ({})".format(so_description, picking.name)
+
+        values = {
+            "order_id": self.id,
+            "name": so_description,
+            "product_uom_qty": qty,
+            "product_uom": fee_product.uom_id.id,
+            "product_id": fee_product.id,
+            "tax_id": [(6, 0, taxes_ids)],
+            "price_unit": price_unit,
+            "package_fee_id": package_fee.id,
+        }
+        if self.order_line:
+            values["sequence"] = self.order_line[-1].sequence + 1
+        return values
+
+    def _create_package_fee_line(self, package_fee, picking):
+        line_model = self.env["sale.order.line"].sudo()
+        qty, price_unit = self._package_fee_line_qty_and_price(package_fee, picking)
+        if not qty or self.currency_id.is_zero(price_unit):
+            return line_model.browse()
+
+        values = self._prepare_package_fee_line(package_fee, picking, qty, price_unit)
+        return line_model.create(values)
+
+    def copy_data(self, default=None):
+        result = super().copy_data(default=default)
+        new_result = []
+        for values in result:
+            # "sale" module sets this key
+            if "order_line" in values:
+                # remove package fee lines
+                order_lines = [
+                    line
+                    for line in values["order_line"]
+                    # lines are (0, 0, {}) commands
+                    if not line[2].get("package_fee_id")
+                ]
+                values["order_line"] = order_lines
+            new_result.append(values)
+        return new_result

--- a/delivery_package_fee/models/sale_order_line.py
+++ b/delivery_package_fee/models/sale_order_line.py
@@ -1,0 +1,9 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    package_fee_id = fields.Many2one(comodel_name="delivery.package.fee", default=False)

--- a/delivery_package_fee/models/stock_picking.py
+++ b/delivery_package_fee/models/stock_picking.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _add_delivery_cost_to_so(self):
+        super()._add_delivery_cost_to_so()
+        self._add_package_fee_cost_to_so()
+
+    def _add_package_fee_cost_to_so(self):
+        if not self.carrier_id.package_fee_ids:
+            return
+        if not self.sale_id:
+            return
+        for package_fee in self.carrier_id.package_fee_ids:
+            self.sale_id._create_package_fee_line(package_fee, self)

--- a/delivery_package_fee/readme/CONFIGURE.rst
+++ b/delivery_package_fee/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+In "Inventory > Configuration > Delivery > Shipping Methods", a new tab allow to
+select the package fees. For each product added, a new fee line will be added in
+the sales order.

--- a/delivery_package_fee/readme/CONTRIBUTORS.rst
+++ b/delivery_package_fee/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/delivery_package_fee/readme/DESCRIPTION.rst
+++ b/delivery_package_fee/readme/DESCRIPTION.rst
@@ -1,0 +1,16 @@
+Add delivery fees on Sales Orders based on the delivered packages.
+
+A list of Package Fees can be added on shipping methods.
+When a outgoing transfer is done, for each package fee configured on the
+shipping method, a new sale order line is created with:
+
+* The product selected on the Package Fee
+* The product name with the number of the transfer in the line's description
+  (e.g. "Service Fee (WH/OUT/00036)")
+* The quantity equal to the number of packages in the transfer
+* The unit price equal to the price set on the product's pricelist (so it can be
+  different per customer and even have different pricing depending on the number
+  of packages)
+* The taxes configured on the product, fiscal position applies if any.
+
+Package Fee lines are added only if their quantity and price is above zero.

--- a/delivery_package_fee/security/ir.model.access.csv
+++ b/delivery_package_fee/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_delivery_package_fee,delivery.package.fee,model_delivery_package_fee,sales_team.group_sale_salesman,1,0,0,0
+access_delivery_package_fee_manager,delivery.package.fee,model_delivery_package_fee,sales_team.group_sale_manager,1,1,1,1
+access_delivery_package_fee_partner_manager,delivery.package.fee partner_manager,model_delivery_package_fee,base.group_partner_manager,1,0,0,0
+access_delivery_package_fee_stock_user,delivery.package.fee stock_user,model_delivery_package_fee,stock.group_stock_user,1,0,0,0
+access_delivery_package_fee_stock_manager,delivery.package.fee,model_delivery_package_fee,stock.group_stock_manager,1,1,1,1

--- a/delivery_package_fee/tests/__init__.py
+++ b/delivery_package_fee/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_package_fee

--- a/delivery_package_fee/tests/test_package_fee.py
+++ b/delivery_package_fee/tests/test_package_fee.py
@@ -1,0 +1,397 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import Form, SavepointCase
+from odoo.tools import mute_logger
+
+
+class TestPackageFee(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product1 = cls.env["product.product"].create(
+            {"name": "Product 1", "type": "product", "lst_price": 1.0}
+        )
+        cls.product2 = cls.env["product.product"].create(
+            {"name": "Product 2", "type": "product", "lst_price": 1.0}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Partner"})
+
+        cls.carrier_product = cls.env["product.product"].create(
+            {"name": "Shipping", "type": "service"}
+        )
+        cls.fee1 = cls.env["product.product"].create(
+            {"name": "LSVA Fee", "type": "service", "lst_price": 3.0}
+        )
+        cls.fee2 = cls.env["product.product"].create(
+            {"name": "Service Fee", "type": "service", "lst_price": 4.0}
+        )
+
+        cls.carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Delivery",
+                "fixed_price": 10.0,
+                "product_id": cls.carrier_product.id,
+                "package_fee_ids": [
+                    (0, 0, {"product_id": cls.fee1.id}),
+                    (0, 0, {"product_id": cls.fee2.id}),
+                ],
+            }
+        )
+        cls.wh = cls.env.ref("stock.warehouse0")
+
+        cls.sale = cls._create_sale()
+        cls._add_sale_carrier(cls.sale, cls.carrier)
+        cls._update_qty_in_location(
+            cls.wh.lot_stock_id,
+            cls.sale.order_line[0].product_id,
+            cls.sale.order_line[0].product_uom_qty,
+        )
+        cls._update_qty_in_location(
+            cls.wh.lot_stock_id,
+            cls.sale.order_line[1].product_id,
+            cls.sale.order_line[1].product_uom_qty,
+        )
+        cls.sale.action_confirm()
+
+        cls.pack1 = cls.env["stock.quant.package"].create({})
+        cls.pack2 = cls.env["stock.quant.package"].create({})
+
+    @classmethod
+    def _update_qty_in_location(cls, location, product, quantity):
+        quants = cls.env["stock.quant"]._gather(product, location, strict=True)
+        # this method adds the quantity to the current quantity, so get the diff
+        quantity -= sum(quants.mapped("quantity"))
+        cls.env["stock.quant"]._update_available_quantity(product, location, quantity)
+
+    @classmethod
+    def _create_sale(cls):
+        sale_form = Form(cls.env["sale.order"])
+        sale_form.partner_id = cls.partner
+        with mute_logger("odoo.tests.common.onchange"):
+            with sale_form.order_line.new() as line:
+                line.product_id = cls.product1
+                line.product_uom_qty = 10.0
+            with sale_form.order_line.new() as line:
+                line.product_id = cls.product2
+                line.product_uom_qty = 10.0
+        return sale_form.save()
+
+    @classmethod
+    def _add_sale_carrier(cls, sale, carrier):
+        delivery_wizard = Form(
+            cls.env["choose.delivery.carrier"].with_context(
+                {"default_order_id": sale.id, "default_carrier_id": carrier.id}
+            )
+        )
+        choose_delivery_carrier = delivery_wizard.save()
+        choose_delivery_carrier.button_confirm()
+
+    def test_package_fee_simple(self):
+        """All stock moves processed at once"""
+        picking = self.sale.picking_ids
+        self.assertEqual(picking.state, "assigned")
+        picking.move_line_ids[0].result_package_id = self.pack1
+        picking.move_line_ids[0].qty_done = 10.0
+        picking.move_line_ids[1].result_package_id = self.pack2
+        picking.move_line_ids[1].qty_done = 10.0
+        picking.action_done()
+        self.assertEqual(picking.state, "done")
+
+        self.assertRecordValues(
+            self.sale.order_line,
+            [
+                {
+                    "product_id": self.product1.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 1",
+                },
+                {
+                    "product_id": self.product2.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 2",
+                },
+                {
+                    "product_id": self.carrier_product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                    "name": "Delivery",
+                },
+                # additional package fee lines from here
+                {
+                    "product_id": self.fee1.id,
+                    # one unit per package
+                    "product_uom_qty": 2.0,
+                    "price_unit": 3.0,
+                    "name": "LSVA Fee ({})".format(picking.name),
+                },
+                {
+                    "product_id": self.fee2.id,
+                    # one unit per package
+                    "product_uom_qty": 2.0,
+                    "price_unit": 4.0,
+                    "name": "Service Fee ({})".format(picking.name),
+                },
+            ],
+        )
+
+    def test_package_fee_backorder(self):
+        """Stock moves valided in 2 times using a backorder"""
+        picking = self.sale.picking_ids
+        self.assertEqual(picking.state, "assigned")
+        picking.move_line_ids[0].result_package_id = self.pack1
+        picking.move_line_ids[0].qty_done = 10.0
+        picking.action_done()
+        self.assertEqual(picking.state, "done")
+        backorder = picking.backorder_ids
+
+        self.assertRecordValues(
+            self.sale.order_line,
+            [
+                {
+                    "product_id": self.product1.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 1",
+                },
+                {
+                    "product_id": self.product2.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 2",
+                },
+                {
+                    "product_id": self.carrier_product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                    "name": "Delivery",
+                },
+                # additional package fee lines from here
+                {
+                    "product_id": self.fee1.id,
+                    # one unit per package
+                    "product_uom_qty": 1.0,
+                    "price_unit": 3.0,
+                    "name": "LSVA Fee ({})".format(picking.name),
+                },
+                {
+                    "product_id": self.fee2.id,
+                    # one unit per package
+                    "product_uom_qty": 1.0,
+                    "price_unit": 4.0,
+                    "name": "Service Fee ({})".format(picking.name),
+                },
+            ],
+        )
+
+        backorder.move_line_ids[0].result_package_id = self.pack2
+        backorder.move_line_ids[0].qty_done = 10.0
+        backorder.action_done()
+        self.assertEqual(backorder.state, "done")
+
+        self.assertRecordValues(
+            self.sale.order_line,
+            [
+                {
+                    "product_id": self.product1.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 1",
+                },
+                {
+                    "product_id": self.product2.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 2",
+                },
+                {
+                    "product_id": self.carrier_product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                    "name": "Delivery",
+                },
+                # these lines have been added by the first picking
+                {
+                    "product_id": self.fee1.id,
+                    # one unit per package
+                    "product_uom_qty": 1.0,
+                    "price_unit": 3.0,
+                    "name": "LSVA Fee ({})".format(picking.name),
+                },
+                {
+                    "product_id": self.fee2.id,
+                    # one unit per package
+                    "product_uom_qty": 1.0,
+                    "price_unit": 4.0,
+                    "name": "Service Fee ({})".format(picking.name),
+                },
+                # new lines added for the backorder
+                {
+                    "product_id": self.fee1.id,
+                    # one unit per package
+                    "product_uom_qty": 1.0,
+                    "price_unit": 3.0,
+                    "name": "LSVA Fee ({})".format(backorder.name),
+                },
+                {
+                    "product_id": self.fee2.id,
+                    # one unit per package
+                    "product_uom_qty": 1.0,
+                    "price_unit": 4.0,
+                    "name": "Service Fee ({})".format(backorder.name),
+                },
+            ],
+        )
+
+    def test_package_fee_pricelist(self):
+        """Price set on a pricelist is used"""
+        # set pricelist prices for package fees
+        pricelist = self.sale.pricelist_id
+        fee1_price = 13.5
+        fee2_price = 17.2
+        self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": pricelist.id,
+                "product_id": self.fee1.id,
+                "applied_on": "0_product_variant",
+                "fixed_price": fee1_price,
+            }
+        )
+        self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": pricelist.id,
+                "product_id": self.fee2.id,
+                "applied_on": "0_product_variant",
+                "fixed_price": fee2_price,
+            }
+        )
+
+        picking = self.sale.picking_ids
+        self.assertEqual(picking.state, "assigned")
+        picking.move_line_ids[0].result_package_id = self.pack1
+        picking.move_line_ids[0].qty_done = 10.0
+        picking.move_line_ids[1].result_package_id = self.pack2
+        picking.move_line_ids[1].qty_done = 10.0
+        picking.action_done()
+        self.assertEqual(picking.state, "done")
+
+        self.assertRecordValues(
+            self.sale.order_line,
+            [
+                {
+                    "product_id": self.product1.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 1",
+                },
+                {
+                    "product_id": self.product2.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 2",
+                },
+                {
+                    "product_id": self.carrier_product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                    "name": "Delivery",
+                },
+                # additional package fee lines from here
+                {
+                    "product_id": self.fee1.id,
+                    # one unit per package
+                    "product_uom_qty": 2.0,
+                    "price_unit": fee1_price,
+                    "name": "LSVA Fee ({})".format(picking.name),
+                },
+                {
+                    "product_id": self.fee2.id,
+                    # one unit per package
+                    "product_uom_qty": 2.0,
+                    "price_unit": fee2_price,
+                    "name": "Service Fee ({})".format(picking.name),
+                },
+            ],
+        )
+
+    def test_package_no_package(self):
+        """No packages, no fees"""
+        picking = self.sale.picking_ids
+        self.assertEqual(picking.state, "assigned")
+        picking.move_line_ids[0].qty_done = 10.0
+        picking.move_line_ids[1].qty_done = 10.0
+        picking.action_done()
+        self.assertEqual(picking.state, "done")
+
+        self.assertRecordValues(
+            self.sale.order_line,
+            [
+                {
+                    "product_id": self.product1.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 1",
+                },
+                {
+                    "product_id": self.product2.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 2",
+                },
+                {
+                    "product_id": self.carrier_product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                    "name": "Delivery",
+                },
+            ],
+        )
+
+    def test_package_no_price(self):
+        """No price on product, no fees"""
+        picking = self.sale.picking_ids
+        self.fee1.lst_price = 0.0
+        self.assertEqual(picking.state, "assigned")
+        picking.move_line_ids[0].result_package_id = self.pack1
+        picking.move_line_ids[0].qty_done = 10.0
+        picking.move_line_ids[1].result_package_id = self.pack2
+        picking.move_line_ids[1].qty_done = 10.0
+        picking.action_done()
+        self.assertEqual(picking.state, "done")
+
+        self.assertRecordValues(
+            self.sale.order_line,
+            [
+                {
+                    "product_id": self.product1.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 1",
+                },
+                {
+                    "product_id": self.product2.id,
+                    "product_uom_qty": 10.0,
+                    "price_unit": 1.0,
+                    "name": "Product 2",
+                },
+                {
+                    "product_id": self.carrier_product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                    "name": "Delivery",
+                },
+                # only the Service Fees are added because there is
+                # no price on the LSVA (could be free for a customer
+                # based on a pricelist for instance)
+                {
+                    "product_id": self.fee2.id,
+                    # one unit per package
+                    "product_uom_qty": 2.0,
+                    "price_unit": 4.0,
+                    "name": "Service Fee ({})".format(picking.name),
+                },
+            ],
+        )

--- a/delivery_package_fee/views/delivery_carrier_views.xml
+++ b/delivery_package_fee/views/delivery_carrier_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_delivery_carrier_form" model="ir.ui.view">
+        <field name="name">delivery.carrier.form</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form" />
+        <field name="arch" type="xml">
+            <page name="pricing" position="after">
+                <page string="Package Fees" name="package_fee">
+                    <group>
+                        <p>
+                            For each line below, each time a transfer is done, a line is added
+                            in the sales order with the product. The unit is the number of packages
+                            in the transfer and the price is the product's pricelist price.
+                        </p>
+                    </group>
+                    <group>
+                        <field name="package_fee_ids" nolabel="1">
+                            <tree string="Package Fees" editable="bottom">
+                                <field
+                                    name="product_id"
+                                    context="{'default_type': 'service', 'default_sale_ok': False, 'default_purchase_ok': False}"
+                                />
+                            </tree>
+                        </field>
+                    </group>
+                </page>
+            </page>
+        </field>
+    </record>
+</odoo>

--- a/setup/delivery_package_fee/odoo/addons/delivery_package_fee
+++ b/setup/delivery_package_fee/odoo/addons/delivery_package_fee
@@ -1,0 +1,1 @@
+../../../../delivery_package_fee

--- a/setup/delivery_package_fee/setup.py
+++ b/setup/delivery_package_fee/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
A list of Package Fees can be added on shipping methods.
When a outgoing transfer is done, for each package fee configured on the
shipping method, a new sale order line is created with:

* The product selected on the Package Fee
* The product name with the number of the transfer in the line's description
  (e.g. "Service Fee (WH/OUT/00036)")
* The quantity equal to the number of packages in the transfer
* The unit price equal to the price set on the product's pricelist (so it can be
  different per customer and even have different pricing depending on the number
  of packages)
* The taxes configured on the product, fiscal position applies if any.

Package Fee lines are added only if their quantity and price is above zero.