### PR TITLE
[14.0][FIX] delivery_postlogistics: fix split on bool

### DIFF
--- a/delivery_postlogistics/models/product_packaging.py
+++ b/delivery_postlogistics/models/product_packaging.py
@@ -16,4 +16,6 @@ class ProductPackaging(models.Model):
         Return the list of packaging codes
         """
         self.ensure_one()
-        return [code.strip() for code in self.shipper_package_code.split(",")]
+        if self.shipper_package_code:
+            return [code.strip() for code in self.shipper_package_code.split(",")]
+        return []

--- a/delivery_postlogistics/tests/__init__.py
+++ b/delivery_postlogistics/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_postlogistics
 from . import test_sanitize_values
+from . import test_packaging_code

--- a/delivery_postlogistics/tests/test_packaging_code.py
+++ b/delivery_postlogistics/tests/test_packaging_code.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import Form, SavepointCase
+
+PACKAGE_CODE = "blah-biddy, bloo-blah, blah-blah-biddy, bloo-blah"
+EXPECTED_CODES = ["blah-biddy", "bloo-blah", "blah-blah-biddy", "bloo-blah"]
+
+
+class TestPackagingCode(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPackagingCode, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.carrier = cls.env.ref("delivery.delivery_carrier")
+        cls.carrier.delivery_type = "postlogistics"
+        cls.packaging = cls.env["product.packaging"].create(
+            {
+                "name": "Packaging Test",
+                "product_id": cls.env.ref("product.product_delivery_01").id,
+                "qty": 5,
+            }
+        )
+
+    def test_shipper_package_code_get_packaging_code(self):
+        # If no shipper_package_code is set on the packaging then
+        # _get_packaging_codes should return []
+        with Form(self.packaging) as packaging:
+            packaging.package_carrier_type = False
+        self.assertEqual(self.packaging._get_packaging_codes(), [])
+        # case 2: type is set, but no matching carrier is found
+        # _get_packaging_codes returns []
+        with Form(self.packaging) as packaging:
+            packaging.package_carrier_type = "none"
+        self.assertEqual(self.packaging._get_packaging_codes(), [])
+        # case 3: When package_carrier_type is set, shipper_package_code is
+        # computed, and _get_packaging_codes should return the expected codes
+        with Form(self.packaging) as packaging:
+            packaging.package_carrier_type = self.carrier.delivery_type
+            packaging.shipper_package_code = PACKAGE_CODE
+        self.assertEqual(self.packaging._get_packaging_codes(), EXPECTED_CODES)


### PR DESCRIPTION
When a packaging doesn't have a `shipper_package_code`, calling `_get_packaging_codes` on it raises an exception.