### PR TITLE
[12.0][IMP] delivery_carrier_label_ups: InvoiceLineTotal/MonetaryValue must be greater than 0

### DIFF
--- a/delivery_carrier_label_ups/tests/__init__.py
+++ b/delivery_carrier_label_ups/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_delivery_carrier_label_ups
+from . import test_invoice_line_total

--- a/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
+++ b/delivery_carrier_label_ups/tests/test_delivery_carrier_label_ups.py
@@ -210,3 +210,11 @@ class TestDeliveryCarrierLabelUps(
         )
         return_picking.carrier_id = self._get_carrier()
         self.assertTrue(return_picking.show_label_button)
+
+    def test_no_invoice_line_total(self):
+        """ InvoiceLineTotal is not present in request payload
+        when shipments destination is not Puerto Rico nor Canada.
+        """
+        self.assertNotIn(self.picking.partner_id.country_id.code, ["CA", "PR"])
+        shipping_data = self.picking._ups_shipping_data()['ShipmentRequest']
+        self.assertNotIn('InvoiceLineTotal', shipping_data['Shipment'])

--- a/delivery_carrier_label_ups/tests/test_invoice_line_total.py
+++ b/delivery_carrier_label_ups/tests/test_invoice_line_total.py
@@ -1,0 +1,63 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from .test_delivery_carrier_label_ups import DeliveryCarrierLabelUpsCase
+
+
+class InvoiceLineDataUps(DeliveryCarrierLabelUpsCase):
+
+    def _partner_data(self):
+        """ Set Canada as destination country """
+        result = super()._partner_data()
+        result["country_id"] = self.env.ref("base.ca").id
+        return result
+
+    def _order_line_data(self):
+        """ Set order line quantity to 3 and add another line. """
+        result = super()._order_line_data()
+        result[0]["product_uom_qty"] = 3
+        new_product = self.env["product.product"].create({
+            "name": "Test product2",
+            "type": "product",
+            "standard_price": 7.0,
+            "lst_price": 10.0,
+        })
+        result.append({
+            "product_id": new_product.id,
+            "product_uom_qty": 2,
+        })
+        return result
+
+    def _product_data(self):
+        """ Set a price for product to be shipped """
+        result = super()._product_data()
+        if result["name"] == "Carrier test product":
+            result["standard_price"] = 100.0
+            result["lst_price"] = 123.4
+        return result
+
+    def test_invoice_line_total(self):
+        """ InvoiceLineTotal is Required for forward shipments
+        whose origin is the US and destination is Puerto Rico or Canada.
+        """
+
+        # in the order check the product price
+        order_line_product = self.order.order_line.mapped("product_id").filtered(
+            lambda p: p.name == "Carrier test product")
+        self.assertEqual(len(order_line_product), 1)
+        self.assertEqual(order_line_product.standard_price, 100.0)
+        self.assertEqual(order_line_product.lst_price, 123.4)
+
+        # check from/to countries
+        self.assertEqual(self.picking.partner_id.country_id.code, "CA")
+        warehouse = self.picking.picking_type_id.warehouse_id
+        self.assertEqual(warehouse.company_id.partner_id.country_id.code, "US")
+
+        # check payload (InvoiceLineTotal is present)
+        shipping_data = self.picking._ups_shipping_data()['ShipmentRequest']
+        ship_from_address = shipping_data['Shipment']['ShipFrom']['Address']
+        self.assertEqual(ship_from_address['CountryCode'], "US")
+        ship_to_address = shipping_data['Shipment']['ShipTo']['Address']
+        self.assertEqual(ship_to_address['CountryCode'], "CA")
+        invoice_line_total = shipping_data['Shipment']['InvoiceLineTotal']
+        self.assertEqual(invoice_line_total['CurrencyCode'], "USD")
+        self.assertEqual(invoice_line_total['MonetaryValue'], "390.2")


### PR DESCRIPTION
When shipping from US to Canada, following error is raised:

`120502 InvoiceLineTotal/MonetaryValue must be greater than 0`

 

This PR implements what is described in the UPS official documentation, regarding field `InvoiceLineTotal`:

- represents the "Container to hold InvoiceLineTotal Information".

- is Required for forward shipments whose origin is the US and destination is Puerto Rico or Canada.


Steps for testing the described scenario:

- In UPS delivery method enable the debug logging

- Make a shipment from US to Canada with UPS

- Get the UPS shipment label

- Verify that the label is created and 120502 error is not raised

- Verify that the communicated InvoiceLineTotal amount is the correct amount. To check what the communicated data was, go to: Settings > Database Structure > Logging.