### PR TITLE
[13.0] delivery_postlogistics: Add disallowed chars

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -22,7 +22,14 @@ _compile_itemnum = re.compile(r"[^0-9]")
 AUTH_PATH = "/WEDECOAuth/token"
 GENERATE_LABEL_PATH = "/api/barcode/v1/generateAddressLabel"
 
-DISALLOWED_CHARS = ["|", "\\", "<", ">"]
+DISALLOWED_CHARS_MAPPING = {
+    "|": "",
+    "\\": "",
+    "<": "",
+    ">": "",
+    "\u2018": "'",
+    "\u2019": "'",
+}
 
 
 class PostlogisticsWebService(object):
@@ -449,10 +456,10 @@ class PostlogisticsWebService(object):
             return cls.access_token
 
     def _sanitize_string(self, value):
-        """Removes disallowed chars ("|", "\", "<", ">") from strings."""
+        """Removes disallowed chars ("|", "\", "<", ">", "’", "‘") from strings."""
         if isinstance(value, str):
-            for char in DISALLOWED_CHARS:
-                value = value.replace(char, "")
+            for char, repl in DISALLOWED_CHARS_MAPPING.items():
+                value = value.replace(char, repl)
         return value
 
     def generate_label(self, picking, packages):

--- a/delivery_postlogistics/tests/test_sanitize_values.py
+++ b/delivery_postlogistics/tests/test_sanitize_values.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 
-from ..postlogistics.web_service import DISALLOWED_CHARS
+from ..postlogistics.web_service import DISALLOWED_CHARS_MAPPING
 from .common import TestPostlogisticsCommon
 
 
@@ -15,7 +15,7 @@ class TestSanitizeValues(TestPostlogisticsCommon):
     def setUpPartner(cls):
         cls.partner = cls.env["res.partner"].create(
             {
-                "name": "P<o\\t|at>o",
+                "name": "‘P<o\\t|at>o’",
                 "mobile": "+33123456789>",
                 "phone": ">+33123456789<",
                 "email": "w<>|\\hatever@whatever.too",
@@ -40,7 +40,9 @@ class TestSanitizeValues(TestPostlogisticsCommon):
 
     def check_strings_in_list(self, values):
         for value in values:
-            self.assertFalse(any(char in value for char in DISALLOWED_CHARS))
+            self.assertFalse(
+                any(char in value for char in DISALLOWED_CHARS_MAPPING.keys())
+            )
 
     def test_sanitize(self):
         customer = self.service_class._prepare_customer(self.picking)


### PR DESCRIPTION
`‘` and `’` are disallowed chars. Replace them by `'` before sending the message to swisspost.

ref 2713