### PR TITLE
[15.0][IMP] delivery_cttexpress: force delivery_price_method dependency

### DIFF
--- a/delivery_cttexpress/README.rst
+++ b/delivery_cttexpress/README.rst
@@ -36,12 +36,8 @@ Installation
 ============
 
 This module needs the `zeep` python library. It depends on the modules
-`delivery_package_number` and `delivery_state` that can be found on
-OCA/delivery-carrier.
-
-CTT Express Iberic Web Services API doesn't provide shipping price calculation methods.
-To rely on Odoo standard price calculations you'll to install the module
-`delivery_price_method` found in this repository as well.
+`delivery_package_number`, `delivery_price_method` and `delivery_state` that can be
+found on OCA/delivery-carrier.
 
 The following ports and hosts should be visible from your Odoo deployment:
 
@@ -50,6 +46,10 @@ The following ports and hosts should be visible from your Odoo deployment:
 
 Configuration
 =============
+
+CTT Express Iberic Web Services API doesn't provide shipping price calculation methods.
+So you'll have to rely on Odoo standard methods selecting them in the field
+*Price method*.
 
 To configure your CTT Express services, go to:
 

--- a/delivery_cttexpress/__manifest__.py
+++ b/delivery_cttexpress/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
-    "depends": ["delivery_package_number", "delivery_state"],
+    "depends": ["delivery_package_number", "delivery_state", "delivery_price_method"],
     "external_dependencies": {"python": ["zeep"]},
     "data": [
         "security/ir.model.access.csv",

--- a/delivery_cttexpress/models/delivery_carrier.py
+++ b/delivery_cttexpress/models/delivery_carrier.py
@@ -43,6 +43,12 @@ class DeliveryCarrier(models.Model):
     )
     cttexpress_document_offset = fields.Integer(string="Document Offset")
 
+    @api.onchange("delivery_type")
+    def _onchange_delivery_type_ctt(self):
+        """Default price method for CTT as the API can't gather prices."""
+        if self.delivery_type == "cttexpress":
+            self.price_method = "base_on_rule"
+
     def _ctt_request(self):
         """Get CTT Request object
 

--- a/delivery_cttexpress/readme/CONFIGURE.rst
+++ b/delivery_cttexpress/readme/CONFIGURE.rst
@@ -1,3 +1,7 @@
+CTT Express Iberic Web Services API doesn't provide shipping price calculation methods.
+So you'll have to rely on Odoo standard methods selecting them in the field
+*Price method*.
+
 To configure your CTT Express services, go to:
 
 #. *Inventory/Sales > Configuration > Delivery methods* and create a new one.

--- a/delivery_cttexpress/readme/INSTALL.rst
+++ b/delivery_cttexpress/readme/INSTALL.rst
@@ -1,10 +1,6 @@
 This module needs the `zeep` python library. It depends on the modules
-`delivery_package_number` and `delivery_state` that can be found on
-OCA/delivery-carrier.
-
-CTT Express Iberic Web Services API doesn't provide shipping price calculation methods.
-To rely on Odoo standard price calculations you'll to install the module
-`delivery_price_method` found in this repository as well.
+`delivery_package_number`, `delivery_price_method` and `delivery_state` that can be
+found on OCA/delivery-carrier.
 
 The following ports and hosts should be visible from your Odoo deployment:
 

--- a/delivery_cttexpress/static/description/index.html
+++ b/delivery_cttexpress/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Delivery CTT Express</title>
 <style type="text/css">
 
@@ -389,11 +389,8 @@ ul.auto-toc {
 <div class="section" id="installation">
 <h1><a class="toc-backref" href="#id1">Installation</a></h1>
 <p>This module needs the <cite>zeep</cite> python library. It depends on the modules
-<cite>delivery_package_number</cite> and <cite>delivery_state</cite> that can be found on
-OCA/delivery-carrier.</p>
-<p>CTT Express Iberic Web Services API doesn’t provide shipping price calculation methods.
-To rely on Odoo standard price calculations you’ll to install the module
-<cite>delivery_price_method</cite> found in this repository as well.</p>
+<cite>delivery_package_number</cite>, <cite>delivery_price_method</cite> and <cite>delivery_state</cite> that can be
+found on OCA/delivery-carrier.</p>
 <p>The following ports and hosts should be visible from your Odoo deployment:</p>
 <ul class="simple">
 <li>Test: iberws.tourlineexpress.com:8686</li>
@@ -402,6 +399,9 @@ To rely on Odoo standard price calculations you’ll to install the module
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#id2">Configuration</a></h1>
+<p>CTT Express Iberic Web Services API doesn’t provide shipping price calculation methods.
+So you’ll have to rely on Odoo standard methods selecting them in the field
+<em>Price method</em>.</p>
 <p>To configure your CTT Express services, go to:</p>
 <ol class="arabic simple">
 <li><em>Inventory/Sales &gt; Configuration &gt; Delivery methods</em> and create a new one.</li>


### PR DESCRIPTION
CTT Express doesn't have a delivery prices methods in their API. Until now, it was enforced in the instructions to add delivery_price_method to the instance in order to be able to have price rules. We force the dependecy so the module functionality is complete out of the box.

cc @Tecnativa TT40759

please review @pedrobaeza @victoralmau 