### PR TITLE
[FIX] delivery_auto_refresh: avoid singleton

### DIFF
--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -61,7 +61,7 @@ class SaleOrder(models.Model):
             for order in self:
                 delivery_line = order.order_line.filtered("is_delivery")
                 order.with_context(
-                    delivery_discount=delivery_line.discount,
+                    delivery_discount=delivery_line[-1:].discount,
                 )._auto_refresh_delivery()
         return res
 


### PR DESCRIPTION
If there were more than one delivery line, we'd get a singleton error
when trying to refresh due to the need of taking the discount of the
former lines.

cc @Tecnativa TT35025

please review @pedrobaeza @victoralmau 