### PR TITLE
[14][base_delivery_carrier_label]Allow to have multiple carrier accounts for a same delivery type

### DIFF
--- a/base_delivery_carrier_label/models/carrier_account.py
+++ b/base_delivery_carrier_label/models/carrier_account.py
@@ -23,6 +23,18 @@ class CarrierAccount(models.Model):
         .selection,
         help="This field may be used to link an account to a carrier",
     )
+    carrier_ids = fields.Many2many(
+        "delivery.carrier",
+        "delivery_carrier_account_rel",
+        "account_id",
+        "carrier_id",
+        string="Carriers",
+        help=(
+            "This field may be used to link an account to specific delivery methods"
+            " It may be usefull to find an account with more precision than with "
+            "only the delivery type"
+        ),
+    )
     account = fields.Char(string="Account Number", required=True)
     password = fields.Char(string="Account Password", required=True)
     company_id = fields.Many2one(comodel_name="res.company", string="Company")

--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -147,15 +147,22 @@ class StockPicking(models.Model):
         vals = self._values_with_carrier_options(vals)
         return super().create(vals)
 
+    def _get_carrier_account_domain(self):
+        return [
+            ("delivery_type", "in", self.mapped("delivery_type")),
+            "|",
+            ("company_id", "=", False),
+            ("company_id", "in", self.mapped("company_id.id")),
+            "|",
+            ("carrier_ids", "=", False),
+            ("carrier_ids", "in", self.mapped("carrier_id").ids),
+        ]
+
     def _get_carrier_account(self):
         """ Return a carrier suitable for the current picking """
+        domain = self._get_carrier_account_domain()
         return self.env["carrier.account"].search(
-            [
-                ("delivery_type", "in", self.mapped("delivery_type")),
-                "|",
-                ("company_id", "=", False),
-                ("company_id", "in", self.mapped("company_id.id")),
-            ],
+            domain,
             limit=1,
             order="company_id asc, sequence asc",
         )

--- a/base_delivery_carrier_label/views/carrier_account.xml
+++ b/base_delivery_carrier_label/views/carrier_account.xml
@@ -25,6 +25,12 @@
                     <group>
                         <!-- To be able to link a carrier account with a delivery method -->
                         <field name="delivery_type" />
+                        <field
+                            name="carrier_ids"
+                            widget="many2many_tags"
+                            attrs="{'invisible': [('delivery_type', '=', False)]}"
+                            domain="[('delivery_type', '=', delivery_type)]"
+                        />
                         <field name="account" />
                         <field name="password" password="True" />
                         <field name="file_format" />


### PR DESCRIPTION
Sometimes we may have multiple delivery methods for a same carrier/api and some carriers may require to have different accounts depending on the delivery method used.
The goal of this small PR is to allow this case and make the carrier account choice a bit more flexible.
Still it has no impact if this feature is not needed as the new field on account is optional.

@bealdav @yvaucher @hparfr 
