### PR TITLE
[IMP] delivery_state: automatic email sending

### DIFF
--- a/delivery_state/__manifest__.py
+++ b/delivery_state/__manifest__.py
@@ -19,6 +19,8 @@
     ],
     'data': [
         'data/ir_cron_data.xml',
+        'data/mail_template.xml',
         'views/stock_picking_views.xml',
+        'views/res_config_settings_views.xml',
     ],
 }

--- a/delivery_state/data/mail_template.xml
+++ b/delivery_state/data/mail_template.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="delivery_notification" model="mail.template">
+        <field name="name">Delivery State Notification</field>
+        <field name="model_id" ref="delivery.model_stock_picking" />
+        <field name="partner_to">${object.sale_id.partner_id.id or object.partner_id.id}</field>
+        <field
+            name="subject"
+        >${object.company_id.name} - Your order has been shipped by ${object.carrier_id.name}</field>
+        <field
+            name="body_html"
+        ><![CDATA[
+<div>
+    % set partner = object.sale_id.partner_id or object.partner_id
+    <p>
+        Hello, ${partner.name}.
+    </p>
+    <p>
+        We are glad to inform you that your order has been shipped by ${object.carrier_id.name}.
+        %if object.carrier_tracking_ref:
+            Your tracking reference is
+            <strong>
+            %if object.carrier_tracking_url:
+                % set multiple_carrier_tracking = object.get_multiple_carrier_tracking()
+                %if multiple_carrier_tracking:
+                    % for line in multiple_carrier_tracking:
+                        <br/><a href="${line[1]}" target="_blank">${line[0]}</a>
+                    % endfor
+                %else:
+                    <a href="${object.carrier_tracking_url}" target="_blank">${object.carrier_tracking_ref}</a>.
+                %endif
+            %else:
+                ${object.carrier_tracking_ref}.
+            %endif
+            </strong>
+        %endif
+        <br/><br/>
+        Thank you,<br/>
+        % if user and user.signature:
+          ${user.signature | safe}
+        % endif
+    </p>
+</div>
+]]>
+        </field>
+        <field name="lang">${object.sale_id.partner_id.lang or object.partner_id.lang}</field>
+        <field name="auto_delete" eval="True"/>
+        <field name="user_signature" eval="False"/>
+    </record>
+</odoo>

--- a/delivery_state/i18n/delivery_state.pot
+++ b/delivery_state/i18n/delivery_state.pot
@@ -14,6 +14,49 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: delivery_state
+#: model:mail.template,body_html:delivery_state.delivery_notification
+msgid "\n"
+"<div>\n"
+"    % set partner = object.sale_id.partner_id or object.partner_id\n"
+"    <p>\n"
+"        Hello, ${partner.name}.\n"
+"    </p>\n"
+"    <p>\n"
+"        We are glad to inform you that your order has been shipped by ${object.carrier_id.name}.\n"
+"        %if object.carrier_tracking_ref:\n"
+"            Your tracking reference is\n"
+"            <strong>\n"
+"            %if object.carrier_tracking_url:\n"
+"                % set multiple_carrier_tracking = object.get_multiple_carrier_tracking()\n"
+"                %if multiple_carrier_tracking:\n"
+"                    % for line in multiple_carrier_tracking:\n"
+"                        <br/><a href=\"${line[1]}\" target=\"_blank\">${line[0]}</a>\n"
+"                    % endfor\n"
+"                %else:\n"
+"                    <a href=\"${object.carrier_tracking_url}\" target=\"_blank\">${object.carrier_tracking_ref}</a>.\n"
+"                %endif\n"
+"            %else:\n"
+"                ${object.carrier_tracking_ref}.\n"
+"            %endif\n"
+"            </strong>\n"
+"        %endif\n"
+"        <br/><br/>\n"
+"        Thank you,<br/>\n"
+"        % if user and user.signature:\n"
+"          ${user.signature | safe}\n"
+"        % endif\n"
+"    </p>\n"
+"</div>\n"
+"\n"
+"        "
+msgstr ""
+
+#. module: delivery_state
+#: model:mail.template,subject:delivery_state.delivery_notification
+msgid "${object.company_id.name} - Your order has been shipped by ${object.carrier_id.name}"
+msgstr ""
+
+#. module: delivery_state
 #: selection:stock.picking,delivery_state:0
 msgid "Canceled shipment"
 msgstr ""
