### PR TITLE
[14.0][FIX] base_delivery_carrier: Fix alternative_send_shipping return value

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -16,7 +16,7 @@ class DeliveryCarrier(models.Model):
     )
 
     def alternative_send_shipping(self, pickings):
-        return {}
+        return [{"exact_price": False, "tracking_number": False}]
 
     def default_options(self):
         """Returns default and available options for a carrier"""


### PR DESCRIPTION
Function delivery.carrier.alternative_send_shipping is called by
the override of send_shipping (if the call to its super didn't return
any result) and its result is returned by send_shipping.
However, as send_shipping is called by stock.picking.send_to_shipper
in the delivery module with a slicing operator, a list of at least
one element is expected and returning an empty dictionary is raising
a KeyError.
Instead of returning an empty dictionary, the function
alternative_send_shipping must return a list containing a dictionary
with keys `exact_price` and `tracking_number` because these keys are
used to access the result's values inside send_to_shipper function in
the delivery module.