### PR TITLE
[13.0] delivery_package_fee: fix copy w/ no order lines

### DIFF
--- a/delivery_package_fee/models/sale_order.py
+++ b/delivery_package_fee/models/sale_order.py
@@ -93,7 +93,7 @@ class SaleOrder(models.Model):
         new_result = []
         for values in result:
             # "sale" module sets this key
-            if "order_line" in values:
+            if "order_line" in values and values["order_line"]:
                 # remove package fee lines
                 order_lines = [
                     line


### PR DESCRIPTION
'order_line' can be empty when SO is copied
from direct call to copy with False as default.