### PR TITLE
[FIX] delivery_carrier_label_postlogistic char encoding

### DIFF
--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -415,7 +415,7 @@ class PostlogisticsWebService(object):
                 'accept': 'application/json',
                 'content-type': 'application/json',
             },
-            data=json.dumps(data, ensure_ascii=False),
+            data=json.dumps(data, ensure_ascii=False).encode("utf-8"),
             timeout=60,
         )
 

--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -4,7 +4,6 @@
 import base64
 import re
 import logging
-import json
 import requests
 from PIL import Image
 from io import StringIO
@@ -354,7 +353,7 @@ class PostlogisticsWebService(object):
             },
             timeout=60,
         )
-        response_token_dict = json.loads(response_token.content.decode("utf-8"))
+        response_token_dict = response_token.json()
         access_token = response_token_dict['access_token']
 
         if not (access_token):
@@ -413,9 +412,9 @@ class PostlogisticsWebService(object):
             headers={
                 'Authorization': 'Bearer %s' % access_token,
                 'accept': 'application/json',
-                'content-type': 'application/json',
+                'content-type': 'application/json; charset=utf-8',
             },
-            data=json.dumps(data, ensure_ascii=False).encode("utf-8"),
+            json=data,
             timeout=60,
         )
 
@@ -427,7 +426,7 @@ class PostlogisticsWebService(object):
             ]
             return res
 
-        response_dict = json.loads(response.content.decode("utf-8"))
+        response_dict = response.json()
 
         if response_dict['item'].get('errors'):
             res['success'] = False

--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -415,7 +415,7 @@ class PostlogisticsWebService(object):
                 'accept': 'application/json',
                 'content-type': 'application/json',
             },
-            data=json.dumps(data),
+            data=json.dumps(data, ensure_ascii=False),
             timeout=60,
         )
 


### PR DESCRIPTION
It seems Postlogistics REST web service is unhappy with the normal JSON encoding
of non ASCII characters and requires these to be encoded in utf-8 -> by using ensure_ascii=False in the call to json.dumps() we try obtain this. 

From the `json` documentation:

    If `ensure_ascii` is false, then the return value can contain non-ASCII
    characters if they appear in strings contained in `obj`. Otherwise, all
    such characters are escaped in JSON strings.
