### PR TITLE
[13.0][FIX] Do not send disallowed chars on postlogistics api

### DIFF
--- a/delivery_postlogistics/tests/common.py
+++ b/delivery_postlogistics/tests/common.py
@@ -1,0 +1,126 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import SavepointCase
+
+from ..postlogistics.web_service import PostlogisticsWebService
+
+ENDPOINT_URL = "https://wedecint.post.ch/"
+CLIENT_ID = "XXX"
+CLIENT_SECRET = "XXX"
+LICENSE = "XXX"
+
+
+class TestPostlogisticsCommon(SavepointCase):
+    @classmethod
+    def setUpClassLicense(cls):
+        cls.license = cls.env["postlogistics.license"].create(
+            {"name": "TEST", "number": LICENSE}
+        )
+
+    @classmethod
+    def setUpClassCarrier(cls):
+        shipping_product = cls.env["product.product"].create({"name": "Shipping"})
+        option_model = cls.env["postlogistics.delivery.carrier.template.option"]
+        partner_id = cls.env.ref("delivery_postlogistics.partner_postlogistics").id
+        label_layout = option_model.create({"code": "A6", "partner_id": partner_id})
+        output_format = option_model.create({"code": "PDF", "partner_id": partner_id})
+        image_resolution = option_model.create(
+            {"code": "600", "partner_id": partner_id}
+        )
+        cls.carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Postlogistics",
+                "delivery_type": "postlogistics",
+                "product_id": shipping_product.id,
+                "postlogistics_endpoint_url": ENDPOINT_URL,
+                "postlogistics_client_id": CLIENT_ID,
+                "postlogistics_client_secret": CLIENT_SECRET,
+                "postlogistics_license_id": cls.license.id,
+                "postlogistics_label_layout": label_layout.id,
+                "postlogistics_output_format": output_format.id,
+                "postlogistics_resolution": image_resolution.id,
+            }
+        )
+
+    @classmethod
+    def setUpClassPackaging(cls):
+        cls.postlogistics_pd_packaging = cls.env["product.packaging"].create(
+            {
+                "name": "PRI-TEST",
+                "package_carrier_type": "postlogistics",
+                "shipper_package_code": "PRI, BLN",
+            }
+        )
+
+    @classmethod
+    def setUpClassUserCompany(cls):
+        cls.env.user.company_id.write(
+            {"street": "Rue de Lausanne 1", "zip": "1030", "city": "Bussigny"}
+        )
+        cls.env.user.company_id.partner_id.country_id = cls.env.ref("base.ch")
+        cls.env.user.lang = "en_US"
+
+    @classmethod
+    def setUpClassLocation(cls):
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+
+    @classmethod
+    def create_picking(cls, partner=None, product_matrix=None):
+        packaging = cls.postlogistics_pd_packaging
+        if not partner:
+            partner = cls.env["res.partner"].create(
+                {
+                    "name": "Camptocamp SA",
+                    "street": "EPFL Innovation Park, Bât A",
+                    "zip": "1015",
+                    "city": "Lausanne",
+                }
+            )
+        picking = cls.env["stock.picking"].create(
+            {
+                "partner_id": partner.id,
+                "carrier_id": cls.carrier.id,
+                "picking_type_id": cls.env.ref("stock.picking_type_out").id,
+                "location_id": cls.stock_location.id,
+                "location_dest_id": cls.customer_location.id,
+            }
+        )
+        if not product_matrix:
+            product_matrix = [
+                (cls.env["product.product"].create({"name": "Product A"}), 3),
+            ]
+        for product, qty in product_matrix:
+            cls.env["stock.move"].create(
+                {
+                    "name": product.name,
+                    "product_id": product.id,
+                    "product_uom_qty": qty,
+                    "product_uom": product.uom_id.id,
+                    "picking_id": picking.id,
+                    "location_id": cls.stock_location.id,
+                    "location_dest_id": cls.customer_location.id,
+                }
+            )
+        choose_delivery_package_wizard = cls.env["choose.delivery.package"].create(
+            {"picking_id": picking.id, "delivery_packaging_id": packaging.id}
+        )
+        picking.action_assign()
+        choose_delivery_package_wizard.put_in_pack()
+        return picking
+
+    @classmethod
+    def setUpClassWebservice(cls):
+        cls.service_class = PostlogisticsWebService(cls.env.user.company_id)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.setUpClassLicense()
+        cls.setUpClassCarrier()
+        cls.setUpClassPackaging()
+        cls.setUpClassUserCompany()
+        cls.setUpClassLocation()
+        cls.setUpClassWebservice()

--- a/delivery_postlogistics/tests/test_postlogistics.py
+++ b/delivery_postlogistics/tests/test_postlogistics.py
@@ -2,9 +2,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from os.path import dirname, join
 
-from odoo.tests import common
-
 from vcr import VCR
