### PR TITLE
[13.0][IMP] delivery_state: new state to ignore further update calls

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -24,6 +24,7 @@ class StockPicking(models.Model):
             ("incidence", "Incidence"),
             ("customer_delivered", "Customer delivered"),
             ("warehouse_delivered", "Warehouse delivered"),
+            ("no_update", "No more updates from carrier"),
         ],
         string="Carrier State",
         tracking=True,
@@ -51,7 +52,7 @@ class StockPicking(models.Model):
                 (
                     "delivery_state",
                     "not in",
-                    ["customer_delivered", "canceled_shipment"],
+                    ["customer_delivered", "canceled_shipment", "no_update"],
                 ),
                 # These won't ever autoupdate, so we don't want to evaluate them
                 ("delivery_type", "not in", [False, "fixed", "base_one_rule"]),


### PR DESCRIPTION
It could happen that a carrier deletes tracking numbers from its DB and those states are not longer updatable. We don't want to be checking them forever, so we want a state to ignore them in the future.

cc @Tecnativa TT40774

please review @pedrobaeza @victoralmau 