### PR TITLE
[13.0][IMP] delivery_postlogistics: add pack_weight parameter on _prepare_attributes

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -172,7 +172,9 @@ class PostlogisticsWebService(object):
         franking_license = picking.carrier_id.postlogistics_license_id
         return franking_license.number
 
-    def _prepare_attributes(self, picking, pack=None, pack_num=None, pack_total=None):
+    def _prepare_attributes(
+        self, picking, pack=None, pack_num=None, pack_total=None, pack_weight=None
+    ):
         packaging = (
             pack
             and pack.packaging_id
@@ -180,7 +182,10 @@ class PostlogisticsWebService(object):
         )
         services = packaging._get_packaging_codes()
 
-        total_weight = pack.shipping_weight if pack else picking.shipping_weight
+        if pack_weight:
+            total_weight = pack_weight
+        else:
+            total_weight = pack.shipping_weight if pack else picking.shipping_weight
         total_weight *= 1000
 
         if not services:


### PR DESCRIPTION
Copied from https://github.com/trobz/delivery-carrier/pull/4

> 
> We want to be able to send the weight of each parcel pf the package as a parameter. Otherwise calculation it will be always based on:
> `total_weight = pack.shipping_weight if pack else picking.shipping_weight`