### PR TITLE
[13.0][FIX] delivery_tnt_oca: Set correct sequenceNumbers value from labels.

### DIFF
--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -379,9 +379,9 @@ class TntRequest(object):
             res.update({"addressLine3": address[60:30]})
         return res
 
-    def _prepare_label(self):
+    def _prepare_label_data(self):
         data_total = self._get_data_total_shipping()
-        data = {
+        return {
             "consignment": {
                 "consignmentIdentity": {
                     "consignmentNumber": re.sub(
@@ -414,12 +414,20 @@ class TntRequest(object):
                         "weight": data_total["weight"],
                     },
                     "pieces": {
-                        "sequenceNumbers": self.record.number_of_packages,
+                        "sequenceNumbers": ",".join(
+                            [
+                                str(i)
+                                for i in range(1, self.record.number_of_packages + 1)
+                            ]
+                        ),
                         "pieceReference": "",
                     },
                 },
             }
         }
+
+    def _prepare_label(self):
+        data = self._prepare_label_data()
         return dicttoxml.dicttoxml(
             data, attr_type=False, custom_root="labelRequest"
         ).decode("utf-8")

--- a/delivery_tnt_oca/tests/test_delivery_tnt.py
+++ b/delivery_tnt_oca/tests/test_delivery_tnt.py
@@ -80,6 +80,19 @@ class DeliveryTnt(TestDeliveryTntBase):
         package_data = tnt_request._quant_package_data_from_picking()
         self.assertEqual(package_data["WEIGHT"], 0.5)
 
+    def test_label_tnt_oca_misc(self):
+        tnt_request = TntRequest(self.carrier, self.picking)
+        self.picking.carrier_tracking_ref = "TEST"
+        label_data = tnt_request._prepare_label_data()
+        self.assertEqual(
+            label_data["consignment"]["pieceLine"]["pieces"]["sequenceNumbers"], "1"
+        )
+        self.picking.number_of_packages = 2
+        label_data = tnt_request._prepare_label_data()
+        self.assertEqual(
+            label_data["consignment"]["pieceLine"]["pieces"]["sequenceNumbers"], "1,2"
+        )
+
     def test_order_tnt_oca_rate_shipment(self):
         if not self.carrier or self.carrier.prod_environment:
             self.skipTest("Without TNT carrier created")


### PR DESCRIPTION
Set correct `sequenceNumbers` value from labels.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40767