@@ -21,6 +64,16 @@ msgstr ""
 #. module: delivery_state
 #: model:ir.model.fields,field_description:delivery_state.field_stock_picking__delivery_state
 msgid "Carrier State"
+msgstr ""
+
+#. module: delivery_state
+#: model:ir.model,name:delivery_state.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: delivery_state
+#: model:ir.model,name:delivery_state.model_res_config_settings
+msgid "Config Settings"
 msgstr ""
 
 #. module: delivery_state
@@ -46,6 +99,16 @@ msgstr ""
 #. module: delivery_state
 #: selection:stock.picking,delivery_state:0
 msgid "Incidence"
+msgstr ""
+
+#. module: delivery_state
+#: model:ir.model.fields,field_description:delivery_state.field_res_config_settings__send_delivery_confirmation
+msgid "Send Delivery Confirmation"
+msgstr ""
+
+#. module: delivery_state
+#: model_terms:ir.ui.view,arch_db:delivery_state.res_config_settings_view_form
+msgid "Send automatic tracking info to customer"
 msgstr ""
 
 #. module: delivery_state
@@ -90,3 +153,13 @@ msgstr ""
 msgid "Warehouse delivered"
 msgstr ""
 
+#. module: delivery_state
+#: model:ir.model.fields,field_description:delivery_state.field_res_company__send_delivery_confirmation
+msgid "When the delivery is done send a confirmation email to the customer with the tracking number."
+msgstr ""
+
+#. module: delivery_state
+#: model_terms:ir.ui.view,arch_db:delivery_state.res_config_settings_view_form
+msgid "When the picking is confirmed, send an automatic delivery tracking\n"
+"                            information email."
+msgstr ""

--- a/delivery_state/i18n/es.po
+++ b/delivery_state/i18n/es.po
@@ -17,6 +17,84 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: delivery_state
+#: model:mail.template,body_html:delivery_state.delivery_notification
+msgid ""
+"\n"
+"<div>\n"
+"    % set partner = object.sale_id.partner_id or object.partner_id\n"
+"    <p>\n"
+"        Hello, ${partner.name}.\n"
+"    </p>\n"
+"    <p>\n"
+"        We are glad to inform you that your order has been shipped by ${object.carrier_id.name}.\n"
+"        %if object.carrier_tracking_ref:\n"
+"            Your tracking reference is\n"
+"            <strong>\n"
+"            %if object.carrier_tracking_url:\n"
+"                % set multiple_carrier_tracking = object.get_multiple_carrier_tracking()\n"
+"                %if multiple_carrier_tracking:\n"
+"                    % for line in multiple_carrier_tracking:\n"
+"                        <br/><a href=\"${line[1]}\" target=\"_blank\">${line[0]}</a>\n"
+"                    % endfor\n"
+"                %else:\n"
+"                    <a href=\"${object.carrier_tracking_url}\" target=\"_blank\">${object.carrier_tracking_ref}</a>.\n"
+"                %endif\n"
+"            %else:\n"
+"                ${object.carrier_tracking_ref}.\n"
+"            %endif\n"
+"            </strong>\n"
+"        %endif\n"
+"        <br/><br/>\n"
+"        Thank you,<br/>\n"
+"        % if user and user.signature:\n"
+"          ${user.signature | safe}\n"
+"        % endif\n"
+"    </p>\n"
+"</div>\n"
+"\n"
+"        "
+msgstr ""
+"\n"
+"<div>\n"
+"    % set partner = object.sale_id.partner_id or object.partner_id\n"
+"    <p>\n"
+"        Hola, ${partner.name}.\n"
+"    </p>\n"
+"    <p>\n"
+"        Nos complace informarle de que su pedido ha sido enviado por ${object.carrier_id.name}.\n"
+"        %if object.carrier_tracking_ref:\n"
+"            Su número de seguimiento es\n"
+"            <strong>\n"
+"            %if object.carrier_tracking_url:\n"
+"                % set multiple_carrier_tracking = object.get_multiple_carrier_tracking()\n"
+"                %if multiple_carrier_tracking:\n"
+"                    % for line in multiple_carrier_tracking:\n"
+"                        <br/><a href=\"${line[1]}\" target=\"_blank\">${line[0]}</a>\n"
+"                    % endfor\n"
+"                %else:\n"
+"                    <a href=\"${object.carrier_tracking_url}\" target=\"_blank\">${object.carrier_tracking_ref}</a>.\n"
+"                %endif\n"
+"            %else:\n"
+"                ${object.carrier_tracking_ref}.\n"
+"            %endif\n"
+"            </strong>\n"
+"        %endif\n"
+"        <br/><br/>\n"
+"        Gracias,<br/>\n"
+"        % if user and user.signature:\n"
+"          ${user.signature | safe}\n"
+"        % endif\n"
+"    </p>\n"
+"</div>\n"
+"\n"
+"        "
+
+#. module: delivery_state
+#: model:mail.template,subject:delivery_state.delivery_notification
+msgid "${object.company_id.name} - Your order has been shipped by ${object.carrier_id.name}"
+msgstr "${object.company_id.name} - Su pedido ha sido enviado por ${object.carrier_id.name}"
+
+#. module: delivery_state
 #: selection:stock.picking,delivery_state:0
 msgid "Canceled shipment"
 msgstr "Envío cancelado"
