### PR TITLE
[12.0][FIX] delivery_state: cron

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -62,17 +62,7 @@ class StockPicking(models.Model):
             # These won't ever autoupdate, so we don't want to evaluate them
             ("delivery_type", "not in", [False, "fixed", "base_one_rule"]),
         ])
-        delivery_types = self.mapped("delivery_type")
-        # Split them by delivery type so we can ignore those without the
-        # proper method.
-        for delivery_type in delivery_types:
-            method = "%s_tracking_state_update" % delivery_type
-            if not hasattr(self.env["delivery.carrier"], method):
-                continue
-            delivery_type_pickings = pickings.filtered(
-                lambda x: x.delivery_type == delivery_type)
-            for picking in delivery_type_pickings:
-                getattr(picking.carrier_id, method)(picking)
+        pickings.tracking_state_update()
 
     def _get_delivery_mail_context(self):
         """Extensible context for customization"""


### PR DESCRIPTION
We were running the cron action over an empty recordset. Anyway code complexity can be reduced as we're repeating `tracking_state_update` method code.

cc @Tecnativa TT39099

please review @victoralmau @pedrobaeza 