### PR TITLE
[14.0][ADD] delivery_carrier_location

### DIFF
--- a/delivery_carrier_location/__init__.py
+++ b/delivery_carrier_location/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_carrier_location/__manifest__.py
+++ b/delivery_carrier_location/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Delivery Carrier Location",
+    "summary": "Integrates delivery with base_location",
+    "version": "14.0.1.0.0",
+    "category": "Delivery",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "license": "AGPL-3",
+    "depends": [
+        "delivery_carrier_city",
+        "base_location",
+    ],
+    "data": [
+        "views/delivery_carrier.xml",
+    ],
+}

--- a/delivery_carrier_location/models/__init__.py
+++ b/delivery_carrier_location/models/__init__.py
@@ -1,0 +1,1 @@
+from . import delivery_carrier

--- a/delivery_carrier_location/models/delivery_carrier.py
+++ b/delivery_carrier_location/models/delivery_carrier.py
@@ -1,0 +1,26 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    zip_ids = fields.Many2many(
+        "res.city.zip",
+        relation="delivery_carrier_zip_rel",
+        column1="carrier_id",
+        column2="zip_id",
+        string="Zip codes",
+    )
+
+    def _match_address(self, partner):
+        # Override to account for city_ids and zip_ids
+        res = super()._match_address(partner)
+        # Fail quickly if super already rejected it
+        if not res or not self.zip_ids:
+            return res  # pragma: no cover
+        # Check partner's zip.
+        partner_zip = (partner.zip or partner.zip_id.name or "").upper()
+        return partner_zip in {r.name.upper() for r in self.zip_ids}

--- a/delivery_carrier_location/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_location/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/delivery_carrier_location/readme/DESCRIPTION.rst
+++ b/delivery_carrier_location/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Integrates delivery carrier with base_location, to allow to
+use zip codes in the delivery methods' destinations.

--- a/delivery_carrier_location/tests/__init__.py
+++ b/delivery_carrier_location/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_delivery_carrier_location

