### PR TITLE
[14.0] delivery_send_to_shipper_at_operation: keep and split tracking with a comma

### DIFF
--- a/delivery_send_to_shipper_at_operation/models/stock_picking.py
+++ b/delivery_send_to_shipper_at_operation/models/stock_picking.py
@@ -53,7 +53,10 @@ class StockPicking(models.Model):
                 self.delivery_notification_sent = True
                 related_ship.delivery_notification_sent = True
                 related_ship.carrier_price = self.carrier_price
-                related_ship.carrier_tracking_ref = self.carrier_tracking_ref
+                if not related_ship.carrier_tracking_ref:
+                    related_ship.carrier_tracking_ref = self.carrier_tracking_ref
+                else:
+                    related_ship.carrier_tracking_ref += "," + self.carrier_tracking_ref
                 return True
         return False
 


### PR DESCRIPTION
Keeps and splits the tracking in multi pickings.