### PR TITLE
[13.0][FIX] delivery_sending: Avoid displaying a non-existent error

### DIFF
--- a/delivery_sending/models/delivery_carrier.py
+++ b/delivery_sending/models/delivery_carrier.py
@@ -114,7 +114,6 @@ class DeliveryCarrier(models.Model):
         if hasattr(sending_request, method):
             try:
                 res = getattr(sending_request, method)(reference)
-                self._sending_check_error(res)
             except Exception as e:
                 raise (e)
             return res


### PR DESCRIPTION
Avoid displaying a non-existent error.
Remove `_sending_check_error()` in `sending_get_label()` function because content is returned directly.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40492