### PR TITLE
[14.0][ADD] delivery_carrier_agency

### DIFF
--- a/delivery_carrier_agency/__init__.py
+++ b/delivery_carrier_agency/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_carrier_agency/__manifest__.py
+++ b/delivery_carrier_agency/__manifest__.py
@@ -1,0 +1,23 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+{
+    "name": "Delivery Carrier Agency",
+    "summary": "Add a model for Carrier Agencies",
+    "version": "14.0.1.0.1",
+    "category": "Delivery",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "author": "Akretion,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "delivery",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/delivery_carrier_agency_view.xml",
+    ],
+    "demo": [],
+    "qweb": [],
+}

--- a/delivery_carrier_agency/models/__init__.py
+++ b/delivery_carrier_agency/models/__init__.py
@@ -1,0 +1,2 @@
+from . import delivery_carrier_agency
+from . import stock_picking

--- a/delivery_carrier_agency/models/delivery_carrier_agency.py
+++ b/delivery_carrier_agency/models/delivery_carrier_agency.py
@@ -1,0 +1,33 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class DeliveryCarrierAgency(models.Model):
+    _name = "delivery.carrier.agency"
+    _description = "Carrier Agency"
+    _order = "sequence, id"
+
+    name = fields.Char(required=True)
+    external_reference = fields.Char(help="Reference or code supplied by the carrier")
+    delivery_type = fields.Selection(
+        selection=lambda self: self.env["delivery.carrier"]
+        ._fields["delivery_type"]
+        .selection,
+        required=True,
+    )
+    carrier_ids = fields.Many2many(
+        "delivery.carrier",
+        "delivery_carrier_agency_rel",
+        "agency_id",
+        "carrier_id",
+        string="Carriers",
+        help=(
+            "This field may be used to link an account to specific delivery methods"
+            " It may be usefull to find an account with more precision than with "
+            "only the delivery type"
+        ),
+    )
+    partner_id = fields.Many2one("res.partner", string="Address")
+    warehouse_ids = fields.Many2many("stock.warehouse", string="Warehouses")
+    sequence = fields.Integer()

--- a/delivery_carrier_agency/models/stock_picking.py
+++ b/delivery_carrier_agency/models/stock_picking.py
@@ -1,0 +1,25 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _get_domain_agency(self):
+        self.ensure_one()
+        wh = self.location_id.get_warehouse()
+        return [
+            ("delivery_type", "=", self.carrier_id.delivery_type),
+            "|",
+            ("warehouse_ids", "=", False),
+            ("warehouse_ids", "in", wh.ids),
+            "|",
+            ("carrier_ids", "in", [self.carrier_id.id]),
+            ("carrier_ids", "=", False),
+        ]
+
+    def _get_carrier_agency(self):
+        self.ensure_one()
+        domain = self._get_domain_agency()
+        return self.env["delivery.carrier.agency"].search(domain, limit=1)

--- a/delivery_carrier_agency/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_agency/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Florian da Costa <florian.dacosta@akretion.com>

--- a/delivery_carrier_agency/readme/DESCRIPTION.rst
+++ b/delivery_carrier_agency/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+Add carrier agency concept
+A delivery carrier may have one or mutliple agencies.
+The module does not add any logic around these agencies, it will be done in dedicated carrier modules if necessary.
+For instance, when generating label, sometimes, some information may depend on the agency that will receive the package, which may depend on the warehouse

--- a/delivery_carrier_agency/security/ir.model.access.csv
+++ b/delivery_carrier_agency/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_delivery_carrier_agency_wh_user,delivery.carrier.agency.wh.user,model_delivery_carrier_agency,stock.group_stock_user,1,0,0,0
+access_delivery_carrier_agency_wh_manager,delivery.carrier.agency.wh.manager,model_delivery_carrier_agency,stock.group_stock_manager,1,1,1,1

--- a/delivery_carrier_agency/tests/__init__.py
+++ b/delivery_carrier_agency/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_carrier_agency

