### PR TITLE
[14.0][FIX] delivery_carrier_package_measure_required for not done transfer

### DIFF
--- a/delivery_carrier_package_measure_required/models/stock_quant_package.py
+++ b/delivery_carrier_package_measure_required/models/stock_quant_package.py
@@ -13,11 +13,17 @@ class StockQuantPackage(models.Model):
     height_required = fields.Boolean(related="packaging_id.package_height_required")
     weight_required = fields.Boolean(related="packaging_id.package_weight_required")
 
-    @api.constrains("length", "width", "height", "weight")
     # The boolean field use to check if a dimension is required are intentionally left out.
     # To not raise error when changing packaging configuration.
+    @api.constrains("length", "width", "height", "weight", "quant_ids")
     def _check_required_dimension(self):
+        ignore_pack_content = self.env.context.get(
+            "delivery_pkg_measure__ignore_package_content"
+        )
         for package in self:
+            if not ignore_pack_content and not package.quant_ids:
+                # Only validate a package when it contains goods
+                continue
             required_dimension = []
             if package.length_required and not package.pack_length:
                 required_dimension.append(_("length"))


### PR DESCRIPTION
The required dimensions on a package need not to be enforce before the picking is being set to done.
Because that blocks any preparation on the package before it is delivered.

But we still want to be able to check if the package is valid at will. This can be done with the `ignore_picking_state` context key.