### PR TITLE
[13.0][FIX] delivery_ups_oca: Create label from create_shipping response to avoid error.

### DIFF
--- a/delivery_ups_oca/__manifest__.py
+++ b/delivery_ups_oca/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Hunki Enterprises BV
-# Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021-2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Delivery UPS OCA",
@@ -17,6 +17,9 @@
         "delivery_price_method",
         "delivery_state",
     ],
-    "data": ["data/product_packaging_data.xml", "views/delivery_carrier_view.xml"],
-    "demo": [],
+    "data": [
+        "data/product_packaging_data.xml",
+        "views/delivery_carrier_view.xml",
+        "views/stock_picking_view.xml",
+    ],
 }

--- a/delivery_ups_oca/i18n/delivery_ups_oca.pot
+++ b/delivery_ups_oca/i18n/delivery_ups_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-27 13:57+0000\n"
+"PO-Revision-Date: 2022-06-27 13:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -235,6 +237,11 @@ msgid "Tracking state update sync"
 msgstr ""
 
 #. module: delivery_ups_oca
+#: model:ir.model,name:delivery_ups_oca.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: delivery_ups_oca
 #: model:ir.model.fields.selection,name:delivery_ups_oca.selection__delivery_carrier__delivery_type__ups
 #: model:ir.model.fields.selection,name:delivery_ups_oca.selection__product_packaging__package_carrier_type__ups
 #: model_terms:ir.ui.view,arch_db:delivery_ups_oca.view_delivery_carrier_form
@@ -249,6 +256,11 @@ msgstr ""
 #. module: delivery_ups_oca
 #: model:ir.model.fields.selection,name:delivery_ups_oca.selection__delivery_carrier__ups_service_code__74
 msgid "UPS Express®12:00"
+msgstr ""
+
+#. module: delivery_ups_oca
+#: model_terms:ir.ui.view,arch_db:delivery_ups_oca.view_picking_withcarrier_out_form
+msgid "UPS Label"
 msgstr ""
 
 #. module: delivery_ups_oca
@@ -309,6 +321,11 @@ msgstr ""
 #. module: delivery_ups_oca
 #: model:ir.model.fields.selection,name:delivery_ups_oca.selection__delivery_carrier__ups_service_code__71
 msgid "UPS Worldwide Express Freight Midday"
+msgstr ""
+
+#. module: delivery_ups_oca
+#: model:ir.model.fields,field_description:delivery_ups_oca.field_delivery_carrier__ups_use_packages_from_picking
+msgid "Use packages from picking"
 msgstr ""
 
 #. module: delivery_ups_oca

--- a/delivery_ups_oca/models/__init__.py
+++ b/delivery_ups_oca/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import delivery_carrier
 from . import product_packaging
+from . import stock_picking
 from . import ups_request

