### PR TITLE
[13.0][IMP] delivery_free_fee_removal fix invoicing

### DIFF
--- a/delivery_free_fee_removal/models/__init__.py
+++ b/delivery_free_fee_removal/models/__init__.py
@@ -1,1 +1,2 @@
+from . import sale_order
 from . import sale_order_line

--- a/delivery_free_fee_removal/models/sale_order.py
+++ b/delivery_free_fee_removal/models/sale_order.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def action_confirm(self):
+        super().action_confirm()
+        # Invoice all the free delivery line on order confirmation
+        # Or the order will never be fully invoiced.
+        delivery_lines = self.order_line.filtered(
+            lambda line: line.order_id.state == "sale" and line.is_free_delivery
+        )
+        for line in delivery_lines:
+            line.qty_invoiced = line.product_uom_qty

--- a/delivery_free_fee_removal/models/sale_order_line.py
+++ b/delivery_free_fee_removal/models/sale_order_line.py
@@ -15,10 +15,3 @@ class SaleOrderLine(models.Model):
             line.is_free_delivery = line.is_delivery and line.currency_id.is_zero(
                 line.price_total
             )
-
-    @api.depends("is_free_delivery")
-    def _get_to_invoice_qty(self):
-        free_delivery_lines = self.filtered("is_free_delivery")
-        free_delivery_lines.qty_to_invoice = 0
-        other_lines = self - free_delivery_lines
-        super(SaleOrderLine, other_lines)._get_to_invoice_qty()

--- a/delivery_free_fee_removal/readme/CONTRIBUTORS.rst
+++ b/delivery_free_fee_removal/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * `Camptocamp <https://www.camptocamp.com>`__:
 
   * Guewen Baconnier
+  * Thierry Ducrest

--- a/delivery_free_fee_removal/tests/test_delivery_free_fee_removal.py
+++ b/delivery_free_fee_removal/tests/test_delivery_free_fee_removal.py
@@ -48,7 +48,14 @@ class TestDeliveryFreeFeeRemoval(SavepointCase):
         delivery_line = self.sale.mapped("order_line").filtered(lambda x: x.is_delivery)
         self.sale.action_confirm()
         self.assertRecordValues(
-            delivery_line, [{"is_free_delivery": False, "qty_to_invoice": 1}]
+            delivery_line,
+            [
+                {
+                    "is_free_delivery": False,
+                    "qty_to_invoice": 1,
+                    "invoice_status": "to invoice",
+                }
+            ],
         )
 
     def test_delivery_free_fee_removal_free_fee(self):
@@ -56,5 +63,12 @@ class TestDeliveryFreeFeeRemoval(SavepointCase):
         delivery_line = self.sale.mapped("order_line").filtered(lambda x: x.is_delivery)
         self.sale.action_confirm()
         self.assertRecordValues(
-            delivery_line, [{"is_free_delivery": True, "qty_to_invoice": 0}]
+            delivery_line,
+            [
+                {
+                    "is_free_delivery": True,
+                    "qty_to_invoice": 0,
+                    "invoice_status": "invoiced",
+                }
+            ],
         )


### PR DESCRIPTION
The free delivery line stop the order from being fully invoiced.
To fix that they are set as invoiced on order confirmation.