### PR TITLE
[14.0][IMP] delivery_schenker: Return expected dict instead of error

### DIFF
--- a/delivery_schenker/models/delivery_carrier.py
+++ b/delivery_schenker/models/delivery_carrier.py
@@ -561,13 +561,20 @@ class DeliveryCarrier(models.Model):
 
     def schenker_rate_shipment(self, order):
         """There's no public API so another price method should be used."""
-        raise NotImplementedError(
-            _(
+        return {
+            "success": True,
+            "price": self.product_id.lst_price,
+            "error_message": _(
                 "Schenker API doesn't provide methods to compute delivery "
                 "rates, so you should relay on another price method instead or "
                 "override this one in your custom code."
-            )
-        )
+            ),
+            "warning_message": _(
+                "Schenker API doesn't provide methods to compute delivery "
+                "rates, so you should relay on another price method instead or "
+                "override this one in your custom code."
+            ),
+        }
 
     # UX Control over not implemented features.
 


### PR DESCRIPTION
Avoid errors when trying to rate the shipment, not returning the `dict` properly makes it unusable for website created orders, when practically the price can just be edited on the sale order if it needs to be customised rather than block the whole creation