### PR TITLE
[14.0][FIX] delivery_package_number: number_of_packages set in wizard overriden in compute

### DIFF
--- a/delivery_package_number/models/stock_picking.py
+++ b/delivery_package_number/models/stock_picking.py
@@ -14,6 +14,8 @@ class StockPicking(models.Model):
     )
 
     @api.depends("package_ids")
+    @api.depends_context("force_write_number_of_packages")
     def _compute_number_of_packages(self):
         for picking in self:
-            picking.number_of_packages = len(picking.package_ids) or 1
+            if not self.env.context.get("force_write_number_of_packages", False):
+                picking.number_of_packages = len(picking.package_ids) or 1

--- a/delivery_package_number/wizard/stock_inmediate_transfer.py
+++ b/delivery_package_number/wizard/stock_inmediate_transfer.py
@@ -13,4 +13,7 @@ class StockImmediateTransfer(models.TransientModel):
     def process(self):
         if self.number_of_packages:
             self.pick_ids.write({"number_of_packages": self.number_of_packages})
-        return super().process()
+        return super(
+            StockImmediateTransfer,
+            self.with_context(force_write_number_of_packages=True),
+        ).process()


### PR DESCRIPTION
Steps to reproduce:
- Validate a picking that has a `carrier_id` and in the wizard set `number_of_packages` different than 1:
 ![image](https://user-images.githubusercontent.com/85128566/198578181-ed04f5c0-c74c-46d6-bae7-351450890ab2.png)

- Check that the value hasn't been updated:
![image](https://user-images.githubusercontent.com/85128566/198581167-a6f59ecf-b197-4a1c-8036-1d40b67ef7bb.png)

@pedrobaeza 