### PR TITLE
[10.0] delivery_dropoff_site : add inherit on onchange_partner_shipping_id

### DIFF
--- a/base_delivery_carrier_label/wizard/manifest_wizard.py
+++ b/base_delivery_carrier_label/wizard/manifest_wizard.py
@@ -37,7 +37,6 @@ class ManifestWizard(models.TransientModel):
         ('end', 'END')
     ], readonly=True, default='init')
 
-    @api.one
     def get_manifest_file(self):
         raise exceptions.Warning(_("Manifest not implemented for '%s' "
                                    "carrier type.") % self.carrier_type)

--- a/delivery_carrier_category/security/delivery_carrier_category.xml
+++ b/delivery_carrier_category/security/delivery_carrier_category.xml
@@ -24,16 +24,6 @@
         <field name="perm_unlink" eval="1"/>
     </record>
 
-    <record model="ir.model.access" id="delivery_carrier_category_sale_manager">
-        <field name="name">delivery.carrier.category Sales Manager</field>
-        <field name="model_id" ref="model_delivery_carrier_category"/>
-        <field name="group_id" ref="sales_team.group_sale_manager"/>
-        <field name="perm_read" eval="1"/>
-        <field name="perm_create" eval="1"/>
-        <field name="perm_write" eval="1"/>
-        <field name="perm_unlink" eval="1"/>
-    </record>
-
     <record model="ir.model.access" id="delivery_carrier_category_partner_manager">
         <field name="name">delivery.carrier.category Partner Manager</field>
         <field name="model_id" ref="model_delivery_carrier_category"/>

--- a/delivery_carrier_category/views/delivery_carrier_category.xml
+++ b/delivery_carrier_category/views/delivery_carrier_category.xml
@@ -67,7 +67,7 @@
         <field name="action" ref="delivery_carrier_category_act_window"/>
         <field name="sequence" eval="16"/>
     </record>
-    <record model="ir.ui.menu" id="delivery_carrier_category_menu">
+    <record model="ir.ui.menu" id="delivery_carrier_category_sale_menu">
         <field name="name">Delivery Methods Categories</field>
         <field name="parent_id" ref="delivery.sale_menu_delivery"/>
         <field name="action" ref="delivery_carrier_category_act_window"/>

--- a/delivery_carrier_default_tracking_url/__manifest__.py
+++ b/delivery_carrier_default_tracking_url/__manifest__.py
@@ -9,7 +9,7 @@
     'version': '10.0.1.0.0',
     'license': 'AGPL-3',
     'maintainers': ['rousseldenis'],
-    'development_status': 'alpha',
+    'development_status': 'Alpha',
     'author': 'ACSONE SA/NV,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/delivery-carrier',
     'depends': [

--- a/delivery_carrier_deposit/models/deposit_slip.py
+++ b/delivery_carrier_deposit/models/deposit_slip.py
@@ -22,9 +22,9 @@ class DepositSlip(models.Model):
             }
         }
 
-    @api.one
     @api.depends('picking_ids')
     def _compute_deposit_slip(self):
+        self.ensure_one()
         weight = 0.0
         number_of_packages = 0
         for picking in self.picking_ids:

--- a/delivery_carrier_label_postlogistics/patches/suds_recursion_patch.py
+++ b/delivery_carrier_label_postlogistics/patches/suds_recursion_patch.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from logging import getLogger

--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -425,9 +425,9 @@ class PostlogisticsWebService(object):
             'ImageResolution': image_resolution,
             'PrintPreview': False,
         }
-        license = self._get_license(picking)
+        frankingLicense = self._get_license(picking)
         file_infos = {
-            'FrankingLicense': license,
+            'FrankingLicense': frankingLicense,
             'PpFranking': False,
             'CustomerSystem': 'Odoo',
             'Customer': post_customer,

--- a/delivery_dropoff_site/models/sale_order.py
+++ b/delivery_dropoff_site/models/sale_order.py
@@ -39,6 +39,7 @@ class SaleOrder(models.Model):
 
     @api.onchange('partner_shipping_id')
     def onchange_partner_shipping_id(self):
+        super(SaleOrder, self).onchange_partner_shipping_id()
         if self.partner_shipping_id and\
                 self.partner_shipping_id.dropoff_site_id and\
                 not self.final_shipping_partner_id:


### PR DESCRIPTION
Hello,

When we install delivery_dropoff_site, we replace the function :  onchange_partner_shipping_id ( https://github.com/OCA/OCB/blob/10.0/addons/sale/models/sale.py#L187 )

This function initializes the fiscal position of the quotation with that of the partner.
This PR call "super" to keep this functionality.