### PR TITLE
[13.0][FIX] delivery_tnt_oca: Encode data to utf-8 to prevent error in some cases (Šempas for example)

### DIFF
--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -39,10 +39,12 @@ class TntRequest(object):
         if data is None:
             data = {}
         try:
-            headers = {"Content-Type": content_type}
+            headers = {"Content-Type": content_type, "charset": "UTF-8"}
             if auth:
                 headers["Authorization"] = "Basic {}".format(self.authorization)
-            res = requests.post(url=url, data=data, headers=headers, timeout=60)
+            res = requests.post(
+                url=url, data=data.encode("utf-8"), headers=headers, timeout=60
+            )
             res.raise_for_status()
             tnt_last_request = ("URL: {}\nData: {}").format(self.url, data)
             self.carrier.log_xml(tnt_last_request, "tnt_last_request")

--- a/delivery_tnt_oca/views/delivery_carrier_view.xml
+++ b/delivery_tnt_oca/views/delivery_carrier_view.xml
@@ -23,6 +23,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                             />
                             <field
                                 name="tnt_oca_ws_password"
+                                password="True"
                                 attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"
                                 string="Password"
                             />


### PR DESCRIPTION
Encode data to utf-8 to prevent error in some cases (Šempas for example)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT37181