### PR TITLE
[14.0][FIX] base_delivery_carrier_label: avoid duplicating carrier_id

### DIFF
--- a/base_delivery_carrier_label/__manifest__.py
+++ b/base_delivery_carrier_label/__manifest__.py
@@ -6,7 +6,10 @@
     "author": "Camptocamp,Akretion,Odoo Community Association (OCA)",
     "maintainer": "Camptocamp",
     "category": "Delivery",
-    "depends": ["delivery_carrier_info"],
+    "depends": [
+        "delivery",
+        "delivery_carrier_info",
+    ],
     "website": "https://github.com/OCA/delivery-carrier",
     "data": [
         "views/delivery.xml",

--- a/base_delivery_carrier_label/views/stock.xml
+++ b/base_delivery_carrier_label/views/stock.xml
@@ -19,10 +19,10 @@
     </record>
     <record id="vpicktree" model="ir.ui.view">
         <field name="model">stock.picking</field>
-        <field name="inherit_id" ref="stock.vpicktree" />
+        <field name="inherit_id" ref="delivery.vpicktree_view_tree" />
         <field name="arch" type="xml">
-            <field name="state" position="before">
-                <field name="carrier_id" />
+            <field name="carrier_id" position="attributes">
+                <attribute name="optional">show</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
This is to remove duplicated carrier_id.