### PR TITLE
[FIX] Always add postlogistics_office to customer data

### DIFF
--- a/delivery_carrier_label_postlogistics/postlogistics/web_service.py
+++ b/delivery_carrier_label_postlogistics/postlogistics/web_service.py
@@ -227,12 +227,8 @@ class PostlogisticsWebService(object):
             'ZIP': partner.zip,
             'City': partner.city,
             'Country': partner.country_id.code,
+            'DomicilePostOffice': company.postlogistics_office or "",
         }
-        if (
-            picking.picking_type_id.code == 'outgoing'
-            and company.postlogistics_office
-        ):
-            customer['DomicilePostOffice'] = company.postlogistics_office
 
         if partner.parent_id and partner.parent_id.name != partner_name:
             customer['Name2'] = customer.get('Name1')


### PR DESCRIPTION
due to https://github.com/OCA/delivery-carrier/pull/183/files postlogistics_office was added to customer data only in case of outgoing pickings. With this setup API returns code "E2002: A domicile post office must be provided" which is preventing correct label generation.
