### PR TITLE
[IMP] delivery_ups_oca: add insurance and service package options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.7
   node: "14.13.0"
 repos:
   - repo: local

--- a/delivery_ups_oca/__manifest__.py
+++ b/delivery_ups_oca/__manifest__.py
@@ -16,7 +16,12 @@
         "delivery_package_number",
         "delivery_price_method",
         "delivery_state",
+        "sale_stock",
     ],
-    "data": ["data/product_packaging_data.xml", "views/delivery_carrier_view.xml"],
+    "data": [
+        "data/product_packaging_data.xml",
+        "views/delivery_carrier_view.xml",
+        "views/stock_picking_views.xml",
+    ],
     "demo": [],
 }

--- a/delivery_ups_oca/i18n/delivery_ups_oca.pot
+++ b/delivery_ups_oca/i18n/delivery_ups_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-19 10:31+0000\n"
+"PO-Revision-Date: 2022-03-19 10:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -59,6 +61,11 @@ msgid "Economy Mail Innovations"
 msgstr ""
 
 #. module: delivery_ups_oca
+#: model_terms:ir.ui.view,arch_db:delivery_ups_oca.view_delivery_carrier_form
+msgid "Insurance"
+msgstr ""
+
+#. module: delivery_ups_oca
 #: model:ir.model.fields.selection,name:delivery_ups_oca.selection__delivery_carrier__ups_service_code__08
 msgid "Expedited"
 msgstr ""
@@ -99,10 +106,21 @@ msgid "IN"
 msgstr ""
 
 #. module: delivery_ups_oca
+#: model:ir.model.fields,help:delivery_ups_oca.field_delivery_carrier__ups_negotiated_rates
+msgid "If checked, negotiated rates are used instead of total charges"
+msgstr ""
+
+#. module: delivery_ups_oca
 #: model:ir.model.fields,help:delivery_ups_oca.field_delivery_carrier__ups_tracking_state_update_sync
 msgid ""
 "If checked, odoo try to state update from picking according to UPS "
 "webservice (you will necessary to activate tracking API)"
+msgstr ""
+
+#. module: delivery_ups_oca
+#: model:ir.model.fields,help:delivery_ups_oca.field_delivery_carrier__ups_insurance
+#: model:ir.model.fields,help:delivery_ups_oca.field_stock_picking__ups_insurance
+msgid "If checked, we send insurance information to get rate"
 msgstr ""
 
 #. module: delivery_ups_oca
@@ -136,6 +154,17 @@ msgstr ""
 #. module: delivery_ups_oca
 #: model:ir.model.fields.selection,name:delivery_ups_oca.selection__delivery_carrier__ups_service_code__m7
 msgid "Mail Innovations (MI) Returns"
+msgstr ""
+
+#. module: delivery_ups_oca
+#: model:ir.model.fields,field_description:delivery_ups_oca.field_delivery_carrier__ups_negotiated_rates
+msgid "Manage UPS Negotiated Rates"
+msgstr ""
+
+#. module: delivery_ups_oca
+#: model:ir.model.fields,field_description:delivery_ups_oca.field_delivery_carrier__ups_insurance
+#: model:ir.model.fields,field_description:delivery_ups_oca.field_stock_picking__ups_insurance
+msgid "Manage UPS Insurance"
 msgstr ""
 
 #. module: delivery_ups_oca
@@ -215,6 +244,11 @@ msgid "Service"
 msgstr ""
 
 #. module: delivery_ups_oca
+#: model_terms:ir.ui.view,arch_db:delivery_ups_oca.view_delivery_carrier_form
+msgid "Service Package Options"
+msgstr ""
+
+#. module: delivery_ups_oca
 #: model:ir.model.fields,field_description:delivery_ups_oca.field_delivery_carrier__ups_service_code
 msgid "Service code"
 msgstr ""
@@ -225,6 +259,11 @@ msgid "Shipper number"
 msgstr ""
 
 #. module: delivery_ups_oca
+#: model:ir.model.fields,field_description:delivery_ups_oca.field_stock_picking__ups_insurance_value
+msgid "Shipping Declared Value"
+msgstr ""
+
+#. module: delivery_ups_oca
 #: model:ir.model,name:delivery_ups_oca.model_delivery_carrier
 msgid "Shipping Methods"
 msgstr ""
@@ -232,6 +271,11 @@ msgstr ""
 #. module: delivery_ups_oca
 #: model:ir.model.fields,field_description:delivery_ups_oca.field_delivery_carrier__ups_tracking_state_update_sync
 msgid "Tracking state update sync"
+msgstr ""
+
+#. module: delivery_ups_oca
+#: model:ir.model,name:delivery_ups_oca.model_stock_picking
+msgid "Transfer"
 msgstr ""
 
 #. module: delivery_ups_oca

--- a/delivery_ups_oca/models/__init__.py
+++ b/delivery_ups_oca/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import delivery_carrier
 from . import product_packaging
+from . import stock_picking
 from . import ups_request

--- a/delivery_ups_oca/models/delivery_carrier.py
+++ b/delivery_ups_oca/models/delivery_carrier.py
@@ -76,6 +76,14 @@ class DeliveryCarrier(models.Model):
         help="If checked, odoo try to state update from picking according to UPS "
         "webservice (you will necessary to activate tracking API)",
     )
