### PR TITLE
[12.0][FIX] delivery_multi_destination: Correctly handle base_on_rule subcarriers

### DIFF
--- a/delivery_multi_destination/models/__init__.py
+++ b/delivery_multi_destination/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import delivery_carrier
+from . import sale_order

--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -103,3 +103,4 @@ class DeliveryCarrier(models.Model):
                         _('There is no matching delivery rule.'))
                 res += picking_res
             return res
+                            ).send_shipping(p)

--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -86,7 +86,7 @@ class DeliveryCarrier(models.Model):
                 for subcarrier in carrier.child_ids:
                     if subcarrier.delivery_type == 'fixed':
                         if subcarrier._match_address(p.partner_id):
-                            p.tentative_carrier = subcarrier
+                            p.sale_id.tentative_carrier = subcarrier
                             picking_res = [{
                                 'exact_price': subcarrier.fixed_price,
                                 'tracking_number': False}]

--- a/delivery_multi_destination/models/sale_order.py
+++ b/delivery_multi_destination/models/sale_order.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Coop IT Easy SC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    tentative_carrier = fields.Many2one(
+        comodel_name="delivery.carrier",
+        string="Tentative Delivery Method",
+    )


### PR DESCRIPTION
Depending on `tentative_carrier` here is hacky beyond belief,
and there should exist a better way.

The problem this solves is as follows: Although `send_shipping()` is
called using the subcarrier, some code in
`base_on_rule_send_shipping()` (if the subcarrier has delivery type
`base_on_rule`) uses the _picking_'s carrier to call
`_get_price_available()`. This obviously breaks, because the picking's
carrier is the subcarrier's parent, and has no rules configured.

So we need to figure out what the chosen subcarrier was. The problem
is that there exists no hypothetical method
`determine_chosen_subcarrier_for_sale_order()` in this module.
Instead, the chosen subcarrier is determined by simply trying to call
`send_shipping()` until you find one that works.

So either we write the hypothetical
`determine_chosen_subcarrier_for_sale_order()` method and use it in
both `send_picking()` and here, or we use this workaround hack of
storing `tentative_carrier` on the order. But because you're reading
this, you can see which option was chosen.

Signed-off-by: Carmen Bianca BAKKER <carmen@coopiteasy.be>

---

Internal task: https://gestion.coopiteasy.be/web#id=9564&model=project.task&view_type=form&menu_id=