### PR TITLE
[12.0] Fix postlogistics error when email contains a "realname"

### DIFF
--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -11,6 +11,7 @@ import threading
 from PIL import Image
 from io import StringIO
 from datetime import datetime, timedelta
+from email.utils import parseaddr
 
 from odoo import _, exceptions
 
@@ -74,12 +75,13 @@ class PostlogisticsWebService(object):
         partner = picking.partner_id
 
         partner_name = partner.name or partner.parent_id.name
+        email = parseaddr(partner.email)[1]
         recipient = {
             'name1': _sanitize_string(partner_name),
             'street': _sanitize_string(partner.street),
             'zip': partner.zip,
             'city': partner.city,
-            'email': partner.email or None,
+            'email': email or None,
         }
 
         if partner.country_id.code:


### PR DESCRIPTION
When the webservices receives a 2 parts email such as `Real Name
<email@example.com>`, it returns a 500 internal error.
Extract the email address only and send only this part to the service.

Note: parseaddr is pretty tolerant regarding the input, even if it
receives False or '', it returns ('', ''), so we don't need to be
very defensive.