### PR TITLE
[UPD] delivery_carrier_info: fix website key in manifest

### DIFF
--- a/delivery_carrier_info/__manifest__.py
+++ b/delivery_carrier_info/__manifest__.py
@@ -8,7 +8,7 @@
     "summary": "Add code and description on carrier",
     "version": "12.0.1.0.0",
     "category": "Delivery",
-    "website": "www.akretion.com",
+    "website": "http://github.com/OCA/delivery-carrier",
     "author": "Akretion,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,


### PR DESCRIPTION
As mentioned by Pedro on https://github.com/OCA/delivery-carrier/pull/283,
the referenced PR broke pip installs, as the module odoo12-addon-delivery-carrier-info is not available on PyPI.
So the real purpose  of this is to force a bump to actually make the module available.