### PR TITLE
[13.0] delivery_postlogistics: Handle case where no label is returned by the API

### DIFF
--- a/delivery_postlogistics/models/stock_picking.py
+++ b/delivery_postlogistics/models/stock_picking.py
@@ -155,6 +155,11 @@ class StockPicking(models.Model):
         zpl_patch_string = self.carrier_id.zpl_patch_string
 
         labels = []
+
+        # It could happen that no successful label has been returned by the API
+        if not label_result:
+            return labels
+
         if not packages:
             label = label_result[0]["value"][0]
             self.carrier_tracking_ref = label["tracking_number"]


### PR DESCRIPTION
Sometimes, no sucess label is returned by the API.
In such case, we should just ignore it, and raise the errors.