### PR TITLE
[12.0][IMP] delivery_carrier_label_ups: split of methods

### DIFF
--- a/delivery_carrier_label_ups/models/carrier_account.py
+++ b/delivery_carrier_label_ups/models/carrier_account.py
@@ -8,3 +8,9 @@ class CarrierAccount(models.Model):
 
     ups_access_license = fields.Char("Access license number")
     ups_shipper_number = fields.Char("Shipper number")
+    ups_negotiated_rates = fields.Boolean(
+        help="""By default, shipping to UPS makes use of Published Rates. To
+        use Negotiated Rates instead, just set this flag to True.
+        A negotiated rate can be enabled only in case it's established by contract
+        between your company and UPS.
+    """)

--- a/delivery_carrier_label_ups/models/stock_picking.py
+++ b/delivery_carrier_label_ups/models/stock_picking.py
@@ -315,6 +315,11 @@ class StockPicking(models.Model):
             and "LBS"
             or "KGS"
         )
+        dimension_uom = (
+            int(get_param("product.weight_in_lbs", 0,))
+            and "IN"
+            or "CM"
+        )
         return dict(
             Description=package.name,
             NumOfPieces=str(sum(package.mapped("quant_ids.quantity"))),
@@ -324,7 +329,7 @@ class StockPicking(models.Model):
                 Description=package.packaging_id.name or "Custom",
             ),
             Dimensions=dict(
-                UnitOfMeasurement=dict(Code="CM"),
+                UnitOfMeasurement=dict(Code=dimension_uom),
                 Length=str(package.packaging_id.length),
                 Width=str(package.packaging_id.width),
                 Height=str(package.packaging_id.height),

--- a/delivery_carrier_label_ups/models/stock_picking.py
+++ b/delivery_carrier_label_ups/models/stock_picking.py
@@ -216,7 +216,7 @@ class StockPicking(models.Model):
                 LabelSpecification=self._ups_label_specification(account),
             )
         )
-        if self.env.context.get("enable_negotiated_rates"):
+        if account.ups_negotiated_rates:
             # Enable negotiated rates
             result['ShipmentRequest']['Shipment'].update(
                 ShipmentRatingOptions=dict(NegotiatedRatesIndicator="")

--- a/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
+++ b/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
@@ -19,9 +19,13 @@ class DeliveryCarrierLabelUpsCase(carrier_label_case.CarrierLabelCase):
                 "password": "password",
                 "ups_access_license": "access license",
                 "ups_shipper_number": "shipper number",
+                "ups_negotiated_rates": True,
             }
         )
         with self._setup_mock_requests() as mock_requests:
+            ctx = dict(self.env.context)
+            ctx["get_parcel_labels"] = True
+            self.env = self.env(context=ctx)
             super()._create_order_picking()
             self.assertTrue(
                 mock_requests.post.call_args[1]["json"]["ShipmentRequest"]["Shipment"][

--- a/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
+++ b/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
@@ -42,7 +42,70 @@ class DeliveryCarrierLabelUpsCase(carrier_label_case.CarrierLabelCase):
                             TotalCharges=dict(MonetaryValue=42, CurrencyCode="USD",),
                         ),
                         ShipmentIdentificationNumber="shipping_tracking",
-                        PackageResults=dict(TrackingNumber="package_tracking",),
+                        PackageResults=[
+                            {"TrackingNumber": "1ZWA82900192955557",
+                             "BaseServiceCharge": {
+                                 "CurrencyCode": "USD",
+                                 "MonetaryValue": "126.27"
+                             },
+                             "ServiceOptionsCharges": {
+                                 "CurrencyCode": "USD",
+                                 "MonetaryValue": "0.00"
+                             },
+                             "ShippingLabel": {
+                                 "ImageFormat": {
+                                     "Code": "GIF",
+                                     "Description": "GIF"
+                                 },
+                                 "GraphicImage": base64.b64encode(
+                                     bytes("hello", "utf8")),
+                             },
+                             "ItemizedCharges": [
+                                 {
+                                     "Code": "376",
+                                     "CurrencyCode": "USD",
+                                     "MonetaryValue": "0.00",
+                                     "SubType": "Urban"
+                                 },
+                                 {
+                                     "Code": "375",
+                                     "CurrencyCode": "USD",
+                                     "MonetaryValue": "10.73"
+                                 }
+                             ]
+                             },
+                            {"TrackingNumber": "1ZWA82900194633561",
+                             "BaseServiceCharge": {
+                                 "CurrencyCode": "USD",
+                                 "MonetaryValue": "184.76"
+                             },
+                             "ServiceOptionsCharges": {
+                                 "CurrencyCode": "USD",
+                                 "MonetaryValue": "0.00"
+                             },
+                             "ShippingLabel": {
+                                 "ImageFormat": {
+                                     "Code": "GIF",
+                                     "Description": "GIF"
+                                 },
+                                 "GraphicImage": base64.b64encode(
+                                     bytes("hello", "utf8")),
+                             },
+                             "ItemizedCharges": [
+                                 {
+                                     "Code": "376",
+                                     "CurrencyCode": "USD",
+                                     "MonetaryValue": "0.00",
+                                     "SubType": "Urban"
+                                 },
+                                 {
+                                     "Code": "375",
+                                     "CurrencyCode": "USD",
+                                     "MonetaryValue": "15.70"
+                                 }
+                             ]
+                             }
+                        ],
                     ),
                 ),
             )
@@ -110,6 +173,7 @@ class TestDeliveryCarrierLabelUps(
             active_id=self.picking.id
         ).create({}).create_returns()
         return_picking = self.env[action['res_model']].browse(action['res_id'])
+        self.assertTrue(return_picking.location_id.usage == 'customer')
         return_data = return_picking._ups_shipping_data()['ShipmentRequest']
         self.assertEqual(
             shipping_data['Shipment']['ShipFrom']['Name'],

--- a/delivery_carrier_label_ups/views/carrier_account.xml
+++ b/delivery_carrier_label_ups/views/carrier_account.xml
@@ -18,6 +18,10 @@
                     name="ups_shipper_number"
                     attrs="{'invisible': [('delivery_type', '!=', 'ups')], 'required': [('delivery_type', '=', 'ups')]}"
                 />
+                <field
+                    name="ups_negotiated_rates"
+                    attrs="{'invisible': [('delivery_type', '!=', 'ups')]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This is a proposal of splitting methods to ease customizations. Similar PR as it was done for Paazl (https://github.com/OCA/delivery-carrier/pull/372).

In addition, the following features are added:

- [x] write label immediately when sending shipment
- [x] allow negotiated rates
- [x] make dimension uom consistent with weight uom