@@ -25,6 +103,16 @@ msgstr "Envío cancelado"
 #: model:ir.model.fields,field_description:delivery_state.field_stock_picking__delivery_state
 msgid "Carrier State"
 msgstr "Estado del transportista"
+
+#. module: delivery_state
+#: model:ir.model,name:delivery_state.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: delivery_state
+#: model:ir.model,name:delivery_state.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de Configuración"
 
 #. module: delivery_state
 #: selection:stock.picking,delivery_state:0
@@ -39,7 +127,7 @@ msgstr "Fecha de entrega"
 #. module: delivery_state
 #: model:ir.model,name:delivery_state.model_delivery_carrier
 msgid "Delivery Methods"
-msgstr "Métodos de entrega"
+msgstr "Método de envío"
 
 #. module: delivery_state
 #: selection:stock.picking,delivery_state:0
@@ -50,6 +138,16 @@ msgstr "En tránsito"
 #: selection:stock.picking,delivery_state:0
 msgid "Incidence"
 msgstr "Incidencia"
+
+#. module: delivery_state
+#: model:ir.model.fields,field_description:delivery_state.field_res_config_settings__send_delivery_confirmation
+msgid "Send Delivery Confirmation"
+msgstr "Enviar confirmación de envío"
+
+#. module: delivery_state
+#: model_terms:ir.ui.view,arch_db:delivery_state.res_config_settings_view_form
+msgid "Send automatic tracking info to customer"
+msgstr "Enviar automáticamente información del seguimiento al cliente"
 
 #. module: delivery_state
 #: model:ir.model.fields,field_description:delivery_state.field_stock_picking__date_shipped
@@ -74,15 +172,14 @@ msgstr "Historia del estado de seguimiento"
 #. module: delivery_state
 #: model:ir.model,name:delivery_state.model_stock_picking
 msgid "Transfer"
-msgstr "Transferir"
+msgstr "Albarán"
 
 #. module: delivery_state
 #: model:ir.actions.server,name:delivery_state.ir_cron_delivery_state_ir_actions_server
 #: model:ir.cron,cron_name:delivery_state.ir_cron_delivery_state
 #: model:ir.cron,name:delivery_state.ir_cron_delivery_state
-#, fuzzy
 msgid "Update deliveries states"
-msgstr "Actualizar seguimiento"
+msgstr "Actualizar estados de entrega"
 
 #. module: delivery_state
 #: model_terms:ir.ui.view,arch_db:delivery_state.view_picking_withcarrier_out_form
@@ -93,3 +190,15 @@ msgstr "Actualizar seguimiento"
 #: selection:stock.picking,delivery_state:0
 msgid "Warehouse delivered"
 msgstr "Entregado por almacén"
+
+#. module: delivery_state
+#: model:ir.model.fields,field_description:delivery_state.field_res_company__send_delivery_confirmation
+msgid "When the delivery is done send a confirmation email to the customer with the tracking number."
+msgstr "Cuando se confirme el albarán, enviar un correo de confirmación al cliente con el número de seguimiento."
+
+#. module: delivery_state
+#: model_terms:ir.ui.view,arch_db:delivery_state.res_config_settings_view_form
+msgid ""
+"When the picking is confirmed, send an automatic delivery tracking\n"
+"                            information email."
+msgstr "Cuando se valide el albarán, enviar un correo automático con la información de seguimiento del envío."

