### PR TITLE
[13.0][FIX] delivery_ups_oca: Prevent error when convert price in different currency

### DIFF
--- a/delivery_ups_oca/tests/test_delivery_ups.py
+++ b/delivery_ups_oca/tests/test_delivery_ups.py
@@ -85,6 +85,16 @@ class DeliveryUps(common.SavepointCase):
         self.assertGreater(res["price"], 0)
         self.assertTrue(res["success"])
 
+    def test_order_ups_rate_shipment_currency_extra(self):
+        usd = self.env.ref("base.USD")
+        eur = self.env.ref("base.EUR")
+        currency = self.env.ref("base.main_company").currency_id
+        currency_extra = eur if currency == usd else usd
+        self.sale.currency_id = currency_extra
+        res = self.carrier.ups_rate_shipment(self.sale)
+        self.assertGreater(res["price"], 0)
+        self.assertTrue(res["success"])
+
     def test_delivery_carrier_ups_integration(self):
         self.picking.action_confirm()
         self.picking.action_assign()


### PR DESCRIPTION
Prevent error when convert price in different currency (We need to convert the price if the currency is different).
It is necessary to do the currency conversion in the `delivery.carrier` model because the `UpsRequest` class does not have access to `self.env`

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT30631