### PR TITLE
[13.0][FIX] delivery_tnt_oca: Change to .txt extension to prevent printer incompatibilities.

### DIFF
--- a/delivery_tnt_oca/models/delivery_carrier.py
+++ b/delivery_tnt_oca/models/delivery_carrier.py
@@ -135,7 +135,7 @@ class DeliveryCarrier(models.Model):
         res = iar._get_report_from_name(report_name).render_qweb_text(picking.ids)
         return self.env["ir.attachment"].create(
             {
-                "name": "TNT-%s.zpl" % picking.carrier_tracking_ref,
+                "name": "TNT-%s.txt" % picking.carrier_tracking_ref,
                 "type": "binary",
                 "datas": base64.b64encode(res[0]),
                 "res_model": picking._name,


### PR DESCRIPTION
Change to .txt extension to prevent printer incompatibilities.

Please @pedrobaeza and  @chienandalu can you review it?

@Tecnativa TT35954