### PR TITLE
12.0 add base delivery carrier files grouped

### DIFF
--- a/base_delivery_carrier_files_grouped/__init__.py
+++ b/base_delivery_carrier_files_grouped/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2020 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import generator
+from . import models

--- a/base_delivery_carrier_files_grouped/__manifest__.py
+++ b/base_delivery_carrier_files_grouped/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2020 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Base Delivery Carrier Files Grouped",
+    "summary": "Groups Delivery Carrier lines of delivery carriers by partner",
+    "version": "12.0.1.0.0",
+    "category": "Generic Modules/Warehouse",
+    "website": "https://www.planetatic.com/",
+    "author": "PlanetaTIC",
+    "maintainers": ["PlanetaTIC"],
+    "license": "LGPL-3",
+    "depends": [
+        "base_delivery_carrier_files",
+    ],
+    "data": [
+        'views/partner_view.xml',
+    ],
+    "application": False,
+    "installable": True,
+}

--- a/base_delivery_carrier_files_grouped/generator/__init__.py
+++ b/base_delivery_carrier_files_grouped/generator/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2020 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import file_generator
+from .file_generator import GroupedCarrierFileGenerator
+from .file_generator import new_file_generator
+from odoo.addons.base_delivery_carrier_files.models import delivery_carrier_file as base_carrier_file
+base_carrier_file.new_file_generator = new_file_generator

--- a/base_delivery_carrier_files_grouped/generator/file_generator.py
+++ b/base_delivery_carrier_files_grouped/generator/file_generator.py
@@ -1,0 +1,99 @@
+# Copyright 2020 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.base_delivery_carrier_files.generator import (
+    CarrierFileGenerator
+)
+from odoo.addons.base_delivery_carrier_files.generator.generic_generator import GenericLine
+
+
+class GroupedCarrierFileGenerator(CarrierFileGenerator):
+
+    @classmethod
+    def carrier_for(cls, carrier_name):
+        for subcls in GroupedCarrierFileGenerator.__subclasses__():
+            if subcls.carrier_for(carrier_name):
+                return subcls
+        return False
+
+    def _get_filename_grouped(
+            self, configuration, extension='csv', partner_id=False):
+        """
+        Generate the filename for a file which group many pickings.
+        When pickings are grouped in one file, the filename cannot
+        be based on the picking data
+        Inherit and implement in subclasses.
+
+        :param browse_record configuration: configuration of
+                                            the file to generate
+        :param str extension: extension of the file to create, csv by default
+        :return: a string with the name of the file
+        """
+        if not partner_id:
+            res = super(GroupedCarrierFileGenerator, self)._get_filename_grouped(
+                configuration, extension=extension)
+        else:
+            res = "%s_%s_%s.%s" % (
+                'out', self._filename_date(), partner_id, extension)
+        return res
+
+    def _generate_files_grouped(self, pickings, configuration):
+        grouped_pickings = []
+        pickings_by_partner = {}
+        for picking in pickings:
+            if picking.partner_id.one_delivery_by_picking:
+                grouped_pickings.append(picking)
+            else:
+                if picking.partner_id.id not in pickings_by_partner:
+                    pickings_by_partner[picking.partner_id.id] = picking
+                else:
+                    pickings_by_partner[picking.partner_id.id] |= picking
+        files = super(GroupedCarrierFileGenerator, self)._generate_files_grouped(
+            grouped_pickings, configuration)
+        # files:: (filename, file_content, [p.id for p in pickings])
+        first_file = files.pop(0)
+        filename = first_file[0]
+        file_content = first_file[1]
+        result_picking_list = first_file[2]
+
+        grouped_rows, grouped_picking_ids = self._get_grouped_rows(
+            pickings_by_partner, configuration)
+        grouped_content = self._get_file(grouped_rows, configuration)
+        file_content += grouped_content
+        result_picking_list += grouped_picking_ids
+        files.append((filename, file_content, result_picking_list))
+        return files
+
+    def _get_grouped_rows(self, pickings_by_partner, configuration):
+        grouped_picking_ids = []
+
+        test_line = GenericLine()
+        fields = test_line.fields
+        name_index = fields.index('name')
+        weight_index = fields.index('weight')
+        grouped_rows = []
+        for key, cur_pickings in pickings_by_partner.items():
+            cur_row = False
+            for picking in cur_pickings:
+                rows = self._get_rows(picking, configuration)
+                row = rows[0]
+                if not cur_row:
+                    cur_row = row
+                else:
+                    cur_row[name_index] += ',' + row[name_index]
+                    cur_weight = float(cur_row[weight_index].replace(',', '.'))
+                    cur_row[weight_index] = cur_weight
+            grouped_rows.append(cur_row)
+            grouped_picking_ids += cur_pickings.ids
+        return (grouped_rows, grouped_picking_ids)
+
+
+def new_file_generator(carrier_name):
+    for cls in CarrierFileGenerator.__subclasses__():
+        carrier_for = cls.carrier_for(carrier_name)
+        if carrier_for:
+            if isinstance(carrier_for, type):
+                return carrier_for(carrier_name)
+            else:
+                return cls(carrier_name)
+    raise ValueError

