### PR TITLE
[14.0] delivery_carrier_label_batch: Allow testing labels generation

### DIFF
--- a/delivery_carrier_label_batch/tests/test_generate_labels.py
+++ b/delivery_carrier_label_batch/tests/test_generate_labels.py
@@ -127,13 +127,13 @@ class TestGenerateLabels(common.SavepointCase):
     def test_action_generate_labels(self):
         """Check merging of pdf labels
 
-        We don't test pdf generation as without dependancies the
-        test would fail
+        Test pdf generation without multiple threading
 
         """
         wizard = self.DeliveryCarrierLabelGenerate.with_context(
             active_ids=self.batch.ids, active_model="stock.picking.batch"
-        ).create({})
+        ).create({"generate_new_labels": True})
+
         wizard.action_generate_labels()
 
         attachment = self.env["ir.attachment"].search(

--- a/delivery_carrier_label_batch/wizard/generate_labels.py
+++ b/delivery_carrier_label_batch/wizard/generate_labels.py
@@ -158,6 +158,9 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
 
             # wait for all tasks to be done
             data_queue.join()
+            # empty the cache so the main env doesn't miss any data updates
+            # (parcel tracking numbers...) done by the threads
+            self.invalidate_cache()
 
         # We will not create a partial PDF if some labels weren't
         # generated thus we raise catched exceptions by the workers

--- a/delivery_carrier_label_batch/wizard/generate_labels.py
+++ b/delivery_carrier_label_batch/wizard/generate_labels.py
@@ -138,13 +138,14 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
                 picking = operations[0].picking_id
                 groups.setdefault(picking.id, []).append((pack, picking, label))
 
+        is_in_testing = getattr(threading.current_thread(), "testing", False)
         for group in groups.values():
-            if not getattr(threading.currentThread(), "testing", False):
+            if not is_in_testing:
                 data_queue.put(group)
             else:
                 self._do_generate_labels(group)
 
-        if not getattr(threading.currentThread(), "testing", False):
+        if not is_in_testing:
             # create few workers to parallelize label generation
             num_workers = self._get_num_workers()
             _logger.info("Starting %s workers to generate labels", num_workers)


### PR DESCRIPTION
The threading option doesn't work in test mode but was not tested
because labels were already generated in the test.
Using a condition to use different threads only when test mode
is not activated allows to test label generation.

Requires: #479 