### PR TITLE
[14][delivery_roulier] Avoid failure if getting price from carrier webservice is not implemented

### DIFF
--- a/delivery_roulier/models/delivery_carrier.py
+++ b/delivery_roulier/models/delivery_carrier.py
@@ -45,3 +45,16 @@ class DeliveryCarrier(models.Model):
                 return first_package._get_tracking_link(picking)
         else:
             return super().get_tracking_link(picking)
+
+    def rate_shipment(self, order):
+        res = super().rate_shipment(order)
+        # for roulier carrier, usually getting the price by carrier webservice
+        # is usually not available for now. Avoid failure in that case.
+        if not res and self.is_roulier():
+            res = {
+                "success": True,
+                "price": 0.0,
+                "error_message": False,
+                "warning_message": False,
+            }
+        return res


### PR DESCRIPTION
Somme carriers implemented as submodule of delivery roulier does not manage getting the price from the carrier webservice.
Because it is not made possible by the carrier, of just because this was not implemented yet, the main/original goal of these modules beeing to be able to generate the carrier labels.

This PR aims to avoid a failure if the price for such a carrier is asked by Odoo but not implemented.
(in this case we just return a null price).

This should solve the issue here https://github.com/OCA/delivery-carrier/issues/407
Although it won't give a price, but this could be implemented as an improvement if needed (in roulier lib)

@delkano