### PR TITLE
[IMP] field description translatable

### DIFF
--- a/delivery_carrier_info/models/delivery_carrier.py
+++ b/delivery_carrier_info/models/delivery_carrier.py
@@ -11,4 +11,4 @@ class DeliveryCarrier(models.Model):
     code = fields.Char(
         help="Delivery Method Code (according to carrier)",
     )
-    description = fields.Text()
+    description = fields.Text(translate=True)


### PR DESCRIPTION
Field description must be translatable in the context of shopinvader to show the description in the selected user language on the front