### PR TITLE
[15.0][IMP] delivery_package_number: Hide Number of packages in Immediate Transfer wizard if picking have not carrier.

### DIFF
--- a/delivery_package_number/i18n/delivery_package_number.pot
+++ b/delivery_package_number/i18n/delivery_package_number.pot
@@ -6,12 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-08-16 08:40+0000\n"
+"PO-Revision-Date: 2022-08-16 08:40+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: delivery_package_number
+#: model:ir.model.fields,field_description:delivery_package_number.field_stock_immediate_transfer__ask_number_of_packages
+msgid "Ask Number Of Packages"
+msgstr ""
 
 #. module: delivery_package_number
 #: model:ir.model,name:delivery_package_number.model_stock_immediate_transfer

--- a/delivery_package_number/i18n/es.po
+++ b/delivery_package_number/i18n/es.po
@@ -6,15 +6,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-20 06:48+0000\n"
-"PO-Revision-Date: 2020-07-20 06:48+0000\n"
+"POT-Creation-Date: 2022-08-16 08:40+0000\n"
+"PO-Revision-Date: 2022-08-16 10:40+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 2.3\n"
+
+#. module: delivery_package_number
+#: model:ir.model.fields,field_description:delivery_package_number.field_stock_immediate_transfer__ask_number_of_packages
+msgid "Ask Number Of Packages"
+msgstr "Preguntar número de Bultos"
 
 #. module: delivery_package_number
 #: model:ir.model,name:delivery_package_number.model_stock_immediate_transfer

--- a/delivery_package_number/wizard/stock_immediate_transfer_views.xml
+++ b/delivery_package_number/wizard/stock_immediate_transfer_views.xml
@@ -5,7 +5,8 @@
         <field name="inherit_id" ref="stock.view_immediate_transfer" />
         <field name="arch" type="xml">
             <xpath expr="//footer" position="before">
-                <group>
+                <field name="ask_number_of_packages" invisible="1" />
+                <group attrs="{'invisible': [('ask_number_of_packages','=',False)]}">
                     <field name="number_of_packages" />
                 </group>
             </xpath>

--- a/delivery_package_number/wizard/stock_inmediate_transfer.py
+++ b/delivery_package_number/wizard/stock_inmediate_transfer.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockImmediateTransfer(models.TransientModel):
@@ -9,6 +9,12 @@ class StockImmediateTransfer(models.TransientModel):
     number_of_packages = fields.Integer(
         help="Set the number of packages for this picking(s)",
     )
+    ask_number_of_packages = fields.Boolean(compute="_compute_ask_number_of_packages")
+
+    @api.depends("pick_ids")
+    def _compute_ask_number_of_packages(self):
+        for item in self:
+            item.ask_number_of_packages = bool(item.pick_ids.carrier_id)
 
     def process(self):
         if self.number_of_packages:


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/delivery-carrier/pull/520

Hide Number of packages in Immediate Transfer wizard if picking have not carrier.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38549