### PR TITLE
[13.0][ADD] stock_picking_carrier_from_rule

### DIFF
--- a/stock_picking_carrier_from_rule/__init__.py
+++ b/stock_picking_carrier_from_rule/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_carrier_from_rule/__manifest__.py
+++ b/stock_picking_carrier_from_rule/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Stock Picking Carrier From Rule",
+    "summary": """
+    Set the carrier on picking if the stock rule used has a partner
+    address set with a delivery method.
+    """,
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "depends": ["delivery"],
+    "installable": True,
+}

--- a/stock_picking_carrier_from_rule/models/__init__.py
+++ b/stock_picking_carrier_from_rule/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_move

--- a/stock_picking_carrier_from_rule/models/stock_move.py
+++ b/stock_picking_carrier_from_rule/models/stock_move.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_new_picking_values(self):
+        vals = super()._get_new_picking_values()
+        if not vals.get("carrier_id"):
+            rule_carrier = self.rule_id.partner_address_id.property_delivery_carrier_id
+            if rule_carrier:
+                vals["carrier_id"] = rule_carrier.id
+        return vals

--- a/stock_picking_carrier_from_rule/readme/CONTRIBUTORS.rst
+++ b/stock_picking_carrier_from_rule/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/stock_picking_carrier_from_rule/readme/DESCRIPTION.rst
+++ b/stock_picking_carrier_from_rule/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module sets a shipping method on stock picking based on the partner address
+set on the stock rule.
+If the value for `carrier_id` is not yet set on the picking. And the partner as
+a delivery method set.

--- a/stock_picking_carrier_from_rule/readme/ROADMAP.rst
+++ b/stock_picking_carrier_from_rule/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+Add unit tests


### PR DESCRIPTION
This module sets a shipping method on stock picking based on the partner address
set on the stock rule.
If the value for carrier_id is not yet set on the picking. And the partner as
a delivery method set.