### PR TITLE
[FIX] delivery_price_method: method permissions

### DIFF
--- a/delivery_price_method/models/delivery_carrier.py
+++ b/delivery_price_method/models/delivery_carrier.py
@@ -24,10 +24,10 @@ class DeliveryCarrier(models.Model):
         previous_method = False
         if self.price_method in ("fixed", "base_on_rule"):
             previous_method = self.delivery_type
-            self.delivery_type = self.price_method
+            self.sudo().delivery_type = self.price_method
         res = super().rate_shipment(order)
         if previous_method:
-            self.delivery_type = previous_method
+            self.sudo().delivery_type = previous_method
         return res
 
     def send_shipping(self, pickings):


### PR DESCRIPTION
If a user don't have the necessary permissions for writing in the
`delivery.carrier` model (like a low range salesman) he won't be able to
choose a carrier wich uses the rate shipment override.

cc @Tecnativa TT31627

please review @victoralmau @pedrobaeza 