--- a/delivery_carrier_agency/tests/test_carrier_agency.py
+++ b/delivery_carrier_agency/tests/test_carrier_agency.py
@@ -1,0 +1,43 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestCarrierAgency(TransactionCase):
+    def test_get_carrier_agency(self):
+        """Test finding the correct account for a picking"""
+        chicago_wh = self.env.ref("stock.stock_warehouse_shop0")
+        san_fransico_wh = self.env.ref("stock.warehouse0")
+        agency_chicago = self.env["delivery.carrier.agency"].create(
+            {
+                "name": "Normal Carrier Chicago agency",
+                "delivery_type": "fixed",
+                "warehouse_ids": [(6, 0, chicago_wh.ids)],
+            }
+        )
+        agency_san_fransisco = self.env["delivery.carrier.agency"].create(
+            {
+                "name": "Normal Carrier San Fransisco agency",
+                "delivery_type": "fixed",
+                "warehouse_ids": [(6, 0, san_fransico_wh.ids)],
+            }
+        )
+        san_fransisco_picking = self.env["stock.picking"].new(
+            dict(
+                carrier_id=self.env.ref("delivery.normal_delivery_carrier").id,
+                company_id=self.env.user.company_id.id,
+                location_id=san_fransico_wh.lot_stock_id.id,
+            )
+        )
+        agency = san_fransisco_picking._get_carrier_agency()
+        self.assertEqual(agency, agency_san_fransisco)
+
+        chicago_picking = self.env["stock.picking"].new(
+            dict(
+                carrier_id=self.env.ref("delivery.normal_delivery_carrier").id,
+                company_id=self.env.user.company_id.id,
+                location_id=chicago_wh.lot_stock_id.id,
+            )
+        )
+        agency = chicago_picking._get_carrier_agency()
+        self.assertEqual(agency, agency_chicago)

--- a/delivery_carrier_agency/views/delivery_carrier_agency_view.xml
+++ b/delivery_carrier_agency/views/delivery_carrier_agency_view.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="carrier_agency_view_tree" model="ir.ui.view">
+        <field name="model">delivery.carrier.agency</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle" optional="show" />
+                <field name="name" />
+                <field name="external_reference" />
+                <field name="partner_id" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_delivery_carrier_agency_form" model="ir.ui.view">
+        <field name="name">delivery_base.delivery.carrier.agency.form</field>
+        <field name="model">delivery.carrier.agency</field>
+        <field name="arch" type="xml">
+            <form class="oe_form_nomargin o_note_form_view">
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" />
+                        </h1>
+                    </div>
+                    <group>
+                        <field name="external_reference" />
+                        <field name="partner_id" />
+                        <field name="delivery_type" />
+                        <field
+                            name="carrier_ids"
+                            widget="many2many_tags"
+                            attrs="{'invisible': [('delivery_type', '=', False)]}"
+                            domain="[('delivery_type', '=', delivery_type)]"
+                        />
+                        <field name="warehouse_ids" widget="many2many_tags" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_carrier_agency" model="ir.actions.act_window">
+        <field name="name">Carrier Agency</field>
+        <field name="res_model">delivery.carrier.agency</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem
+        id="carrier_agency_menu"
+        parent="delivery.menu_delivery"
+        sequence="10"
+        action="action_carrier_agency"
+    />
+
+</odoo>

--- a/setup/delivery_carrier_agency/odoo/addons/delivery_carrier_agency
+++ b/setup/delivery_carrier_agency/odoo/addons/delivery_carrier_agency
@@ -1,0 +1,1 @@
+../../../../delivery_carrier_agency

--- a/setup/delivery_carrier_agency/setup.py
+++ b/setup/delivery_carrier_agency/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
It is a small module, that does not do much by itself.
It add the concept of carrier agency.
This module could be usefull for label generation for some carrier for instance.
Indeed, some carrier (like GEODIS) need the information of which agency will receive the package when generating the delivery labels.
For instance if you have one warehouse in north of France and another in south, the carrier agency that will handle the packages will be different.

So this module add the model of carrier agency and a helper to find the right agency of a carrier.

@hparfr 