### PR TITLE
[12.0][FIX] delivery_carrier_label_ups: total UPS shipment price

### DIFF
--- a/delivery_carrier_label_ups/models/stock_picking.py
+++ b/delivery_carrier_label_ups/models/stock_picking.py
@@ -412,9 +412,16 @@ class StockPicking(models.Model):
             "Password": account.password,
             "transactionSrc": "Odoo (%s)" % self.env.cr.dbname,
         }
-        return getattr(requests, method)(
+        res = getattr(requests, method)(
             url, json=payload, headers=headers, params=query_parameters
         ).json()
+        # log request and response
+        ups_last_request = ("URL: {}").format(url)
+        if payload:
+            ups_last_request += ("\nData: {}").format(str(payload))
+        self.carrier_id.log_xml(ups_last_request, "ups_last_request")
+        self.carrier_id.log_xml(str(res), "ups_last_response")
+        return res
 
     def _ups_auth_account(self):
         """Find a carrier.account matching our carrier"""

--- a/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
+++ b/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
@@ -43,7 +43,12 @@ class DeliveryCarrierLabelUpsCase(carrier_label_case.CarrierLabelCase):
                 ShipmentResponse=dict(
                     ShipmentResults=dict(
                         ShipmentCharges=dict(
-                            TotalCharges=dict(MonetaryValue=42, CurrencyCode="USD",),
+                            TotalCharges=dict(
+                                MonetaryValue="42.00", CurrencyCode="USD",),
+                        ),
+                        NegotiatedRateCharges=dict(
+                            TotalCharge=dict(
+                                MonetaryValue="39.89", CurrencyCode="USD",),
                         ),
                         ShipmentIdentificationNumber="shipping_tracking",
                         PackageResults=[
@@ -135,6 +140,14 @@ class DeliveryCarrierLabelUpsCase(carrier_label_case.CarrierLabelCase):
 
     def _get_carrier(self):
         return self.env.ref("delivery_carrier_label_ups.carrier_ups")
+
+    def test_picking_total_price(self):
+        """ Check total contracted price. Negotiated rates
+        have the priority over the published rates.
+         """
+        self._create_order_picking()
+        self.assertTrue(self.picking)
+        self.assertEqual(self.picking.carrier_price, 39.89)
 
 
 class TestDeliveryCarrierLabelUps(


### PR DESCRIPTION
The total price by public rates is always shown on the chatter of the shipment, even when UPS is charging the contracted rate.
This PR is a proposal to get the total price by contracted rate if present, otherwise get the standard price by public rates.

@hbrunn 