### PR TITLE
[IMP] delivery_auto_refresh: void delivery lines on uninvoiced returns

### DIFF
--- a/delivery_auto_refresh/README.rst
+++ b/delivery_auto_refresh/README.rst
@@ -52,6 +52,11 @@ Configuration
   or create a new one if not exists.
   Put a non Falsy value (1, True...) if you want to refresh delivery price
   after transferring.
+* Locate the setting with key "delivery_auto_refresh.auto_void_delivery_line"
+  or create a new one if it doesn't exists.
+  Put a non Falsy value (1, True...) if you want to void the delivery line
+  values (price, units ordered, units delivered) in the sale order when the
+  delivered picking is returned to refund prior to be invoiced.
 
 Known issues / Roadmap
 ======================

--- a/delivery_auto_refresh/data/ir_config_parameter.xml
+++ b/delivery_auto_refresh/data/ir_config_parameter.xml
@@ -10,4 +10,8 @@
         <field name="key">delivery_auto_refresh.refresh_after_picking</field>
         <field name="value">0</field>
     </record>
+    <record id="default_auto_void_delivery_line" model="ir.config_parameter">
+        <field name="key">delivery_auto_refresh.auto_void_delivery_line</field>
+        <field name="value">0</field>
+    </record>
 </odoo>

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -81,3 +81,42 @@ class SaleOrder(models.Model):
         current_carrier = self.carrier_id
         super()._remove_delivery_line()
         self.carrier_id = current_carrier
+
+    def _is_delivery_line_voidable(self):
+        """If the picking is returned before being invoiced, like when the picking
+        is delivered but immediately return because the customer refused the order,
+        so no delivery charges should be applied."""
+        # There are invoiceable lines so there's no full return or the lines
+        # were not set to refund.
+        qty_delivered = sum(
+            self.order_line.filtered(
+                lambda x: not x.is_delivery and x.product_id.type != "service"
+            ).mapped("qty_delivered")
+        )
+        # There must be validated pickings
+        pickings = self.picking_ids.filtered(lambda x: x.state == "done")
+        # If there aren't delivery lines or the order is a quotation there's
+        # nothing to be done either. If there are more than one delivery lines
+        # we won't be doing anything as well.
+        if (
+            self.state not in {"done", "sale"}
+            or self.invoice_ids
+            or not self.order_line.filtered("is_delivery")
+            or len(self.order_line.filtered("is_delivery")) > 1
+            or qty_delivered
+            or not pickings
+        ):
+            return False
+        return True
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _get_protected_fields(self):
+        """Avoid locked orders validation error when voiding the
+        delivery line"""
+        fields = super()._get_protected_fields()
+        if self.env.context.get("delivery_auto_refresh_override_locked"):
+            return [x for x in fields if x not in ["product_uom_qty", "price_unit"]]
+        return fields

--- a/delivery_auto_refresh/models/stock_picking.py
+++ b/delivery_auto_refresh/models/stock_picking.py
@@ -44,3 +44,24 @@ class StockPicking(models.Model):
             total, weight, volume, quantity,
         )
         return res
+
+    def action_done(self):
+        """If configured, we want to set to 0 automatically the delivery line
+        when we have a returned picking that isn't invoiced so we don't have
+        it as invoiceable line. Otherwise, the salesman has to do it on hand"""
+        res = super().action_done()
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        param = "delivery_auto_refresh.auto_void_delivery_line"
+        if not safe_eval(get_param(param, "0")):
+            return res
+        sales_to_void_delivery = self.filtered(
+            lambda x: x.sale_id
+            and x.picking_type_code == "incoming"
+            and x.sale_id._is_delivery_line_voidable()
+        ).mapped("sale_id")
+        sales_to_void_delivery.mapped("order_line").filtered(
+            lambda x: x.is_delivery
+        ).with_context(delivery_auto_refresh_override_locked=True).write(
+            {"qty_delivered": 0, "product_uom_qty": 0, "price_unit": 0}
+        )
+        return res

--- a/delivery_auto_refresh/readme/CONFIGURE.rst
+++ b/delivery_auto_refresh/readme/CONFIGURE.rst
@@ -8,3 +8,8 @@
   or create a new one if not exists.
   Put a non Falsy value (1, True...) if you want to refresh delivery price
   after transferring.
+* Locate the setting with key "delivery_auto_refresh.auto_void_delivery_line"
+  or create a new one if it doesn't exists.
+  Put a non Falsy value (1, True...) if you want to void the delivery line
+  values (price, units ordered, units delivered) in the sale order when the
+  delivered picking is returned to refund prior to be invoiced.

--- a/delivery_auto_refresh/static/description/index.html
+++ b/delivery_auto_refresh/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Auto-refresh delivery</title>
 <style type="text/css">
 
@@ -404,6 +404,11 @@ delivery line on save.</li>
 or create a new one if not exists.
 Put a non Falsy value (1, True…) if you want to refresh delivery price
 after transferring.</li>
+<li>Locate the setting with key “delivery_auto_refresh.auto_void_delivery_line”
+or create a new one if it doesn’t exists.
+Put a non Falsy value (1, True…) if you want to void the delivery line
+values (price, units ordered, units delivered) in the sale order when the
+delivered picking is returned to refund prior to be invoiced.</li>
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -66,6 +66,7 @@ class TestDeliveryAutoRefresh(common.HttpCase):
         )
         self.param_name1 = "delivery_auto_refresh.auto_add_delivery_line"
         self.param_name2 = "delivery_auto_refresh.refresh_after_picking"
