### PR TITLE
[14.0][IMP] delivery_tnt_oca: Add pieceLine info from rate_shipment request + Round some data to 2 decimal places

### DIFF
--- a/delivery_tnt_oca/__manifest__.py
+++ b/delivery_tnt_oca/__manifest__.py
@@ -17,6 +17,7 @@
     ],
     "external_dependencies": {"python": ["dicttoxml", "xmltodict"]},
     "data": [
+        "data/product_packaging_data.xml",
         "views/delivery_carrier_view.xml",
         "report/picking_templates.xml",
         "report/stock_report_views.xml",

--- a/delivery_tnt_oca/data/product_packaging_data.xml
+++ b/delivery_tnt_oca/data/product_packaging_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Tecnativa - Víctor Martínez
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_packaging_tnt_default" model="product.packaging">
+        <field name="name">TNT Default (cm)</field>
+        <field name="package_carrier_type">tnt_oca</field>
+        <field name="length">35</field>
+        <field name="width">35</field>
+        <field name="height">35</field>
+    </record>
+</odoo>

--- a/delivery_tnt_oca/data/product_packaging_data.xml
+++ b/delivery_tnt_oca/data/product_packaging_data.xml
@@ -5,7 +5,7 @@
     <record id="product_packaging_tnt_default" model="product.packaging">
         <field name="name">TNT Default (cm)</field>
         <field name="package_carrier_type">tnt_oca</field>
-        <field name="length">35</field>
+        <field name="packaging_length">35</field>
         <field name="width">35</field>
         <field name="height">35</field>
     </record>

--- a/delivery_tnt_oca/i18n/delivery_tnt_oca.pot
+++ b/delivery_tnt_oca/i18n/delivery_tnt_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-27 14:10+0000\n"
+"PO-Revision-Date: 2022-06-27 14:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -76,6 +78,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:delivery_tnt_oca.field_product_packaging__display_name
 #: model:ir.model.fields,field_description:delivery_tnt_oca.field_stock_picking__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields,field_description:delivery_tnt_oca.field_delivery_carrier__tnt_default_packaging_id
+msgid "Default Packaging Type"
 msgstr ""
 
 #. module: delivery_tnt_oca
@@ -342,6 +349,11 @@ msgstr ""
 #. module: delivery_tnt_oca
 #: model:ir.model,name:delivery_tnt_oca.model_stock_picking
 msgid "Transfer"
+msgstr ""
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields,field_description:delivery_tnt_oca.field_delivery_carrier__tnt_use_packages_from_picking
+msgid "Use packages from picking"
 msgstr ""
 
 #. module: delivery_tnt_oca

--- a/delivery_tnt_oca/i18n/es.po
+++ b/delivery_tnt_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-04 15:09+0000\n"
-"PO-Revision-Date: 2021-11-04 16:10+0100\n"
+"POT-Creation-Date: 2022-06-27 14:10+0000\n"
+"PO-Revision-Date: 2022-06-27 16:11+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -79,6 +79,11 @@ msgstr "Hora de recogida fin"
 #: model_terms:ir.ui.view,arch_db:delivery_tnt_oca.view_delivery_carrier_tnt_oca_form
 msgid "Credentials"
 msgstr "Credenciales"
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields,field_description:delivery_tnt_oca.field_delivery_carrier__tnt_default_packaging_id
+msgid "Default Packaging Type"
+msgstr "Tipo de paquete por defecto"
 
 #. module: delivery_tnt_oca
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_type__d
@@ -331,6 +336,11 @@ msgstr "Datos de pieza de TNT"
 #: model:ir.model,name:delivery_tnt_oca.model_stock_picking
 msgid "Transfer"
 msgstr "Albarán"
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields,field_description:delivery_tnt_oca.field_delivery_carrier__tnt_use_packages_from_picking
+msgid "Use packages from picking"
+msgstr "Usar paquetes de picking"
 
 #. module: delivery_tnt_oca
 #: model_terms:ir.ui.view,arch_db:delivery_tnt_oca.view_delivery_carrier_tnt_oca_form

--- a/delivery_tnt_oca/models/delivery_carrier.py
+++ b/delivery_tnt_oca/models/delivery_carrier.py
@@ -86,7 +86,9 @@ class DeliveryCarrier(models.Model):
     tnt_collect_time_from = fields.Float(default=10.5, string="Collect time from")
     tnt_collect_time_to = fields.Float(default=16, string="Collect time to")
     tnt_default_packaging_id = fields.Many2one(
-        comodel_name="product.packaging", string="Default Packaging Type"
+        comodel_name="product.packaging",
+        string="Default Packaging Type",
+        domain=[("package_carrier_type", "=", "tnt_oca")],
     )
 
     @api.depends("delivery_type", "tnt_product_type")

--- a/delivery_tnt_oca/models/delivery_carrier.py
+++ b/delivery_tnt_oca/models/delivery_carrier.py
@@ -85,6 +85,9 @@ class DeliveryCarrier(models.Model):
     )
     tnt_collect_time_from = fields.Float(default=10.5, string="Collect time from")
     tnt_collect_time_to = fields.Float(default=16, string="Collect time to")
