### PR TITLE
[13.0][FIX] delivery_package_fee: flag order lines

### DIFF
--- a/delivery_package_fee/models/delivery_carrier.py
+++ b/delivery_package_fee/models/delivery_carrier.py
@@ -7,5 +7,7 @@ class DeliveryCarrier(models.Model):
     _inherit = "delivery.carrier"
 
     package_fee_ids = fields.One2many(
-        comodel_name="delivery.package.fee", inverse_name="carrier_id",
+        comodel_name="delivery.package.fee",
+        inverse_name="carrier_id",
+        context={"active_test": False},
     )

--- a/delivery_package_fee/models/delivery_package_fee.py
+++ b/delivery_package_fee/models/delivery_package_fee.py
@@ -13,3 +13,4 @@ class DeliveryPackageFee(models.Model):
     product_id = fields.Many2one(
         comodel_name="product.product", required=True, ondelete="restrict",
     )
+    active = fields.Boolean(string="Active", default=True)

--- a/delivery_package_fee/models/sale_order_line.py
+++ b/delivery_package_fee/models/sale_order_line.py
@@ -6,4 +6,9 @@ from odoo import fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    package_fee_id = fields.Many2one(comodel_name="delivery.package.fee", default=False)
+    package_fee_id = fields.Many2one(
+        comodel_name="delivery.package.fee", default=False, ondelete="restrict"
+    )
+
+    def _is_delivery(self):
+        return super()._is_delivery() or bool(self.package_fee_id)

--- a/delivery_package_fee/views/delivery_carrier_views.xml
+++ b/delivery_package_fee/views/delivery_carrier_views.xml
@@ -21,6 +21,7 @@
                                     name="product_id"
                                     context="{'default_type': 'service', 'default_sale_ok': False, 'default_purchase_ok': False}"
                                 />
+                                <field name="active" />
                             </tree>
                         </field>
                     </group>


### PR DESCRIPTION
Flag package fee order lines with a new boolean `is_delivery_package_fee`.
Standard method `_is_delivery` will also consider this field to exclude
the lines from the computation of the `expected_date` in `sale` module.

Ref. 2438