### PR TITLE
[14.0][ADD] delivery_carrier_city

### DIFF
--- a/delivery_carrier_city/__init__.py
+++ b/delivery_carrier_city/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_carrier_city/__manifest__.py
+++ b/delivery_carrier_city/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Delivery Carrier City",
+    "summary": "Integrates delivery with base_address_city",
+    "version": "14.0.1.0.0",
+    "category": "Delivery",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "license": "AGPL-3",
+    "depends": [
+        "delivery",
+        "base_address_city",
+    ],
+    "data": [
+        "views/delivery_carrier.xml",
+    ],
+}

--- a/delivery_carrier_city/models/__init__.py
+++ b/delivery_carrier_city/models/__init__.py
@@ -1,0 +1,1 @@
+from . import delivery_carrier

--- a/delivery_carrier_city/models/delivery_carrier.py
+++ b/delivery_carrier_city/models/delivery_carrier.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    city_ids = fields.Many2many(
+        "res.city",
+        relation="delivery_carrier_city_rel",
+        column1="carrier_id",
+        column2="city_id",
+        string="Cities",
+    )
+
+    def _match_address(self, partner):
+        # Override to account for city_ids
+        if self.city_ids and partner.city_id not in self.city_ids:
+            return False
+        return super()._match_address(partner)

--- a/delivery_carrier_city/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_city/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/delivery_carrier_city/readme/DESCRIPTION.rst
+++ b/delivery_carrier_city/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Integrates delivery carrier with base_address_city, to allow to
+use cities in the delivery methods' destination conditions.

--- a/delivery_carrier_city/tests/__init__.py
+++ b/delivery_carrier_city/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_delivery_carrier_city

--- a/delivery_carrier_city/tests/test_delivery_carrier_city.py
+++ b/delivery_carrier_city/tests/test_delivery_carrier_city.py
@@ -1,0 +1,103 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestDeliveryCarrierCity(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        # Countries
+        cls.france = cls.env.ref("base.fr")
+        # States
+        cls.ile_de_france = cls.env["res.country.state"].create(
+            {
+                "name": "Île-de-France",
+                "code": "FR-IDF",
+                "country_id": cls.france.id,
+            }
+        )
+        cls.cote_azur = cls.env["res.country.state"].create(
+            {
+                "name": "Provence-Alpes-Côte-d'Azur",
+                "code": "FR-PAC",
+                "country_id": cls.france.id,
+            }
+        )
+        # Cities
+        cls.paris = cls.env["res.city"].create(
+            {
+                "name": "Paris",
+                "state_id": cls.ile_de_france.id,
+                "country_id": cls.france.id,
+                "zipcode": "75000",
+            }
+        )
+        cls.nice = cls.env["res.city"].create(
+            {
+                "name": "Nice",
+                "state_id": cls.cote_azur.id,
+                "country_id": cls.france.id,
+                "zipcode": "06000",
+            }
+        )
+        # Disable all other delivery methods
+        cls.env["delivery.carrier"].search([]).write({"active": False})
+        # Create delivery methods
+        cls.product = cls.env["product.product"].create({"name": "Delivery"})
+        cls.carrier_paris = cls.env["delivery.carrier"].create(
+            {
+                "name": "Delivery in Paris",
+                "product_id": cls.product.id,
+                "delivery_type": "fixed",
+                "fixed_price": 15,
+                "sequence": 10,
+                "country_ids": [(4, cls.france.id)],
+                "city_ids": [(4, cls.paris.id)],
+            }
+        )
+        cls.carrier_france = cls.env["delivery.carrier"].create(
+            {
+                "name": "Delivery in France",
+                "product_id": cls.product.id,
+                "delivery_type": "fixed",
+                "fixed_price": 25,
+                "sequence": 20,
+                "country_ids": [(4, cls.france.id)],
+            }
+        )
+
+    def _get_available_carriers(self, partner):
+        return self.env["delivery.carrier"].search([]).available_carriers(partner)
+
+    def test_00_delivery_carrier_city_match(self):
+        # Partner living in paris
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Edgar Degas",
+                "city_id": self.paris.id,
+                "state_id": self.paris.state_id.id,
+                "country_id": self.paris.country_id.id,
+            }
+        )
+        # Check available carriers
+        carriers = self._get_available_carriers(partner)
+        self.assertIn(self.carrier_france, carriers)
+        self.assertIn(self.carrier_paris, carriers)
+
+    def test_01_delivery_carrier_city_not_match(self):
+        # Partner not living in paris
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Henri Matisse",
+                "city_id": self.nice.id,
+                "state_id": self.nice.state_id.id,
+                "country_id": self.nice.country_id.id,
+            }
+        )
+        # Check available carriers
+        carriers = self._get_available_carriers(partner)
+        self.assertIn(self.carrier_france, carriers)
+        self.assertNotIn(self.carrier_paris, carriers)

--- a/delivery_carrier_city/views/delivery_carrier.xml
+++ b/delivery_carrier_city/views/delivery_carrier.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp SA - Iván Todorovich
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_delivery_carrier_form" model="ir.ui.view">
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form" />
+        <field name="arch" type="xml">
+            <field name="state_ids" position="after">
+                <field name="city_ids" widget="many2many_tags" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/delivery_carrier_city/odoo/addons/delivery_carrier_city
+++ b/setup/delivery_carrier_city/odoo/addons/delivery_carrier_city
@@ -1,0 +1,1 @@
+../../../../delivery_carrier_city

--- a/setup/delivery_carrier_city/setup.py
+++ b/setup/delivery_carrier_city/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Integrates `delivery` with `base_address_city`, to allow to use cities in the delivery methods' destination conditions.