### PR TITLE
[14.0][FIX] delivery_tnt_oca: Encode data to utf-8 to prevent error in some cases (Šempas for example)

### DIFF
--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -41,10 +41,12 @@ class TntRequest(object):
         tnt_last_request = ("URL: {}\nData: {}").format(self.url, data)
         self.carrier.log_xml(tnt_last_request, "tnt_last_request")
         try:
-            headers = {"Content-Type": content_type}
+            headers = {"Content-Type": content_type, "charset": "UTF-8"}
             if auth:
                 headers["Authorization"] = "Basic {}".format(self.authorization)
-            res = requests.post(url=url, data=data, headers=headers, timeout=60)
+            res = requests.post(
+                url=url, data=data.encode("utf-8"), headers=headers, timeout=60
+            )
             res.raise_for_status()
             self.carrier.log_xml(res.text or "", "tnt_last_response")
             res = res.text


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/delivery-carrier/pull/493

Encode data to utf-8 to prevent error in some cases (Šempas for example)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT37181