### PR TITLE
[12.0][RFR] base_delivery_carrier_label: show options as tags

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier_option.py
+++ b/base_delivery_carrier_label/models/delivery_carrier_option.py
@@ -2,7 +2,7 @@
 # Copyright 2013-2016 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class DeliveryCarrierOption(models.Model):
@@ -18,8 +18,9 @@ class DeliveryCarrierOption(models.Model):
 
     active = fields.Boolean(default=True)
     mandatory = fields.Boolean(
-        help="If checked, this option is necessarily applied "
-             "to the delivery order"
+        help=("If checked, this option is necessarily applied "
+              "to the delivery order. Mandatory options show up in orange "
+              "in the option widget on the picking."),
     )
     by_default = fields.Boolean(
         string='Applied by Default',
@@ -39,3 +40,13 @@ class DeliveryCarrierOption(models.Model):
         help="When True, help to prevent the user to modify some fields "
              "option (if attribute is defined in the view)"
     )
+    color = fields.Integer(
+        compute="_compute_color",
+        help="Orange if the option is mandatory, otherwise no color",
+    )
+
+    @api.depends("mandatory")
+    def _compute_color(self):
+        """Show that a tag is mandatory using the color attribute"""
+        for tag in self:
+            tag.color = 2 if tag.mandatory else False

--- a/base_delivery_carrier_label/tests/test_helper_functions.py
+++ b/base_delivery_carrier_label/tests/test_helper_functions.py
@@ -53,3 +53,13 @@ class TestHelperFunctions(TransactionCase):
         ))
         self.assertEqual(label.name, 'Hello')
         self.assertFalse(picking.show_label_button)
+
+    def test_delivery_carrier_option(self):
+        """Mandatory option on delivery options sets color"""
+        option = self.env["delivery.carrier.option"].create({
+            "name": __name__,
+            "code": __name__,
+        })
+        self.assertFalse(option.color)
+        option.mandatory = True
+        self.assertEqual(option.color, 2)

--- a/base_delivery_carrier_label/views/stock.xml
+++ b/base_delivery_carrier_label/views/stock.xml
@@ -16,10 +16,10 @@
       </field>
       <xpath expr="//page//field[@name='carrier_id']" position="after">
         <field name="carrier_code"/>
-      </xpath>
-      <xpath expr="//page//group[@name='carrier_data']/.." position="after">
         <field name="option_ids"
-          domain="[('carrier_id', '=', carrier_id)]"/>
+          domain="[('carrier_id', '=', carrier_id)]"
+          widget="many2many_tags"
+          options="{'color_field': 'color', 'no_create_edit': True}" />
       </xpath>
     </field>
   </record>


### PR DESCRIPTION
Show carrier options as tags.

Before:
![image](https://user-images.githubusercontent.com/1033124/112543135-a8788600-8db5-11eb-9985-9bc1a20677ab.png)

After:
![image](https://user-images.githubusercontent.com/1033124/121772067-76d0b900-cb73-11eb-8a45-d5d9bbf096f6.png)
