### PR TITLE
[13.0][IMP]delivery_auto_refresh: prevent warning decoration after refresh

### DIFF
--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -38,6 +38,9 @@ class SaleOrder(models.Model):
             if self.state in {"draft", "sent"}:
                 price_unit = self.carrier_id.rate_shipment(self)["price"]
                 self._create_delivery_line(self.carrier_id, price_unit)
+                self.with_context(auto_refresh_delivery=True).write(
+                    {"recompute_delivery_price": False}
+                )
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
After refreshing the delivery line automatically, if the standard flag _recompute_delivery_price_ is not set to False the delivery line is marked with a decoration warning, as it is implying that the line price should be updated.