### PR TITLE
[13.0][FIX] delivery_auto_refresh: behave as core

### DIFF
--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -13,14 +13,13 @@ class SaleOrder(models.Model):
         compute="_compute_carrier_id", store=True, readonly=False
     )
 
-    @api.depends("partner_id")
+    @api.depends("partner_id", "partner_shipping_id")
     def _compute_carrier_id(self):
         if hasattr(super(), "_compute_carrier_id"):
             super()._compute_carrier_id()
-        for rec in self:
-            if rec.partner_id:
-                if rec.partner_id.property_delivery_carrier_id:
-                    rec.carrier_id = rec.partner_id.property_delivery_carrier_id
+        for order in self:
+            action = order.action_open_delivery_wizard()
+            order.carrier_id = action["context"]["default_carrier_id"]
 
     def _get_param_auto_add_delivery_line(self):
         get_param = self.env["ir.config_parameter"].sudo().get_param

--- a/delivery_multi_destination/tests/test_delivery_multi_destination.py
+++ b/delivery_multi_destination/tests/test_delivery_multi_destination.py
@@ -145,8 +145,8 @@ class TestDeliveryMultiDestination(common.SavepointCase):
         sale_order_line = order.order_line.filtered("is_delivery")
         self.assertAlmostEqual(sale_order_line.price_unit, 100, 2)
         self.assertTrue(sale_order_line.is_delivery)
-        order.carrier_id = self.carrier_multi.id
         order.partner_shipping_id = self.partner_2.id
+        order.carrier_id = self.carrier_multi.id
         delivery_wizard = Form(
             self.env["choose.delivery.carrier"].with_context(
                 {
@@ -161,6 +161,7 @@ class TestDeliveryMultiDestination(common.SavepointCase):
         self.assertAlmostEqual(sale_order_line.price_unit, 50, 2)
         self.assertTrue(sale_order_line.is_delivery)
         order.partner_shipping_id = self.partner_3.id
+        order.carrier_id = self.carrier_multi
         delivery_wizard = Form(
             self.env["choose.delivery.carrier"].with_context(
                 {
@@ -195,8 +196,8 @@ class TestDeliveryMultiDestination(common.SavepointCase):
 
     def test_picking_validation(self):
         """Test a complete sales flow with picking."""
-        self.sale_order.carrier_id = self.carrier_multi.id
         self.sale_order.partner_shipping_id = self.partner_2.id
+        self.sale_order.carrier_id = self.carrier_multi.id
         self.sale_order.action_confirm()
         picking = self.sale_order.picking_ids
         self.assertEqual(picking.carrier_id, self.carrier_multi)


### PR DESCRIPTION
We should get as the same default carrier as Odoo does.

cc @Tecnativa TT34020

ping @CarlosRoca13 @pedrobaeza 