+
+from .common import TestPostlogisticsCommon
 
 recorder = VCR(
     record_mode="once",
@@ -17,54 +17,12 @@ recorder = VCR(
     decode_compressed_response=True,
 )
 
-ENDPOINT_URL = "https://wedecint.post.ch/"
-CLIENT_ID = "XXX"
-CLIENT_SECRET = "XXX"
-LICENSE = "XXX"
 
-
-class TestPostlogistics(common.SavepointCase):
+class TestPostlogistics(TestPostlogisticsCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.env["postlogistics.license"].create({"name": "TEST", "number": LICENSE})
-        Product = cls.env["product.product"]
-        partner_id = cls.env.ref("delivery_postlogistics.partner_postlogistics").id
-        OptionTmpl = cls.env["postlogistics.delivery.carrier.template.option"]
-        label_layout = OptionTmpl.create({"code": "A6", "partner_id": partner_id})
-        output_format = OptionTmpl.create({"code": "PDF", "partner_id": partner_id})
-        image_resolution = OptionTmpl.create({"code": "600", "partner_id": partner_id})
-
-        cls.carrier = cls.env["delivery.carrier"].create(
-            {
-                "name": "Postlogistics",
-                "delivery_type": "postlogistics",
-                "product_id": Product.create({"name": "Shipping"}).id,
-                "postlogistics_endpoint_url": ENDPOINT_URL,
-                "postlogistics_client_id": CLIENT_ID,
-                "postlogistics_client_secret": CLIENT_SECRET,
-                "postlogistics_label_layout": label_layout.id,
-                "postlogistics_output_format": output_format.id,
-                "postlogistics_resolution": image_resolution.id,
-            }
-        )
-
-        # Create Product packaging
-        postlogistics_pd_packaging = cls.env["product.packaging"].create(
-            {
-                "name": "PRI-TEST",
-                "package_carrier_type": "postlogistics",
-                "shipper_package_code": "PRI, BLN",
-            }
-        )
-
-        cls.env.user.company_id.write(
-            {"street": "Rue de Lausanne 1", "zip": "1030", "city": "Bussigny"}
-        )
-        cls.env.user.company_id.partner_id.country_id = cls.env.ref("base.ch")
-        cls.picking = cls.create_picking(cls, postlogistics_pd_packaging)
-        cls.env.user.lang = "en_US"
+        cls.picking = cls.create_picking()
 
     def test_store_label(self):
         with recorder.use_cassette("test_store_label") as cassette:
@@ -81,47 +39,3 @@ class TestPostlogistics(common.SavepointCase):
         with recorder.use_cassette("test_missing_language") as cassette:
             self.picking._generate_postlogistics_label(skip_attach_file=True)
             self.assertEqual(len(cassette.requests), 2)
-
-    def create_picking(self, prod_packaging):
-        Product = self.env["product.product"]
-        stock_location = self.env.ref("stock.stock_location_stock")
-        customer_location = self.env.ref("stock.stock_location_customers")
-        Picking = self.env["stock.picking"]
-        recipient = self.env["res.partner"].create(
-            {
-                "name": "Camptocamp SA",
-                "street": "EPFL Innovation Park, Bât A",
-                "zip": "1015",
-                "city": "Lausanne",
-            }
-        )
-        picking = Picking.create(
-            {
-                "partner_id": recipient.id,
-                "carrier_id": self.carrier.id,
-                "picking_type_id": self.env.ref("stock.picking_type_out").id,
-                "location_id": stock_location.id,
-                "location_dest_id": customer_location.id,
-            }
-        )
-        product = Product.create({"name": "Product A"})
-
-        self.env["stock.move"].create(
-            {
-                "name": "a move",
-                "product_id": product.id,
-                "product_uom_qty": 3.0,
-                "product_uom": product.uom_id.id,
-                "picking_id": picking.id,
-                "location_id": stock_location.id,
-                "location_dest_id": customer_location.id,
-            }
-        )
-
-        # Add to the packages
-        choose_delivery_package_wizard = self.env["choose.delivery.package"].create(
-            {"picking_id": picking.id, "delivery_packaging_id": prod_packaging.id}
-        )
-        picking.action_assign()
-        choose_delivery_package_wizard.put_in_pack()
-        return picking

--- a/delivery_postlogistics/tests/test_sanitize_values.py
+++ b/delivery_postlogistics/tests/test_sanitize_values.py
@@ -1,0 +1,58 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+from ..postlogistics.web_service import DISALLOWED_CHARS
+from .common import TestPostlogisticsCommon
+
+
+class TestSanitizeValues(TestPostlogisticsCommon):
+    """Just create records full of disallowed chars, an test that everyone of them
+    is correctly removed, as none of those chars should be sent on postlogistics api.
+    """
+
+    @classmethod
+    def setUpPartner(cls):
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "P<o\\t|at>o",
+                "mobile": "+33123456789>",
+                "phone": ">+33123456789<",
+                "email": "w<>|\\hatever@whatever.too",
+                "street": "42\\|<>whateverstraße",
+                "street2": "42\\|<>whateverstraße",
+                "zip": "43123\\",
+                "city": "Mouais\\<>|",
+            }
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpPartner()
+        cls.picking = cls.create_picking(cls.partner)
+
+    def check_strings_in_dict(self, values):
+        # Do not check other types than strings.
+        # Dict values are individually tested, no recursion here.
+        values_to_check = [value for value in values.values() if isinstance(value, str)]
+        self.check_strings_in_list(values_to_check)
+
+    def check_strings_in_list(self, values):
+        for value in values:
+            self.assertFalse(any(char in value for char in DISALLOWED_CHARS))
+
+    def test_sanitize(self):
+        customer = self.service_class._prepare_customer(self.picking)
+        self.check_strings_in_dict(customer)
+        recipient = self.service_class._prepare_recipient(self.picking)
+        self.check_strings_in_dict(recipient)
+        packages = self.picking._get_packages_from_picking()
+        item_list = self.service_class._prepare_item_list(
+            self.picking, recipient, packages
+        )
+        self.check_strings_in_list(item_list)
+        attributes = self.service_class._prepare_attributes(
+            self.picking, packages, 1, 1
+        )
+        self.check_strings_in_dict(attributes)


### PR DESCRIPTION
Some chars are disallowed from postlogistics API ("|", "\", "<", ">") and output json should be sanitized

Based on https://github.com/OCA/delivery-carrier/pull/367.
Those will need to be rebased when one will be merged.