+    tnt_default_packaging_id = fields.Many2one(
+        comodel_name="product.packaging", string="Default Packaging Type"
+    )
 
     @api.depends("delivery_type", "tnt_product_type")
     def _compute_tnt_product_code(self):

--- a/delivery_tnt_oca/models/delivery_carrier.py
+++ b/delivery_tnt_oca/models/delivery_carrier.py
@@ -90,6 +90,7 @@ class DeliveryCarrier(models.Model):
         string="Default Packaging Type",
         domain=[("package_carrier_type", "=", "tnt_oca")],
     )
+    tnt_use_packages_from_picking = fields.Boolean(string="Use packages from picking")
 
     @api.depends("delivery_type", "tnt_product_type")
     def _compute_tnt_product_code(self):

--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -28,6 +28,7 @@ class TntRequest(object):
         self.password = self.carrier.tnt_oca_ws_password
         self.account = self.carrier.tnt_oca_ws_account
         self.default_packaging_id = self.carrier.tnt_default_packaging_id
+        self.use_packages_from_picking = self.carrier.tnt_use_packages_from_picking
         self.url = "https://express.tnt.com"
         auth_encoding = "%s:%s" % (self.username, self.password)
         self.authorization = base64.b64encode(auth_encoding.encode("utf-8")).decode(
@@ -200,7 +201,7 @@ class TntRequest(object):
 
     def _get_data_total_shipping(self):
         weight = self.record.shipping_weight
-        if self.record.package_ids:
+        if self.use_packages_from_picking and self.record.package_ids:
             height = sum(self.record.package_ids.mapped("height"))
             width = sum(self.record.package_ids.mapped("width"))
             p_length = sum(self.record.package_ids.mapped("length"))

--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -103,7 +103,8 @@ class TntRequest(object):
             "priceCheck": {
                 "rateId": self.record.name,
                 "sender": self._partner_to_shipping_data(
-                    self.record.company_id.partner_id
+                    self.record.warehouse_id.partner_id
+                    or self.record.company_id.partner_id
                 ),
                 "delivery": self._partner_to_shipping_data(
                     self.record.partner_shipping_id
@@ -223,7 +224,10 @@ class TntRequest(object):
         }
 
     def _prepare_create_shipping(self):
-        receiver = self._prepare_address(self.record.company_id.partner_id)
+        receiver = self._prepare_address(
+            self.record.picking_type_id.warehouse_id.partner_id
+            or self.record.company_id.partner_id
+        )
         del receiver["ACCOUNT"]
         delivery = self._prepare_address(self.record.partner_id)
         del delivery["ACCOUNT"]

--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021-2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import base64
 import json
@@ -27,6 +27,7 @@ class TntRequest(object):
         self.username = self.carrier.tnt_oca_ws_username
         self.password = self.carrier.tnt_oca_ws_password
         self.account = self.carrier.tnt_oca_ws_account
+        self.default_packaging_id = self.carrier.tnt_default_packaging_id
         self.url = "https://express.tnt.com"
         auth_encoding = "%s:%s" % (self.username, self.password)
         self.authorization = base64.b64encode(auth_encoding.encode("utf-8")).decode(
@@ -82,13 +83,19 @@ class TntRequest(object):
 
     def _prepare_rate_shipment(self):
         totalWeight = 0
-        totalVolume = 0
-        for line in self.record.order_line.filtered(
-            lambda x: x.product_id
-            and (x.product_id.weight > 0 or x.product_id.volume > 0)
-        ):
-            totalWeight += line.product_id.weight * line.product_uom_qty
-            totalVolume += line.product_id.volume * line.product_uom_qty
+        lines = self.record.order_line.filtered(
+            lambda x: x.product_id and x.product_id.weight > 0
+        )
+        for line in lines:
+            weight_line = line.product_id.weight
+            totalWeight += weight_line * line.product_uom_qty
+        # Set totalVolume (in cm, we need to convert to m)
+        height = self.default_packaging_id.height / 100
+        width = self.default_packaging_id.width / 100
+        p_length = self.default_packaging_id.length / 100
+        totalVolume = height * width * p_length
+        # Set 0.1 as the minimum value of the volume
+        totalVolume = max(totalVolume, 0.01)
         data = {
             "appId": "PC",
             "appVersion": self.appVersion,
@@ -106,8 +113,8 @@ class TntRequest(object):
                 "currency": self.record.currency_id.name,
                 "priceBreakDown": True,
                 "consignmentDetails": {
-                    "totalWeight": totalWeight,
-                    "totalVolume": totalVolume,
+                    "totalWeight": round(totalWeight, 2),
+                    "totalVolume": round(totalVolume, 2),
                     "totalNumberOfPieces": 1,
                 },
             },
@@ -193,27 +200,25 @@ class TntRequest(object):
 
     def _get_data_total_shipping(self):
         weight = self.record.shipping_weight
-        volume = p_length = height = width = 0
         if self.record.package_ids:
-            weight = sum(self.record.package_ids.mapped("quant_ids.quantity"))
-            height = max(self.record.package_ids.mapped("height"))
-            width = max(self.record.package_ids.mapped("width"))
-            p_length = max(self.record.package_ids.mapped("length"))
-            for quant in self.record.package_ids.mapped("quant_ids"):
-                volume += quant.product_id.volume * quant.quantity
+            height = sum(self.record.package_ids.mapped("height"))
+            width = sum(self.record.package_ids.mapped("width"))
+            p_length = sum(self.record.package_ids.mapped("length"))
         else:
-            lines = self.record.move_line_ids_without_package
-            for line in lines.filtered(lambda x: x.qty_done > 0):
-                volume += line.product_id.volume * line.qty_done
-                p_length += line.product_id.product_length * line.qty_done
-                height += line.product_id.product_height * line.qty_done
-                width += line.product_id.product_width * line.qty_done
+            # in cm, we need to convert to m
+            height = self.default_packaging_id.height / 100
+            width = self.default_packaging_id.width / 100
+            p_length = self.default_packaging_id.length / 100
+        # Set volume
+        volume = height * width * p_length
+        # Set 0.1 as the minimum value of the volume
+        volume = max(volume, 0.01)
         return {
-            "weight": weight,
-            "volume": volume,
-            "length": p_length,
-            "height": height,
-            "width": width,
+            "weight": round(weight, 2),
+            "volume": round(volume, 2),
+            "length": round(p_length, 2),
+            "height": round(height, 2),
+            "width": round(width, 2),
         }
 
     def _prepare_create_shipping(self):
@@ -340,15 +345,24 @@ class TntRequest(object):
 
     # TntLabel
     def _prepare_label_address(self, partner):
-        return {
+        """Adapt to limit addressLine to 30 characters."""
+        address = partner.street or ""
+        if partner.street2:
+            address += " " + partner.street2
+        res = {
             "name": partner.name,
-            "addressLine1": partner.street,
+            "addressLine1": address[:30],
             "town": partner.city,
             "exactMatch": "Y",
             "province": partner.state_id.name,
             "postcode": partner.zip,
             "country": partner.country_id.code,
         }
+        if len(address) > 30:
+            res.update({"addressLine2": address[30:30]})
+        if len(address) > 60:
+            res.update({"addressLine3": address[60:30]})
+        return res
 
     def _prepare_label(self):
         data_total = self._get_data_total_shipping()

--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -82,7 +82,7 @@ class TntRequest(object):
             "accountCountry": partner.country_id.code,
         }
 
-    def _prepare_rate_shipment(self):
+    def _prepare_rate_shipment_data(self):
         totalWeight = 0
         lines = self.record.order_line.filtered(
             lambda x: x.product_id and x.product_id.weight > 0
@@ -97,7 +97,7 @@ class TntRequest(object):
         totalVolume = height * width * p_length
         # Set 0.1 as the minimum value of the volume
         totalVolume = max(totalVolume, 0.01)
-        data = {
+        return {
             "appId": "PC",
             "appVersion": self.appVersion,
             "priceCheck": {
@@ -121,6 +121,9 @@ class TntRequest(object):
                 },
             },
         }
+
+    def _prepare_rate_shipment(self):
+        data = self._prepare_rate_shipment_data()
         return dicttoxml.dicttoxml(
             data, attr_type=False, custom_root="priceRequest"
         ).decode("utf-8")

--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -93,7 +93,7 @@ class TntRequest(object):
         # Set totalVolume (in cm, we need to convert to m)
         height = self.default_packaging_id.height / 100
         width = self.default_packaging_id.width / 100
-        p_length = self.default_packaging_id.length / 100
+        p_length = self.default_packaging_id.packaging_length / 100
         totalVolume = height * width * p_length
         # Set 0.1 as the minimum value of the volume
         totalVolume = max(totalVolume, 0.01)
@@ -208,12 +208,12 @@ class TntRequest(object):
         if self.use_packages_from_picking and self.record.package_ids:
             height = sum(self.record.package_ids.mapped("height"))
             width = sum(self.record.package_ids.mapped("width"))
-            p_length = sum(self.record.package_ids.mapped("length"))
+            p_length = sum(self.record.package_ids.mapped("packaging_length"))
         else:
             # in cm, we need to convert to m
             height = self.default_packaging_id.height / 100
             width = self.default_packaging_id.width / 100
-            p_length = self.default_packaging_id.length / 100
+            p_length = self.default_packaging_id.packaging_length / 100
         # Set volume
         volume = height * width * p_length
         # Set 0.1 as the minimum value of the volume

--- a/delivery_tnt_oca/tests/test_delivery_tnt.py
+++ b/delivery_tnt_oca/tests/test_delivery_tnt.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021-2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import timedelta
 
@@ -6,7 +6,7 @@ from odoo.exceptions import UserError
 from odoo.tests import Form, common
 
 
-class DeliveryTnt(common.SavepointCase):
+class TestDeliveryTntBase(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -27,9 +27,10 @@ class DeliveryTnt(common.SavepointCase):
                 "vat": cls.company.partner_id.vat,
             }
         )
-        cls.product = cls.env.ref("product.product_delivery_01")
-        cls.product.write(
+        cls.product = cls.env["product.product"].create(
             {
+                "name": "Test product",
+                "type": "product",
                 "weight": 1,
                 "volume": 1,
                 "product_length": 1,
@@ -39,8 +40,6 @@ class DeliveryTnt(common.SavepointCase):
             }
         )
         cls.sale = cls._create_sale_order(cls)
-        cls.picking = cls.sale.picking_ids[0]
-        cls.picking.move_lines.quantity_done = 1
 
     def _create_sale_order(self):
         order_form = Form(self.env["sale.order"])
@@ -58,6 +57,14 @@ class DeliveryTnt(common.SavepointCase):
             delivery_wizard.button_confirm()
         sale.action_confirm()
         return sale
+
+
+class DeliveryTnt(TestDeliveryTntBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.picking = cls.sale.picking_ids[0]
+        cls.picking.move_lines.quantity_done = 1
 
     def test_order_tnt_oca_rate_shipment(self):
         if not self.carrier or self.carrier.prod_environment:

--- a/delivery_tnt_oca/views/delivery_carrier_view.xml
+++ b/delivery_tnt_oca/views/delivery_carrier_view.xml
@@ -67,6 +67,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                                 attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"
                                 context="{'default_package_carrier_type': 'tnt_oca'}"
                             />
+                            <field name="tnt_use_packages_from_picking" />
                             <field
                                 name="tnt_collect_time_from"
                                 attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"

--- a/delivery_tnt_oca/views/delivery_carrier_view.xml
+++ b/delivery_tnt_oca/views/delivery_carrier_view.xml
@@ -63,6 +63,10 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                                 attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"
                             />
                             <field
+                                name="tnt_default_packaging_id"
+                                attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"
+                            />
+                            <field
                                 name="tnt_collect_time_from"
                                 attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"
                                 widget="float_time"

--- a/delivery_tnt_oca/views/delivery_carrier_view.xml
+++ b/delivery_tnt_oca/views/delivery_carrier_view.xml
@@ -65,6 +65,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                             <field
                                 name="tnt_default_packaging_id"
                                 attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"
+                                context="{'default_package_carrier_type': 'tnt_oca'}"
                             />
                             <field
                                 name="tnt_collect_time_from"


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/delivery-carrier/pull/501

Changes done:
- [x] Add pieceLine info from rate_shipment request.
- [x] Round some data to 2 decimal places: weight, volume, width, height, lenght.
- [x] Set 0.1 as the minimum value of the volume.
- [x] Apply domain to `tnt_default_packaging_id` field to show only TNT records.
- [x] Limit `addressLine1` to 30 characters.
- [x] Add `addressLine2` to getlabel request.
- [x] Add `tnt_use_packages_from_picking` field in carrier to use (or not) package from pickings. 
- [x] Set correct receiver (warehouse or company address).
- [x] Separate into functions to allow inheritance.
- [x] Improve tests to allow inheritance.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT37180