--- a/delivery_ups_oca/models/delivery_carrier.py
+++ b/delivery_ups_oca/models/delivery_carrier.py
@@ -55,7 +55,9 @@ class DeliveryCarrier(models.Model):
         string="Service code",
     )
     ups_default_packaging_id = fields.Many2one(
-        comodel_name="product.packaging", string="Default Packaging Type"
+        comodel_name="product.packaging",
+        string="Default Packaging Type",
+        domain=[("package_carrier_type", "=", "ups")],
     )
     ups_package_dimension_code = fields.Selection(
         selection=[("IN", "IN"), ("CM", "CM")],

--- a/delivery_ups_oca/models/stock_picking.py
+++ b/delivery_ups_oca/models/stock_picking.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def ups_get_label(self):
+        self.ensure_one()
+        tracking_ref = self.carrier_tracking_ref
+        if self.delivery_type != "ups" or not tracking_ref:
+            return
+        return self.carrier_id.ups_get_label(tracking_ref)

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -144,6 +144,7 @@ class UpsRequest(object):
                     "ShipTo": self._partner_to_shipping_data(picking.partner_id),
                     "ShipFrom": self._partner_to_shipping_data(
                         picking.picking_type_id.warehouse_id.partner_id
+                        or picking.company_id.partner_id
                     ),
                     "PaymentInformation": {
                         "ShipmentCharge": {
@@ -209,7 +210,7 @@ class UpsRequest(object):
                     ),
                     "ShipTo": self._partner_to_shipping_data(order.partner_shipping_id),
                     "ShipFrom": self._partner_to_shipping_data(
-                        order.warehouse_id.partner_id
+                        order.warehouse_id.partner_id or order.company_id.partner_id
                     ),
                     "Service": {"Code": self.service_code},
                     "Package": packages,

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -63,7 +63,7 @@ class UpsRequest(object):
         PackageWeight = picking.shipping_weight
         if is_package:
             NumOfPieces = sum(package.mapped("quant_ids.quantity"))
-            PackageWeight = package.weight
+            PackageWeight = max(package.shipping_weight, package.weight)
         return {
             "Description": package.name,
             "NumOfPieces": str(NumOfPieces),

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -24,9 +24,9 @@ class UpsRequest(object):
         self.package_dimension_code = self.carrier.ups_package_dimension_code
         self.package_weight_code = self.carrier.ups_package_weight_code
         self.transaction_src = "Odoo (%s)" % self.carrier.name
-        self.url = "https://onlinetools.ups.com"
+        self.url = "https://wwwcie.ups.com"
         if self.carrier.prod_environment:
-            self.url = "https://wwwcie.ups.com"
+            self.url = "https://onlinetools.ups.com"
 
     def _process_reply(
         self, url, data=None, method="post", query_parameters=None,

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -161,6 +161,7 @@ class UpsRequest(object):
         return {
             "price": res["ShipmentCharges"]["TotalCharges"],
             "ShipmentIdentificationNumber": res["ShipmentIdentificationNumber"],
+            "LabelImageFormat": res["PackageResults"]["ShippingLabel"]["ImageFormat"],
             "GraphicImage": res["PackageResults"]["ShippingLabel"]["GraphicImage"],
         }
 

--- a/delivery_ups_oca/views/delivery_carrier_view.xml
+++ b/delivery_ups_oca/views/delivery_carrier_view.xml
@@ -33,6 +33,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                             <field
                                 name="ups_default_packaging_id"
                                 attrs="{'required': [('delivery_type', '=', 'ups')]}"
+                                context="{'default_package_carrier_type': 'ups'}"
                             />
                             <field
                                 name="ups_package_dimension_code"

--- a/delivery_ups_oca/views/delivery_carrier_view.xml
+++ b/delivery_ups_oca/views/delivery_carrier_view.xml
@@ -35,6 +35,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                                 attrs="{'required': [('delivery_type', '=', 'ups')]}"
                                 context="{'default_package_carrier_type': 'ups'}"
                             />
+                            <field name="ups_use_packages_from_picking" />
                             <field
                                 name="ups_package_dimension_code"
                                 attrs="{'required': [('delivery_type', '=', 'ups')]}"
@@ -43,10 +44,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                                 name="ups_package_weight_code"
                                 attrs="{'required': [('delivery_type', '=', 'ups')]}"
                             />
-                            <field
-                                name="ups_tracking_state_update_sync"
-                                attrs="{'required': [('delivery_type', '=', 'ups')]}"
-                            />
+                            <field name="ups_tracking_state_update_sync" />
                         </group>
                         <group string="WS Credentials">
                             <field

--- a/delivery_ups_oca/views/stock_picking_view.xml
+++ b/delivery_ups_oca/views/stock_picking_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright 2022 Tecnativa - Víctor Martínez
+License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="view_picking_withcarrier_out_form" model="ir.ui.view">
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='print_return_label']/.." position='inside'>
+                <button
+                    name="ups_get_label"
+                    string="UPS Label"
+                    type="object"
+                    attrs="{'invisible':[
+                        '|',
+                        '|',
+                        ('carrier_tracking_ref', '=', False),
+                        ('delivery_type', '!=', 'ups'),
+                        ('state', '!=', 'done')
+                    ]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Changes done:
- [x] Create label from create_shipping response to avoid error when trying to get the label right after.
- [x] Set the correct URLs.
- [x] Apply domain to `ups_default_packaging_id` field to show only UPS records.
- [x] Set the correct weight if we use packages.
- [x] Fix packages when `package_ids` is not set
- [x] Add `password="True"` to `ups_ws_password` field.
- [x] Add `ups_use_packages_from_picking` field in carrier to use (or not) package from pickings. 
- [x] Set correct `ShipFrom` (warehouse or company address).
- [x] Improve tests to allow inheritance.

`{'code': '9801031', 'message': 'The shipment for the requested tracking number or the combination of reference number plus shipper number could not be found. Please check the submitted data or wait until the shipment is processed.'}`

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT37248