### PR TITLE
[14] Improve delivery_roulier : no failure when asking price / addresses improvements

### DIFF
--- a/delivery_roulier/models/delivery_carrier.py
+++ b/delivery_roulier/models/delivery_carrier.py
@@ -45,3 +45,16 @@ class DeliveryCarrier(models.Model):
                 return first_package._get_tracking_link(picking)
         else:
             return super().get_tracking_link(picking)
+
+    def rate_shipment(self, order):
+        res = super().rate_shipment(order)
+        # for roulier carrier, usually getting the price by carrier webservice
+        # is usually not available for now. Avoid failure in that case.
+        if not res and self.is_roulier():
+            res = {
+                "success": True,
+                "price": 0.0,
+                "error_message": False,
+                "warning_message": False,
+            }
+        return res


### PR DESCRIPTION
- Getting the price from a carrier webservice using roulier is not implemented yet. But we avoid failure in case of it is used in Odoo
- Make a seperated method for the address data taken from the parent partner, to ease overrides
- Take email and mobile phone from parent if not found on the picking address
replace https://github.com/OCA/delivery-carrier/pull/410