--- a/delivery_carrier_location/tests/test_delivery_carrier_location.py
+++ b/delivery_carrier_location/tests/test_delivery_carrier_location.py
@@ -1,0 +1,150 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestDeliveryCarrierCity(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        # Countries
+        cls.france = cls.env.ref("base.fr")
+        # States
+        cls.ile_de_france = cls.env["res.country.state"].create(
+            {
+                "name": "Île-de-France",
+                "code": "FR-IDF",
+                "country_id": cls.france.id,
+            }
+        )
+        # Cities
+        cls.paris = cls.env["res.city"].create(
+            {
+                "name": "Paris",
+                "state_id": cls.ile_de_france.id,
+                "country_id": cls.france.id,
+                "zipcode": "75000",
+            }
+        )
+        # Locations
+        cls.paris_01 = cls.env["res.city.zip"].create(
+            {"name": "75001", "city_id": cls.paris.id}
+        )
+        cls.paris_02 = cls.env["res.city.zip"].create(
+            {"name": "75002", "city_id": cls.paris.id}
+        )
+        cls.paris_03 = cls.env["res.city.zip"].create(
+            {"name": "75003", "city_id": cls.paris.id}
+        )
+        cls.paris_04 = cls.env["res.city.zip"].create(
+            {"name": "75004", "city_id": cls.paris.id}
+        )
+        cls.paris_05 = cls.env["res.city.zip"].create(
+            {"name": "75005", "city_id": cls.paris.id}
+        )
+        cls.paris_06 = cls.env["res.city.zip"].create(
+            {"name": "75006", "city_id": cls.paris.id}
+        )
+        cls.paris_07 = cls.env["res.city.zip"].create(
+            {"name": "75007", "city_id": cls.paris.id}
+        )
+        cls.paris_08 = cls.env["res.city.zip"].create(
+            {"name": "75008", "city_id": cls.paris.id}
+        )
+        cls.paris_09 = cls.env["res.city.zip"].create(
+            {"name": "75009", "city_id": cls.paris.id}
+        )
+        cls.paris_10 = cls.env["res.city.zip"].create(
+            {"name": "75010", "city_id": cls.paris.id}
+        )
+        cls.paris_11 = cls.env["res.city.zip"].create(
+            {"name": "75011", "city_id": cls.paris.id}
+        )
+        # Disable all other delivery methods
+        cls.env["delivery.carrier"].search([]).write({"active": False})
+        # Create delivery methods
+        cls.product = cls.env["product.product"].create({"name": "Delivery"})
+        cls.carrier_paris_01_05 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Delivery in Paris 01-05",
+                "product_id": cls.product.id,
+                "delivery_type": "fixed",
+                "fixed_price": 20,
+                "sequence": 10,
+                "country_ids": [(4, cls.france.id)],
+                "zip_ids": [
+                    (4, cls.paris_01.id),
+                    (4, cls.paris_02.id),
+                    (4, cls.paris_03.id),
+                    (4, cls.paris_04.id),
+                    (4, cls.paris_05.id),
+                ],
+            }
+        )
+        cls.carrier_paris_06_11 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Delivery in Paris 06-11",
+                "product_id": cls.product.id,
+                "delivery_type": "fixed",
+                "fixed_price": 15,
+                "sequence": 10,
+                "country_ids": [(4, cls.france.id)],
+                "zip_ids": [
+                    (4, cls.paris_06.id),
+                    (4, cls.paris_07.id),
+                    (4, cls.paris_08.id),
+                    (4, cls.paris_09.id),
+                    (4, cls.paris_10.id),
+                    (4, cls.paris_11.id),
+                ],
+            }
+        )
+        cls.carrier_france = cls.env["delivery.carrier"].create(
+            {
+                "name": "Delivery in France",
+                "product_id": cls.product.id,
+                "delivery_type": "fixed",
+                "fixed_price": 25,
+                "sequence": 20,
+                "country_ids": [(4, cls.france.id)],
+            }
+        )
+
+    def _get_available_carriers(self, partner):
+        return self.env["delivery.carrier"].search([]).available_carriers(partner)
+
+    def test_00_partner_zip_id(self):
+        # Partner living in paris 03, with zip_id set
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Edgar Degas",
+                "city_id": self.paris.id,
+                "state_id": self.paris.state_id.id,
+                "country_id": self.paris.country_id.id,
+                "zip_id": self.paris_03.id,
+                "zip": self.paris_03.name,
+            }
+        )
+        # Check available carriers
+        carriers = self._get_available_carriers(partner)
+        self.assertIn(self.carrier_paris_01_05, carriers)
+        self.assertNotIn(self.carrier_paris_06_11, carriers)
+
+    def test_01_partner_zip_but_without_zip_id(self):
+        # Partner living in paris 08, but zip_id is not set
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Claude Monet",
+                "city_id": self.paris.id,
+                "state_id": self.paris.state_id.id,
+                "country_id": self.paris.country_id.id,
+                "zip_id": False,
+                "zip": self.paris_08.name,
+            }
+        )
+        # Check available carriers
+        carriers = self._get_available_carriers(partner)
+        self.assertIn(self.carrier_paris_06_11, carriers)
+        self.assertNotIn(self.carrier_paris_01_05, carriers)

--- a/delivery_carrier_location/views/delivery_carrier.xml
+++ b/delivery_carrier_location/views/delivery_carrier.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp SA - Iván Todorovich
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_delivery_carrier_form" model="ir.ui.view">
+        <field name="model">delivery.carrier</field>
+        <field
+            name="inherit_id"
+            ref="delivery_carrier_city.view_delivery_carrier_form"
+        />
+        <field name="arch" type="xml">
+            <field name="city_ids" position="after">
+                <field name="zip_ids" widget="many2many_tags" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
+partner-contact

--- a/setup/delivery_carrier_location/odoo/addons/delivery_carrier_location
+++ b/setup/delivery_carrier_location/odoo/addons/delivery_carrier_location
@@ -1,0 +1,1 @@
+../../../../delivery_carrier_location

--- a/setup/delivery_carrier_location/setup.py
+++ b/setup/delivery_carrier_location/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Depends on https://github.com/OCA/delivery-carrier/pull/380

Integrates `delivery` with `base_location`, to allow to use `res.city.zip` records in the delivery methods' destinations.