### PR TITLE
[14.0][IMP] delivery_carrier_label_batch: tracking reference purge when regenerating labels

### DIFF
--- a/delivery_carrier_label_batch/tests/test_generate_labels.py
+++ b/delivery_carrier_label_batch/tests/test_generate_labels.py
@@ -1,6 +1,7 @@
 # Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 import base64
+from unittest.mock import patch
 
 import odoo.tests.common as common
 from odoo import exceptions
@@ -20,6 +21,7 @@ class TestGenerateLabels(common.SavepointCase):
         ShippingLabel = cls.env["shipping.label"]
         BatchPicking = cls.env["stock.picking.batch"]
         cls.DeliveryCarrierLabelGenerate = cls.env["delivery.carrier.label.generate"]
+        cls.PickingBatchApplyCarrier = cls.env["picking.batch.apply.carrier"]
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
         cls.customer_location = cls.env.ref("stock.stock_location_customers")
 
@@ -36,28 +38,56 @@ class TestGenerateLabels(common.SavepointCase):
             cls.productB, cls.stock_location, 20.0
         )
 
-        picking_out_1 = Picking.create(
+        cls.carrier_product = cls.env["product.product"].create(
+            {
+                "name": "Test carrier product",
+                "type": "service",
+            }
+        )
+        cls.carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test carrier",
+                "delivery_type": "fixed",
+                "product_id": cls.carrier_product.id,
+            }
+        )
+        cls.new_carrier_product = cls.env["product.product"].create(
+            {
+                "name": "Test NEW carrier product",
+                "type": "service",
+            }
+        )
+        cls.new_carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test NEW carrier",
+                "delivery_type": "fixed",
+                "product_id": cls.new_carrier_product.id,
+            }
+        )
+        cls.picking_out_1 = Picking.create(
             {
                 "partner_id": cls.env.ref("base.res_partner_12").id,
                 "location_id": cls.stock_location.id,
                 "location_dest_id": cls.customer_location.id,
                 "picking_type_id": cls.env.ref("stock.picking_type_out").id,
+                "carrier_id": cls.carrier.id,
             }
         )
 