--- a/delivery_state/models/__init__.py
+++ b/delivery_state/models/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import delivery_carrier
 from . import stock_picking
+from . import res_config_settings
+from . import res_company

--- a/delivery_state/models/res_company.py
+++ b/delivery_state/models/res_company.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    send_delivery_confirmation = fields.Boolean(
+        string="When the delivery is done send a confirmation email "
+               "to the customer with the tracking number.",
+    )

--- a/delivery_state/models/res_config_settings.py
+++ b/delivery_state/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    send_delivery_confirmation = fields.Boolean(
+        string="Send Delivery Confirmation",
+        related="company_id.send_delivery_confirmation",
+        readonly=False,
+    )

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -73,3 +73,44 @@ class StockPicking(models.Model):
                 lambda x: x.delivery_type == delivery_type)
             for picking in delivery_type_pickings:
                 getattr(picking.carrier_id, method)(picking)
+
+    def _get_delivery_mail_context(self):
+        """Extensible context for customization"""
+        delivery_template_id = self.env.ref(
+            "delivery_state.delivery_notification").id
+        return dict(
+            default_composition_mode="comment",
+            default_email_from=self.company_id.email,
+            default_res_id=self.id,
+            default_model="stock.picking",
+            default_use_template=bool(delivery_template_id),
+            default_template_id=delivery_template_id,
+            custom_layout="mail.mail_notification_light"
+        )
+
+    def force_shipping_confirmation_email_send(self):
+        """We'll be using the core method but with a different template as
+        we want to ensure that the shipping notification is sent to the right
+        person. For example, a customer pays for a present that will be sent to
+        a friend. The confirmation email should go to him. Sending it to the
+        friend, would spoil the surprise"""
+        for picking in self:
+            email_act = picking.action_send_confirmation_email()
+            if email_act:
+                email_ctx = picking._get_delivery_mail_context()
+                picking.with_context(**email_ctx).message_post_with_template(
+                    email_ctx.get("default_template_id"))
+        return True
+
+    def send_to_shipper(self):
+        """Send delivery email to customer if configured"""
+        super().send_to_shipper()
+        partner = self.sale_id.partner_id or self.partner_id
+        send_delivery = all({
+            self.company_id.send_delivery_confirmation,
+            partner,
+            self.carrier_id,
+        })
+        if not send_delivery:
+            return
+        self.force_shipping_confirmation_email_send()

--- a/delivery_state/readme/CONFIGURE.rst
+++ b/delivery_state/readme/CONFIGURE.rst
@@ -3,3 +3,9 @@ configured going to *Settings > Technical > Scheduled Actions* and then choosing
 *Update deliveries states*. It will update the pending delivery states for the
 pickings with service providers with tracking methods configured, and in pending
 state (not delivered or cancelled).
+
+In order to send automatic notifications to the customer when the picking is
+confirmed:
+
+  #. Go to *Inventory > Configuration > Settings*.
+  #. Enable the option *Send Delivery Confirmation*.

--- a/delivery_state/readme/USAGE.rst
+++ b/delivery_state/readme/USAGE.rst
@@ -8,6 +8,7 @@ With regular methods (fixed, based on rules):
      based on rules.
   #. Validate the picking and you'll see in the same tab the delivery state
      info with the shipping date and the shipping state.
+  #. If enabled, an automatic notification will be sent to the picking customer.
 
 When service provider methods are implemented, we can follow the same steps as
 described before, but we'll get additionally:

--- a/delivery_state/tests/test_delivery_state.py
+++ b/delivery_state/tests/test_delivery_state.py
@@ -2,33 +2,39 @@
 # Copyright 2020 FactorLibre
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestDeliveryState(TransactionCase):
+class TestDeliveryState(SavepointCase):
 
