### PR TITLE
[ADD] base_delivery_carrier_label: active flag for options

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -17,6 +17,7 @@ class DeliveryCarrier(models.Model):
         comodel_name='delivery.carrier.option',
         inverse_name='carrier_id',
         string='Option',
+        context={'active_test': False},
     )
 
     @api.multi

--- a/base_delivery_carrier_label/models/delivery_carrier_option.py
+++ b/base_delivery_carrier_label/models/delivery_carrier_option.py
@@ -16,6 +16,7 @@ class DeliveryCarrierOption(models.Model):
     _description = 'Delivery carrier option'
     _inherits = {'delivery.carrier.template.option': 'tmpl_option_id'}
 
+    active = fields.Boolean(default=True)
     mandatory = fields.Boolean(
         help="If checked, this option is necessarily applied "
              "to the delivery order"

--- a/base_delivery_carrier_label/views/delivery.xml
+++ b/base_delivery_carrier_label/views/delivery.xml
@@ -35,6 +35,7 @@
     <field name="arch" type="xml">
       <form string="delivery_carrier_option">
         <group col="4">
+          <field name="active" />
           <field name="mandatory" attrs="{'readonly': [('readonly_flag','=',True)]}"/>
           <field name="by_default" attrs="{'invisible': [('mandatory', '=', True)]}"/>
           <field name="readonly_flag" attrs="{'invisible': True}"/>
@@ -52,7 +53,8 @@
     <field name="model">delivery.carrier.option</field>
     <field name="type">tree</field>
     <field name="arch" type="xml">
-      <tree string="delivery_carrier_option">
+      <tree string="delivery_carrier_option" decoration-muted="not active">
+        <field name="active" />
         <field name="mandatory" />
         <field name="tmpl_option_id" />
         <field name="code"/>


### PR DESCRIPTION
For carriers with a lot of options that aren't all relevant for a specific deployment, it's helpful to be able to hide uninteresting options