### PR TITLE
[12.0] postlogistics - Fix return addresses on labels

### DIFF
--- a/delivery_carrier_label_postlogistics/models/stock.py
+++ b/delivery_carrier_label_postlogistics/models/stock.py
@@ -24,6 +24,24 @@ class StockPicking(models.Model):
         "Mobile", help="For notify delivery by telephone (ZAW3213)"
     )
 
+    def _compute_show_label_button(self):
+        """Determine if we should show the button to generate labels
+
+        Allows to print the label early, as for return pickings when
+        the label must be printed and sent to the customer.
+
+        """
+        visible_states = ['confirmed', 'assigned', 'done']
+        postlog_pickings = self.filetered(
+            lambda rec: rec.carrier_id.delivery_type == 'postlogistics'
+        )
+        for pick in postlog_pickings:
+            pick.show_label_button = (
+                pick.state in visible_states and pick.carrier_code
+            )
+        others = self - postlog_pickings
+        return super(StockPicking, others)._compute_show_label_button()
+
     @api.multi
     def postlogistics_cod_amount(self):
         """ Return the Postlogistic Cash on Delivery amount of a picking

--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -64,6 +64,17 @@ class PostlogisticsWebService(object):
             return lang_code
         return 'en'
 
+    def _get_recipient_partner(self, picking):
+        if picking.picking_type_id.code == 'outgoing':
+            return picking.partner_id
+        elif picking.picking_type_id.code == 'incoming':
+            location_dest = picking.location_dest_id
+            return (
+                location_dest.partner_id or
+                location_dest.company_id.partner_id or
+                picking.env.user.company_id
+            )
+
     def _prepare_recipient(self, picking):
         """ Create a ns0:Recipient as a dict from a partner
 
@@ -71,15 +82,7 @@ class PostlogisticsWebService(object):
         :return a dict containing data for ns0:Recipient
 
         """
-        if picking.picking_type_id.code == 'outgoing':
-            partner = picking.partner_id
-        elif picking.picking_type_id.code == 'incoming':
-            location_dest = picking.location_dest_id
-            partner = (
-                location_dest.partner_id or
-                location_dest.company_id.partner_id or
-                picking.env.user.company_id
-            )
+        partner = self._get_recipient_partner(picking)
 
         partner_name = partner.name or partner.parent_id.name
         recipient = {


### PR DESCRIPTION
When pre-printing addresses for customers to return a product
the addresses were inverted. Goal is to have the current company
as the recipient.

Includes #183 


(https://github.com/OCA/delivery-carrier/pull/301 is pre-merged in there as currently being merged by ocabot)