--- a/base_delivery_carrier_files_grouped/i18n/es.po
+++ b/base_delivery_carrier_files_grouped/i18n/es.po
@@ -1,0 +1,28 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* base_delivery_carrier_files_grouped
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-30 12:36+0000\n"
+"PO-Revision-Date: 2020-11-30 12:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: base_delivery_carrier_files_grouped
+#: model:ir.model,name:base_delivery_carrier_files_grouped.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: base_delivery_carrier_files_grouped
+#: model:ir.model.fields,field_description:base_delivery_carrier_files_grouped.field_res_partner__one_delivery_by_picking
+#: model:ir.model.fields,field_description:base_delivery_carrier_files_grouped.field_res_users__one_delivery_by_picking
+msgid "One Delivery by Picking"
+msgstr "Envío por Pedido"
+

--- a/base_delivery_carrier_files_grouped/models/__init__.py
+++ b/base_delivery_carrier_files_grouped/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import res_partner

--- a/base_delivery_carrier_files_grouped/models/res_partner.py
+++ b/base_delivery_carrier_files_grouped/models/res_partner.py
@@ -1,0 +1,11 @@
+# Copyright 2020 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api, _
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    one_delivery_by_picking = fields.Boolean('One Delivery by Picking',
+                                             default=True)

--- a/base_delivery_carrier_files_grouped/readme/CONSTRIBUTRORS.rst
+++ b/base_delivery_carrier_files_grouped/readme/CONSTRIBUTRORS.rst
@@ -1,0 +1,1 @@
+* Marc Poch <mpoch@planetatic.com>

--- a/base_delivery_carrier_files_grouped/readme/DESCRIPTION.rst
+++ b/base_delivery_carrier_files_grouped/readme/DESCRIPTION.rst
@@ -1,3 +1,3 @@
 This module permits to mark partners with one_delivery_by_picking boolean field
-When generating a delivery carrier file for these marked partners,
-it will generate a unique carrier file representing all selected pickings.
+When generating a delivery carrier file, lines afecting these marked partners 
+will be grouped in a single line per partner.

--- a/base_delivery_carrier_files_grouped/readme/DESCRIPTION.rst
+++ b/base_delivery_carrier_files_grouped/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module permits to mark partners with one_delivery_by_picking boolean field
+When generating a delivery carrier file for these marked partners,
+it will generate a unique carrier file representing all selected pickings.

--- a/base_delivery_carrier_files_grouped/views/partner_view.xml
+++ b/base_delivery_carrier_files_grouped/views/partner_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data>
+
+<record id="view_partner_property_form" model="ir.ui.view">
+    <field name="name">res.partner.carrier.property.form.inherit</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="mail.res_partner_view_form_inherit_mail" />
+    <field name="arch" type="xml">
+        <field name="property_delivery_carrier_id" position="after">
+            <field name="one_delivery_by_picking"/>
+        </field>
+    </field>
+</record>
+
+</data>
+</odoo>


### PR DESCRIPTION
This module permits to mark partners with one_delivery_by_picking boolean field.
When generating a delivery carrier file, lines afecting these marked partners 
will be grouped in a single line per partner.