### PR TITLE
[12.0] delivery_carrier_label_batch - Remove broken icon

### DIFF
--- a/delivery_carrier_label_batch/wizard/generate_labels_view.xml
+++ b/delivery_carrier_label_batch/wizard/generate_labels_view.xml
@@ -14,7 +14,7 @@
         <field name="generate_new_labels"/>
       </group>
       <footer>
-        <button name="action_generate_labels" string="Generate Labels" type="object" icon="gtk-execute" class="oe_highlight"/>
+        <button name="action_generate_labels" string="Generate Labels" type="object" class="oe_highlight"/>
         <button string="Close" class="oe_link" special="cancel" />
       </footer>
 


### PR DESCRIPTION
gtk-execute is not available anymore in 12.0.