### PR TITLE
[12.0][REF] extract delivery_carrier_info from base_delivery_carrier_label

### DIFF
--- a/base_delivery_carrier_label/__manifest__.py
+++ b/base_delivery_carrier_label/__manifest__.py
@@ -1,11 +1,11 @@
 # Copyright 2013-2015 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {'name': 'Base module for carrier labels',
- 'version': '12.0.2.1.0',
+ 'version': '12.0.3.0.0',
  'author': "Camptocamp,Akretion,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'category': 'Delivery',
- 'depends': ['delivery'],
+ 'depends': ['delivery_carrier_info'],
  'website': 'https://github.com/OCA/delivery-carrier',
  'data': [
      'views/delivery.xml',

--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -9,10 +9,6 @@ class DeliveryCarrier(models.Model):
     _inherit = 'delivery.carrier'
 
     delivery_type = fields.Selection(oldname='carrier_type')
-    code = fields.Char(
-        help="Delivery Method Code (according to carrier)",
-    )
-    description = fields.Text()
     available_option_ids = fields.One2many(
         comodel_name='delivery.carrier.option',
         inverse_name='carrier_id',

--- a/base_delivery_carrier_label/views/delivery.xml
+++ b/base_delivery_carrier_label/views/delivery.xml
@@ -68,32 +68,12 @@
     <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
     <field name="arch" type="xml">
 
-      <xpath expr="//h1" position="after">
-        <group>
-          <field name="code"/>
-        </group>
-      </xpath>
-
       <xpath expr="//notebook" position="inside">
         <page string="Options">
           <field name="available_option_ids" nolabel="1" colspan="4"/>
         </page>
-        <page string="Description">
-          <field name="description" colspan="4" nolabel="1"/>
-        </page>
       </xpath>
 
-    </field>
-  </record>
-
-  <record id="view_delivery_carrier_tree" model="ir.ui.view">
-    <field name="name">delivery_carrier_base.tree</field>
-    <field name="model">delivery.carrier</field>
-    <field name="inherit_id" ref="delivery.view_delivery_carrier_tree"/>
-    <field name="arch" type="xml">
-      <field name="name" position="after">
-        <field name="code"/>
-      </field>
     </field>
   </record>
 

--- a/delivery_carrier_info/__init__.py
+++ b/delivery_carrier_info/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_carrier_info/__manifest__.py
+++ b/delivery_carrier_info/__manifest__.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+{
+    "name": "Delivery Carrier Info",
+    "summary": "Add code and description on carrier",
+    "version": "12.0.1.0.0",
+    "category": "Delivery",
+    "website": "www.akretion.com",
+    "author": "Akretion,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {
+        "python": [],
+        "bin": [],
+    },
+    "depends": [
+        "delivery",
+    ],
+    "data": [
+        "views/delivery_view.xml"
+    ],
+    "demo": [
+    ],
+    "qweb": [
+    ]
+}

--- a/delivery_carrier_info/models/__init__.py
+++ b/delivery_carrier_info/models/__init__.py
@@ -1,0 +1,1 @@
+from . import delivery_carrier

--- a/delivery_carrier_info/models/delivery_carrier.py
+++ b/delivery_carrier_info/models/delivery_carrier.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Akretion (https://www.akretion.com).
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    code = fields.Char(
+        help="Delivery Method Code (according to carrier)",
+    )
+    description = fields.Text()

--- a/delivery_carrier_info/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_info/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Sébastien BEAU <sebastien.beau@akretion.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/delivery_carrier_info/readme/DESCRIPTION.rst
+++ b/delivery_carrier_info/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module add the field "code" and "description" on the delivery carrier.

--- a/delivery_carrier_info/readme/USAGE.rst
+++ b/delivery_carrier_info/readme/USAGE.rst
@@ -1,0 +1,1 @@
+In your delivery carrier you can fill the code and the description

--- a/delivery_carrier_info/views/delivery_view.xml
+++ b/delivery_carrier_info/views/delivery_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+  <record id="view_delivery_carrier_form" model="ir.ui.view">
+    <field name="name">delivery_base.delivery.carrier.view_form</field>
+    <field name="model">delivery.carrier</field>
+    <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+    <field name="arch" type="xml">
+
+      <xpath expr="//h1" position="after">
+        <group>
+          <field name="code"/>
+        </group>
+      </xpath>
+
+      <xpath expr="//notebook" position="inside">
+        <page name="description" string="Description">
+          <field name="description" colspan="4" nolabel="1"/>
+        </page>
+      </xpath>
+
+    </field>
+  </record>
+
+  <record id="view_delivery_carrier_tree" model="ir.ui.view">
+    <field name="name">delivery_carrier_base.tree</field>
+    <field name="model">delivery.carrier</field>
+    <field name="inherit_id" ref="delivery.view_delivery_carrier_tree"/>
+    <field name="arch" type="xml">
+      <field name="name" position="after">
+        <field name="code"/>
+      </field>
+    </field>
+  </record>
+
+
+</odoo>


### PR DESCRIPTION
In e-commerce case you need some extract info on carrier (code, description) installing the module  base_delivery_carrier_label is too much for having this two field, so I have split the module to reduce the dependency

@florian-dacosta @bealdav @guewen 

Merge with nobump I have updated the version manually