-        picking_out_2 = Picking.create(
+        cls.picking_out_2 = Picking.create(
             {
                 "partner_id": cls.env.ref("base.res_partner_12").id,
                 "location_id": cls.stock_location.id,
                 "location_dest_id": cls.customer_location.id,
                 "picking_type_id": cls.env.ref("stock.picking_type_out").id,
+                "carrier_id": cls.carrier.id,
             }
         )
 
         move1 = Move.create(
             {
                 "name": "/",
-                "picking_id": picking_out_1.id,
+                "picking_id": cls.picking_out_1.id,
                 "product_id": cls.productA.id,
                 "product_uom": cls.env.ref("uom.product_uom_unit").id,
                 "product_uom_qty": 2,
@@ -69,7 +99,7 @@ class TestGenerateLabels(common.SavepointCase):
         move2 = Move.create(
             {
                 "name": "/",
-                "picking_id": picking_out_2.id,
+                "picking_id": cls.picking_out_2.id,
                 "product_id": cls.productB.id,
                 "product_uom": cls.env.ref("uom.product_uom_unit").id,
                 "product_uom_qty": 1,
@@ -81,7 +111,7 @@ class TestGenerateLabels(common.SavepointCase):
         cls.batch = BatchPicking.create(
             {
                 "name": "demo_prep001",
-                "picking_ids": [(4, picking_out_1.id), (4, picking_out_2.id)],
+                "picking_ids": [(4, cls.picking_out_1.id), (4, cls.picking_out_2.id)],
                 "use_oca_batch_validation": True,
             }
         )
@@ -92,37 +122,35 @@ class TestGenerateLabels(common.SavepointCase):
         move1.move_line_ids[0].qty_done = 2
         move2.move_line_ids[0].qty_done = 2
 
-        picking_out_1.action_put_in_pack()
-        picking_out_2.action_put_in_pack()
+        cls.picking_out_1._set_a_default_package()
+        cls.picking_out_2._set_a_default_package()
 
-        label = ""
         dummy_pdf_path = get_module_resource(
             "delivery_carrier_label_batch", "tests", "dummy.pdf"
         )
         with open(dummy_pdf_path, "rb") as dummy_pdf:
             label = dummy_pdf.read()
+            cls.shipping_label_1 = ShippingLabel.create(
+                {
+                    "name": "picking_out_1",
+                    "res_id": cls.picking_out_1.id,
+                    "package_id": move1.move_line_ids[0].result_package_id.id,
+                    "res_model": "stock.picking",
+                    "datas": base64.b64encode(label),
+                    "file_type": "pdf",
+                }
+            )
 
-        ShippingLabel.create(
-            {
-                "name": "picking_out_1",
-                "res_id": picking_out_1.id,
-                "package_id": move1.move_line_ids[0].result_package_id.id,
-                "res_model": "stock.picking",
-                "datas": base64.b64encode(label),
-                "file_type": "pdf",
-            }
-        )
-
-        ShippingLabel.create(
-            {
-                "name": "picking_out_2",
-                "res_id": picking_out_2.id,
-                "package_id": move2.move_line_ids[0].result_package_id.id,
-                "res_model": "stock.picking",
-                "datas": base64.b64encode(label),
-                "file_type": "pdf",
-            }
-        )
+            cls.shipping_label_2 = ShippingLabel.create(
+                {
+                    "name": "picking_out_2",
+                    "res_id": cls.picking_out_2.id,
+                    "package_id": move2.move_line_ids[0].result_package_id.id,
+                    "res_model": "stock.picking",
+                    "datas": base64.b64encode(label),
+                    "file_type": "pdf",
+                }
+            )
 
     def test_action_generate_labels(self):
         """Check merging of pdf labels
@@ -157,3 +185,63 @@ class TestGenerateLabels(common.SavepointCase):
         ).create({})
         with self.assertRaises(exceptions.UserError):
             wizard.action_generate_labels()
+
+    def test_action_regenerate_labels(self):
+        """Check re-generating labels"""
+        wizard = self.DeliveryCarrierLabelGenerate.with_context(
+            active_ids=self.batch.ids, active_model="stock.picking.batch"
+        ).create({"generate_new_labels": True})
+        with patch.object(
+            type(self.carrier), "fixed_send_shipping"
+        ) as fixed_send_shipping:
+            fixed_send_shipping.return_value = [
+                {
+                    "exact_price": 1.0,
+                    "tracking_number": "TEST00001",
+                }
+            ]
+            with patch.object(
+                type(self.batch), "purge_tracking_references"
+            ) as purge_tracking_references:
+                wizard.action_generate_labels()
+                purge_tracking_references.assert_called()
+
+            attachment = self.env["ir.attachment"].search(
+                [
+                    ("res_model", "=", "stock.picking.batch"),
+                    ("res_id", "=", self.batch.id),
+                ]
+            )
+
+            self.assertEqual(len(attachment), 1)
+            self.assertTrue(attachment.datas)
+            self.assertEqual(attachment.name, "demo_prep001.pdf")
+            self.assertEqual(attachment.mimetype, "application/pdf")
+            self.assertEqual(self.picking_out_1.carrier_tracking_ref, "TEST00001")
+            self.assertEqual(self.picking_out_2.carrier_tracking_ref, "TEST00001")
+
+    def test_batch_purge_tracking_reference(self):
+        """Unittest: check that tracking reference purge work as expected"""
+        self.batch.purge_tracking_references()
+        self.assertTrue(
+            all(
+                [
+                    not p.parcel_tracking
+                    for p in self.batch.move_line_ids.result_package_id
+                ]
+            )
+        )
+        pickings = [self.picking_out_1, self.picking_out_2]
+        self.assertTrue(all([not p.carrier_tracking_ref for p in pickings]))
+
+    def test_action_change_carrier_purge_tracking_reference(self):
+        """Functional: Check purge_tracking_reference is called as carrier is
+        changed from wizard"""
+        wizard = self.PickingBatchApplyCarrier.with_context(
+            active_ids=self.batch.ids
+        ).create({"carrier_id": self.new_carrier.id})
+        with patch.object(
+            type(self.batch), "purge_tracking_references"
+        ) as purge_tracking_references:
+            wizard.apply()
+            purge_tracking_references.assert_called()

--- a/delivery_carrier_label_batch/wizard/generate_labels.py
+++ b/delivery_carrier_label_batch/wizard/generate_labels.py
@@ -87,9 +87,9 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
                     picking_name = _("Picking: %s") % picking.name
                     pack_num = _("Pack: %s") % pack.name if pack else ""
                     # pylint: disable=translation-required
-                    raise exceptions.UserError(
-                        ("%s %s - %s") % (picking_name, pack_num, e)
-                    )
+                    msg = ("%s %s - %s") % (picking_name, pack_num, str(e))
+                    _logger.exception(msg)
+                    raise exceptions.UserError(msg)
 
     def _worker(self, data_queue, error_queue):
         """A worker to generate labels
@@ -251,6 +251,8 @@ class DeliveryCarrierLabelGenerate(models.TransientModel):
             to_generate = to_generate.filtered(
                 lambda rec: rec.id not in already_generated_ids
             )
+        else:
+            to_generate.purge_tracking_references()
 
         for batch in to_generate:
             labels = self._get_all_files(batch)


### PR DESCRIPTION
Sometimes, when regenerating labels from third party API, we could not get the new tracking references. And then as we do not purge tracking references correctly, previous ones are kept and lead to incoherences (batch picking tracking references emptied but labels still existing). For this we need to manually purge references AND labels when asking for full regeneration.

Depends on:

- https://github.com/OCA/delivery-carrier/pull/481