### PR TITLE
[14.0][FIX] delivery_package_fee: fix copy_data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.1
+    rev: 5.9.3
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/delivery_package_fee/models/sale_order.py
+++ b/delivery_package_fee/models/sale_order.py
@@ -93,7 +93,7 @@ class SaleOrder(models.Model):
         new_result = []
         for values in result:
             # "sale" module sets this key
-            if "order_line" in values:
+            if values.get("order_line"):
                 # remove package fee lines
                 order_lines = [
                     line


### PR DESCRIPTION
`values["order_line"]` could be set to `False`

This will makes `shopinvader` compatible with the current module: https://github.com/shopinvader/odoo-shopinvader/blob/38d1768acf925ee82d9242297e1b32de921bc4ca/shopinvader/services/cart.py#L121