### PR TITLE
[FIX] delivery_auto_refresh: don't allow to pick a not allowed carrier

### DIFF
--- a/delivery_auto_refresh/views/sale_order_views.xml
+++ b/delivery_auto_refresh/views/sale_order_views.xml
@@ -7,7 +7,11 @@
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//field[@name='payment_term_id']" position='after'>
-                    <field name="carrier_id" />
+                    <field name="available_carrier_ids" invisible="1" />
+                    <field
+                        name="carrier_id"
+                        domain="[('id', 'in', available_carrier_ids)]"
+                    />
                 </xpath>
             </data>
         </field>


### PR DESCRIPTION
When choosing the sale carrier from the header of the order form we
should filter those carriers not available for the given shipping
address the in the same way the wizard does it.

cc @Tecnativa TT35200

please review @victoralmau @pedrobaeza 