### PR TITLE
[14] Fix encoding on laposte webservice error handling

### DIFF
--- a/delivery_roulier_laposte_fr/models/stock_quant_package.py
+++ b/delivery_roulier_laposte_fr/models/stock_quant_package.py
@@ -95,7 +95,7 @@ class StockQuantPackage(models.Model):
 
     def _laposte_fr_carrier_error_handling(self, payload, exception):
         response = exception.response
-        request = response.request.body
+        request = response.request.body.decode()
 
         if self._uid > 2:
             # rm pwd from dict and xml
@@ -142,7 +142,7 @@ class StockQuantPackage(models.Model):
             "Incident\n-----------\n%s\n"
             "Données transmises:\n"
             "-----------------------------\n%s"
-        ) % ("\n".join(parts), request.decode("utf-8"))
+        ) % ("\n".join(parts), request)
         return ret_mess
 
     def _laposte_fr_get_tracking_link(self):


### PR DESCRIPTION
request is a utf-8 encoded string, it needs to be decoded to be able to replace/hide the webservice password in the call