### PR TITLE
[12.0] Fix access to ir.config_parameter to get access token parameters

### DIFF
--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -330,7 +330,7 @@ class PostlogisticsWebService(object):
         }
 
     def get_access_token(self, env):
-        icp = env['ir.config_parameter']
+        icp = env['ir.config_parameter'].sudo()
         client_id = icp.get_param('postlogistics.oauth.client_id')
         client_secret = icp.get_param('postlogistics.oauth.client_secret')
         authentication_url = icp.get_param(


### PR DESCRIPTION
**Context**
Users can not access `ir.config_parameter` to get access token parameters

**Goal**
Use `sudo` to be able to read access token parameters