-    def setUp(self):
-        super().setUp()
-        product_shipping_cost = self.env['product.product'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        product_shipping_cost = cls.env['product.product'].create({
             'type': 'service',
             'name': 'Shipping costs',
             'standard_price': 10,
             'list_price': 100,
         })
-        self.carrier = self.env['delivery.carrier'].create({
+        cls.carrier = cls.env['delivery.carrier'].create({
             'name': 'Test carrier',
             'delivery_type': 'fixed',
             'product_id': product_shipping_cost.id,
             'fixed_price': 99.99,
         })
-        self.product = self.env["product.product"].create({
+        cls.product = cls.env["product.product"].create({
             "name": "Test product",
             "type": "product",
         })
-        self.partner = self.env["res.partner"].create({
+        cls.partner = cls.env["res.partner"].create({
             "name": "Mr. Odoo",
+            "email": "test@test.com",
         })
-        self.pricelist = self.env['product.pricelist'].create({
+        cls.partner_shipping = cls.env["res.partner"].create({
+            "name": "Mr. Odoo (Delivery Address)",
+            "email": "test_shipping@test.com",
+        })
+        cls.pricelist = cls.env['product.pricelist'].create({
             'name': 'Test pricelist',
             'item_ids': [(0, 0, {
                 'applied_on': '3_global',
@@ -36,22 +42,23 @@ class TestDeliveryState(TransactionCase):
                 'base': 'list_price',
             })]
         })
-
-    def test_delivery_state(self):
-        sale = self.env['sale.order'].create({
-            'partner_id': self.partner.id,
-            'carrier_id': self.carrier.id,
-            'pricelist_id': self.pricelist.id,
+        cls.sale = cls.env['sale.order'].create({
+            'partner_id': cls.partner.id,
+            'partner_shipping_id': cls.partner_shipping.id,
+            'carrier_id': cls.carrier.id,
+            'pricelist_id': cls.pricelist.id,
             'order_line': [(0, 0, {
-                'product_id': self.product.id,
+                'product_id': cls.product.id,
                 'product_uom_qty': 1})]
         })
-        sale.get_delivery_price()
-        self.assertEquals(sale.delivery_price, 99.99)
-        sale.set_delivery_line()
-        self.assertEquals(len(sale.order_line), 2)
-        sale.action_confirm()
-        picking = sale.picking_ids[0]
+
+    def test_delivery_state(self):
+        self.sale.get_delivery_price()
+        self.assertEquals(self.sale.delivery_price, 99.99)
+        self.sale.set_delivery_line()
+        self.assertEquals(len(self.sale.order_line), 2)
+        self.sale.action_confirm()
+        picking = self.sale.picking_ids[0]
         self.assertEquals(len(picking.move_lines), 1)
         self.assertEquals(picking.carrier_id, self.carrier)
         picking.action_confirm()
@@ -71,3 +78,20 @@ class TestDeliveryState(TransactionCase):
         self.assertEquals(picking.delivery_state, 'canceled_shipment')
         self.assertFalse(picking.date_shipped)
         self.assertFalse(picking.date_delivered)
+
+    def test_delivery_confirmation_send(self):
+        """Check that the shipping notification is sent to the right partner"""
+        self.env.ref(
+            "delivery_state.delivery_notification").auto_delete = False
+        self.sale.action_confirm()
+        previous_mails = self.env["mail.mail"].search([
+            ("partner_ids", "in", self.partner.ids)])
+        self.assertFalse(previous_mails)
+        picking = self.sale.picking_ids
+        picking.company_id.send_delivery_confirmation = True
+        picking.carrier_tracking_ref = "XX-0000"
+        picking.move_lines.quantity_done = 1
+        picking.action_done()
+        mail = self.env["mail.mail"].search([
+            ("partner_ids", "in", self.partner.ids)])
+        self.assertTrue("XX-0000" in mail.body)

--- a/delivery_state/views/res_config_settings_views.xml
+++ b/delivery_state/views/res_config_settings_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='stock']/div[hasclass('o_settings_container')]" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box" title="Send automatic tracking info to customer">
+                    <div class="o_setting_left_pane">
+                        <field name="send_delivery_confirmation"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="send_delivery_confirmation"/>
+                        <div class="text-muted">
+                            When the picking is confirmed, send an automatic delivery tracking
+                            information email.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In order to send automatic notifications to the customer when the picking is
confirmed:

  1. Go to *Inventory > Configuration > Settings*.
  2. Enable the option *Send Delivery Confirmation*.

If enabled, an automatic notification will be sent to the picking customer.

cc @Tecnativa TT27723