### PR TITLE
[14.0][FIX] delivery_carrier_label_batch: fix re-generating label

### DIFF
--- a/delivery_carrier_label_batch/wizard/generate_labels.py
+++ b/delivery_carrier_label_batch/wizard/generate_labels.py
@@ -87,9 +87,9 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
                     picking_name = _("Picking: %s") % picking.name
                     pack_num = _("Pack: %s") % pack.name if pack else ""
                     # pylint: disable=translation-required
-                    raise exceptions.UserError(
-                        ("%s %s - %s") % (picking_name, pack_num, str(e))
-                    )
+                    msg = ("%s %s - %s") % (picking_name, pack_num, str(e))
+                    _logger.exception(msg)
+                    raise exceptions.UserError(msg)
 
     def _worker(self, data_queue, error_queue):
         """A worker to generate labels


### PR DESCRIPTION
When there are tracking references in pickings and packages, existing labels
will be reused. In order to re-generate label, tracking references should be
cleared.

Depends on:
* #481 