+    ups_insurance = fields.Boolean(
+        string="Manage UPS Insurance",
+        help="If checked, we send insurance information to get rate",
+    )
+    ups_negotiated_rates = fields.Boolean(
+        string="Manage UPS Negotiated Rates",
+        help="If checked, negotiated rates are used instead of total charges",
+    )
 
     def ups_send_shipping(self, pickings):
         return [self.ups_create_shipping(p) for p in pickings]

--- a/delivery_ups_oca/models/stock_picking.py
+++ b/delivery_ups_oca/models/stock_picking.py
@@ -1,0 +1,20 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    ups_insurance = fields.Boolean(
+        string="Manage UPS Insurance",
+        help="If checked, we send insurance information to get rate",
+    )
+    ups_insurance_value = fields.Float(string="Shipping Declared Value",)
+
+    @api.onchange("carrier_id")
+    def _onchange_carrier_id(self):
+        if self.carrier_id.delivery_type == "ups" and self.carrier_id.ups_insurance:
+            self.ups_insurance = self.carrier_id.ups_insurance
+            self.ups_insurance_value = sum(
+                self.mapped("move_lines.sale_line_id.price_subtotal")
+            )

--- a/delivery_ups_oca/readme/CONFIGURE.rst
+++ b/delivery_ups_oca/readme/CONFIGURE.rst
@@ -2,7 +2,7 @@ To configure this module, you need to:
 
 #. Add a carrier account with delivery type ``ups`` and fill in your credentials
 #. Configure in Odoo all required fields of the UPS tab with your account data https://wwwapps.ups.com/ppc/ppc.html (Username WS , Password WS, Access license number, Shipper number, etc)
-#. If yo have "Tracking state update sync" checked all delivery orders state check will be done querying UPS services.
+#. If you have "Tracking state update sync" checked all delivery orders state check will be done querying UPS services.
 
 **NOTE** You need to request an access key from https://www.ups.com/upsdeveloperkit/manageaccesskeys?loc=es_ES
 for using the webservice.

--- a/delivery_ups_oca/readme/CONTRIBUTORS.rst
+++ b/delivery_ups_oca/readme/CONTRIBUTORS.rst
@@ -3,3 +3,6 @@
 
   * Víctor Martínez
   * Pedro M. Baeza
+* `Trey Kilobytes de Soluciones SL <https://www.trey.es>`__:
+
+  * Vicent Cubells

--- a/delivery_ups_oca/readme/ROADMAP.rst
+++ b/delivery_ups_oca/readme/ROADMAP.rst
@@ -1,2 +1,1 @@
 * Support international forms
-* Support package service options

--- a/delivery_ups_oca/readme/USAGE.rst
+++ b/delivery_ups_oca/readme/USAGE.rst
@@ -4,3 +4,7 @@ You have to set the created shipping method in the delivery order to ship:
 * If the shipment creation process fails, a validation error will appear displaying UPS error.
 * When the delivery order is cancelled, it's automatically cancelled too in UPS.
 * If you have "Tracking state update sync" checked in the shipping method, a periodical state check will be done querying UPS services.
+* You can find a section in UPS settings form named `Insurance`, if you want
+  information about insurance to be sent to UPS server.
+* You can find a section in UPS settings form named `Service Package Options`,
+  if you have some negotiated rates with UPS.

--- a/delivery_ups_oca/tests/test_delivery_ups.py
+++ b/delivery_ups_oca/tests/test_delivery_ups.py
@@ -96,6 +96,7 @@ class DeliveryUps(common.SavepointCase):
         self.assertTrue(res["success"])
 
     def test_delivery_carrier_ups_integration(self):
+        self.carrier.prod_environment = True
         self.picking.action_confirm()
         self.picking.action_assign()
         self.picking.send_to_shipper()

--- a/delivery_ups_oca/views/delivery_carrier_view.xml
+++ b/delivery_ups_oca/views/delivery_carrier_view.xml
@@ -57,6 +57,18 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                                 attrs="{'required': [('delivery_type', '=', 'ups')]}"
                             />
                         </group>
+                        <group string="Insurance">
+                            <field
+                                name="ups_insurance"
+                                attrs="{'required': [('delivery_type', '=', 'ups')]}"
+                            />
+                        </group>
+                        <group string="Service Package Options">
+                            <field
+                                name="ups_negotiated_rates"
+                                attrs="{'required': [('delivery_type', '=', 'ups')]}"
+                            />
+                        </group>
                         <group string="Label">
                             <field
                                 name="ups_file_format"

--- a/delivery_ups_oca/views/stock_picking_views.xml
+++ b/delivery_ups_oca/views/stock_picking_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_withcarrier_out_form" model="ir.ui.view">
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form" />
+        <field name="arch" type="xml">
+            <field name="carrier_id" position="after">
+                <field
+                    name="ups_insurance"
+                    attrs="{'invisible': [('delivery_type', '!=', 'ups')]}"
+                />
+                <field
+                    name="ups_insurance_value"
+                    attrs="{'required': [('ups_insurance', '=', True)], 'invisible': ['|', ('delivery_type', '!=', 'ups'), ('ups_insurance', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add insurance option in UPS settings form.
- Add negotiated rates options in UPS settings form.
- User can change insurance value in picking form.
- Updated wrong production URL.
- Add dimensional weight compute in order to send it when no dimensional values are sent.
- Fix incorrect state code.
- Update tests
- Fix error on Canary Island country code (ISO 3166-1)
- Other minor changes