### PR TITLE
[14.0] base_delivery_carrier_label: add check when no carrier_id assigned

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -29,7 +29,7 @@ class DeliveryCarrier(models.Model):
     def send_shipping(self, pickings):
         """Handle labels and  if we have them. Expected format is {'labels': [{}, ...]}
         The dicts are input for stock.picking#attach_label"""
-        result = super().send_shipping(pickings)
+        result = None
         # We could want to generate labels calling a method that does not depend
         # on one specific delivery_type.
         # For instance, if we want to generate a default label in case there are not
@@ -38,7 +38,9 @@ class DeliveryCarrier(models.Model):
         # or at the contrary, we could call a common method for multiple delivery_type
         # for instance, in delivery_roulier, the same method is always called for any
         # carrier implemented in roulier lib.
-        if result is None:
+        if pickings.carrier_id:
+            result = super().send_shipping(pickings)
+        if not result:
             result = self.alternative_send_shipping(pickings)
         for result_dict, picking in zip(result, pickings):
             for label in result_dict.get("labels", []):

--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -63,7 +63,8 @@ class StockPicking(models.Model):
 
     def send_to_shipper(self):
         self.ensure_one()
-        self._set_a_default_package()
+        if self.env.context.get("set_default_package", True):
+            self._set_a_default_package()
         # We consider that label has already been generated in case we have a
         # carrier tracking ref, this way we may print the labels before shipping
         # and not generated in second time during shipment

--- a/base_delivery_carrier_label/tests/test_send.py
+++ b/base_delivery_carrier_label/tests/test_send.py
@@ -1,8 +1,7 @@
 # Copyright 2020 Hunki Enterprises BV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import base64
-
-import mock
+from unittest import mock
 
 from odoo.tests.common import Form, TransactionCase
 

--- a/delivery_carrier_pricelist/tests/test_delivery_pricelist.py
+++ b/delivery_carrier_pricelist/tests/test_delivery_pricelist.py
@@ -92,15 +92,20 @@ class TestRoutePutaway(SavepointCase):
     def test_wizard_send_shipping(self):
         self.create_price_list()
         self.create_wizard()
+        price = self.pricelist_item.fixed_price
         self.carrier_pricelist.invoice_policy = "pricelist"
         delivery_wizard = self.delivery_wizard
         delivery_wizard.carrier_id = self.carrier_pricelist
+        rec = delivery_wizard.save()
+        rec.button_confirm()
         so = self.sale_normal_delivery_charges
         so.action_confirm()
+        self.assertEqual(so.carrier_id, delivery_wizard.carrier_id)
         link = delivery_wizard.carrier_id.get_tracking_link(so.picking_ids)
         self.assertFalse(link)
         result = delivery_wizard.carrier_id.send_shipping(so.picking_ids)
-        self.assertEqual(result, [{"exact_price": 0.0, "tracking_number": False}])
+        expecting = [{"exact_price": price, "tracking_number": False}]
+        self.assertEqual(result, expecting)
 
     def test_fields_view_get(self):
         carrier = self.carrier_pricelist

--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -2,9 +2,12 @@
 # Copyright 2017 Luis M. Ontalba <luis.martinez@tecnativa.com>
 # Copyright 2021 Gianmarco Conte <gconte@dinamicheaziendali.it>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class DeliveryCarrier(models.Model):
@@ -77,33 +80,34 @@ class DeliveryCarrier(models.Model):
         """We have to override this method for redirecting the result to the
         proper "child" carrier.
         """
-        if self.destination_type == "one":
+        # falsy type is considered as one destination
+        if not self.destination_type or self.destination_type == "one":
             return super().send_shipping(pickings)
+        carrier = self.with_context(show_children_carriers=True)
+        res = []
+        for p in pickings:
+            picking_res = False
+            for subcarrier in carrier.child_ids:
+                picking_res = subcarrier._send_shipping_next(p, picking_res)
+            if not picking_res:
+                raise ValidationError(_("There is no matching delivery rule."))
+            res += picking_res
+        return res
+
+    def _send_shipping_next(self, picking, picking_res):
+        if self.delivery_type == "fixed":
+            if self._match_address(picking.partner_id):
+                picking_res = [
+                    {
+                        "exact_price": self.fixed_price,
+                        "tracking_number": False,
+                    }
+                ]
+            # TODO: verify if not match address, previous picking_res (passed
+            # in method's argument) can be used.
         else:
-            carrier = self.with_context(show_children_carriers=True)
-            res = []
-            for p in pickings:
-                picking_res = False
-                for subcarrier in carrier.child_ids:
-                    if subcarrier.delivery_type == "fixed":
-                        if subcarrier._match_address(p.partner_id):
-                            picking_res = [
-                                {
-                                    "exact_price": subcarrier.fixed_price,
-                                    "tracking_number": False,
-                                }
-                            ]
-                            break
-                    else:
-                        try:
-                            picking_res = super(
-                                DeliveryCarrier,
-                                subcarrier,
-                            ).send_shipping(pickings)
-                            break
-                        except Exception:
-                            pass
-                if not picking_res:
-                    raise ValidationError(_("There is no matching delivery rule."))
-                res += picking_res
-            return res
+            try:
+                picking_res = super().send_shipping(picking)
+            except Exception as err:
+                _logger.warning("%s: %s", "_send_shipping_next", str(err))
+        return picking_res

--- a/delivery_package_fee/tests/test_package_fee.py
+++ b/delivery_package_fee/tests/test_package_fee.py
@@ -322,7 +322,7 @@ class TestPackageFee(SavepointCase):
         self.assertEqual(picking.state, "assigned")
         picking.move_line_ids[0].qty_done = 10.0
         picking.move_line_ids[1].qty_done = 10.0
-        picking._action_done()
+        picking.with_context(set_default_package=False)._action_done()
         self.assertEqual(picking.state, "done")
 
         self.assertRecordValues(

--- a/delivery_postlogistics/models/stock_picking.py
+++ b/delivery_postlogistics/models/stock_picking.py
@@ -48,6 +48,7 @@ class StockPicking(models.Model):
         return packages
 
     def get_shipping_label_values(self, label):
+        # TODO: consider to depends on base_delivery_carrier_label
         self.ensure_one()
         return {
             "name": label["name"],
@@ -59,6 +60,8 @@ class StockPicking(models.Model):
 
     def attach_shipping_label(self, label):
         """Attach a label returned by generate_shipping_labels to a picking"""
+        if self.delivery_type != "postlogistics":
+            return super().attach_shipping_label(label)
         self.ensure_one()
         data = self.get_shipping_label_values(label)
         context_attachment = self.env.context.copy()
@@ -76,6 +79,7 @@ class StockPicking(models.Model):
         """Pickings using this module must have a package
         If not this method put it one silently
         """
+        # TODO: consider to depends on base_delivery_carrier_label
         for picking in self:
             move_lines = picking.move_line_ids.filtered(
                 lambda s: not (s.package_id or s.result_package_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # generated from manifests external_dependencies
+PyPDF2
 roulier
 unidecode
 zeep


### PR DESCRIPTION
Add check when no carrier assigned on picking
Fix `import mock `
Merge with [PR#458](https://github.com/OCA/delivery-carrier/pull/458) to improve and fix conflict
* Fix `_set_default_package` from `base_delivery_carrier_label`
* Fix `delivery_carrier_pricelist` module test
* Fix  `delivery_package_fee` module test
* Add `delivery_type` check in `delivery_postlogistics`
* Add `delivery_type` check in `delivery_multi_destination`