+        self.param_name3 = "delivery_auto_refresh.auto_void_delivery_line"
         order_form = Form(self.env["sale.order"])
         order_form.partner_id = self.partner
         order_form.partner_shipping_id = self.partner
@@ -168,3 +169,99 @@ class TestDeliveryAutoRefresh(common.HttpCase):
         order_form_2 = Form(self.env["sale.order"])
         order_form_2.partner_id = partner_without_carrier
         self.assertEquals(order_form_2.carrier_id, no_carrier)
+
+    def _confirm_sale_order(self, order):
+        sale_form = Form(order)
+        # Force the delivery line creation
+        with sale_form.order_line.edit(0) as line_form:
+            line_form.product_uom_qty = 2
+        sale_form.save()
+        line_delivery = order.order_line.filtered("is_delivery")
+        order.action_confirm()
+        return line_delivery
+
+    def _validate_picking(self, picking):
+        """Helper method to confirm the pickings"""
+        for line in picking.move_lines:
+            line.quantity_done = line.product_uom_qty
+        picking.action_done()
+
+    def _return_whole_picking(self, picking, to_refund=True):
+        """Helper method to create a return of the original picking. It could
+        be refundable or not"""
+        return_wiz_form = Form(
+            self.env["stock.return.picking"].with_context(
+                active_ids=picking.ids,
+                active_id=picking[:1].id,
+                active_model="stock.picking",
+            )
+        )
+        return_wiz = return_wiz_form.save()
+        return_wiz.product_return_moves.quantity = picking.move_lines.quantity_done
+        return_wiz.product_return_moves.to_refund = to_refund
+        # import pdb; pdb.set_trace()
+        res = return_wiz.create_returns()
+        return_picking = self.env["stock.picking"].browse(res["res_id"])
+        self._validate_picking(return_picking)
+
+    def _test_autorefresh_void_line(self, lock=False, to_refund=True, invoice=False):
+        """Helper method to test the possible cases for voiding the line"""
+        self.assertFalse(self.order.order_line.filtered("is_delivery"))
+        self.env["ir.config_parameter"].sudo().set_param(self.param_name1, 1)
+        self.env["ir.config_parameter"].sudo().set_param(self.param_name3, 1)
+        line_delivery = self._confirm_sale_order(self.order)
+        self._validate_picking(self.order.picking_ids)
+        if invoice:
+            self.order._create_invoices()
+        if lock:
+            self.order.action_done()
+        self._return_whole_picking(self.order.picking_ids, to_refund)
+        return line_delivery
+
+    def test_auto_refresh_so_and_return_no_invoiced(self):
+        """The delivery line is voided as all conditions apply when the return
+        is made"""
+        line_delivery = self._test_autorefresh_void_line()
+        self.assertEqual(line_delivery.price_unit, 0)
+        self.assertEqual(line_delivery.product_uom_qty, 0)
+
+    def test_auto_refresh_so_and_return_no_invoiced_locked(self):
+        """The delivery line is voided as all conditions apply when the return
+        is made. We overrided the locked state in this case"""
+        line_delivery = self._test_autorefresh_void_line(lock=True)
+        self.assertEqual(line_delivery.price_unit, 0)
+        self.assertEqual(line_delivery.product_uom_qty, 0)
+
+    def test_auto_refresh_so_and_return_invoiced(self):
+        """There's already an invoice, so the delivery line can't be voided"""
+        line_delivery = self._test_autorefresh_void_line(invoice=True)
+        self.assertEqual(line_delivery.price_unit, 50)
+        self.assertEqual(line_delivery.product_uom_qty, 1)
+
+    def test_auto_refresh_so_and_return_no_refund(self):
+        """The return wasn't flagged to refund, so the delivered qty won't
+        change, thus the delivery line shouldn't be either"""
+        line_delivery = self._test_autorefresh_void_line(to_refund=False)
+        self.assertEqual(line_delivery.price_unit, 50)
+        self.assertEqual(line_delivery.product_uom_qty, 1)
+
+    def _test_autorefresh_unlink_line(self):
+        """Helper method to test the possible cases for voiding the line"""
+        self.assertFalse(self.order.order_line.filtered("is_delivery"))
+        self.env["ir.config_parameter"].sudo().set_param(self.param_name1, 1)
+        sale_form = Form(self.order)
+        # Force the delivery line creation
+        with sale_form.order_line.edit(0) as line_form:
+            line_form.product_uom_qty = 2
+        sale_form.save()
+        return self.order.order_line.filtered("is_delivery")
+
+    def test_auto_refresh_so_and_unlink_line(self):
+        """The return wasn't flagged to refund, so the delivered qty won't
+        change, thus the delivery line shouldn't be either"""
+        self._test_autorefresh_unlink_line()
+        delivery_line = self.order.order_line.filtered("is_delivery")
+        sale_form = Form(self.order)
+        sale_form.order_line.remove(0)
+        sale_form.save()
+        self.assertFalse(delivery_line.exists())


### PR DESCRIPTION
forward port of #382 

Added new config paramerter that automates de voiding of the delivery
line for the case of returning a picking that just didn't go away from
the warehouse (due to several causes like the customer cancelling the
sale order in the last minute).

This will only be performed if the order wasn't already invoiced and the
return was set to refund.

cc @Tecnativa TT30359

please review @pedrobaeza @CarlosRoca13 