### PR TITLE
[14.0][IMP] delivery_tnt_oca: Add the tnt_service_option field in the carrier to send that value to the API.

### DIFF
--- a/delivery_tnt_oca/i18n/delivery_tnt_oca.pot
+++ b/delivery_tnt_oca/i18n/delivery_tnt_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-12-14 12:42+0000\n"
+"PO-Revision-Date: 2022-12-14 12:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -49,6 +51,11 @@ msgstr ""
 #. module: delivery_tnt_oca
 #: model_terms:ir.ui.view,arch_db:delivery_tnt_oca.view_delivery_carrier_tnt_oca_form
 msgid "Account"
+msgstr ""
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__bb
+msgid "BB"
 msgstr ""
 
 #. module: delivery_tnt_oca
@@ -99,6 +106,11 @@ msgid "ECONOMY EXPRESS"
 msgstr ""
 
 #. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__eq
+msgid "EQ"
+msgstr ""
+
+#. module: delivery_tnt_oca
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_service_n__ec
 msgid "Economy Express"
 msgstr ""
@@ -113,6 +125,11 @@ msgstr ""
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_code_d__15d
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_code_n__15n
 msgid "GLOBAL EXPRESS"
+msgstr ""
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__hz
+msgid "HZ"
 msgstr ""
 
 #. module: delivery_tnt_oca
@@ -147,6 +164,11 @@ msgstr ""
 #. module: delivery_tnt_oca
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_type__n
 msgid "Non-document (packages)"
+msgstr ""
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__pr
+msgid "PR"
 msgstr ""
 
 #. module: delivery_tnt_oca
@@ -228,6 +250,11 @@ msgstr ""
 #: code:addons/delivery_tnt_oca/models/tnt_request.py:0
 #, python-format
 msgid "Server not reachable, please try again later"
+msgstr ""
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields,field_description:delivery_tnt_oca.field_delivery_carrier__tnt_service_option
+msgid "Service option"
 msgstr ""
 
 #. module: delivery_tnt_oca
@@ -375,11 +402,6 @@ msgid "WS Username"
 msgstr ""
 
 #. module: delivery_tnt_oca
-#: model:product.packaging,weight_uom_name:delivery_tnt_oca.product_packaging_tnt_default
-msgid "kg"
-msgstr ""
-
-#. module: delivery_tnt_oca
-#: model:product.packaging,volume_uom_name:delivery_tnt_oca.product_packaging_tnt_default
-msgid "m³"
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__xbb
+msgid "XBB"
 msgstr ""

--- a/delivery_tnt_oca/i18n/es.po
+++ b/delivery_tnt_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-27 14:10+0000\n"
-"PO-Revision-Date: 2022-06-27 16:11+0200\n"
+"POT-Creation-Date: 2022-12-14 12:42+0000\n"
+"PO-Revision-Date: 2022-12-14 13:43+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: delivery_tnt_oca
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_service_d__ex10
@@ -54,6 +54,11 @@ msgstr "9:00 Express"
 #: model_terms:ir.ui.view,arch_db:delivery_tnt_oca.view_delivery_carrier_tnt_oca_form
 msgid "Account"
 msgstr "Cuenta"
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__bb
+msgid "BB"
+msgstr ""
 
 #. module: delivery_tnt_oca
 #: model:ir.model.fields,field_description:delivery_tnt_oca.field_product_packaging__package_carrier_type
@@ -103,6 +108,11 @@ msgid "ECONOMY EXPRESS"
 msgstr "ECONOMY EXPRESS"
 
 #. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__eq
+msgid "EQ"
+msgstr ""
+
+#. module: delivery_tnt_oca
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_service_n__ec
 msgid "Economy Express"
 msgstr "Economy Express"
@@ -118,6 +128,11 @@ msgstr "Express"
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_code_n__15n
 msgid "GLOBAL EXPRESS"
 msgstr "GLOBAL EXPRESS"
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__hz
+msgid "HZ"
+msgstr ""
 
 #. module: delivery_tnt_oca
 #: model:ir.model.fields,field_description:delivery_tnt_oca.field_delivery_carrier__id
@@ -152,6 +167,11 @@ msgstr "Varios"
 #: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_product_type__n
 msgid "Non-document (packages)"
 msgstr "No documentos (paquetes)"
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__pr
+msgid "PR"
+msgstr ""
 
 #. module: delivery_tnt_oca
 #: model_terms:ir.ui.view,arch_db:delivery_tnt_oca.view_delivery_carrier_tnt_oca_form
@@ -233,6 +253,11 @@ msgstr ""
 #, python-format
 msgid "Server not reachable, please try again later"
 msgstr "El servidor no responde, por favor vuelve a intentarlo más tarde"
+
+#. module: delivery_tnt_oca
+#: model:ir.model.fields,field_description:delivery_tnt_oca.field_delivery_carrier__tnt_service_option
+msgid "Service option"
+msgstr "Opción servicio adicional"
 
 #. module: delivery_tnt_oca
 #: model:ir.model,name:delivery_tnt_oca.model_delivery_carrier
@@ -379,14 +404,6 @@ msgid "WS Username"
 msgstr "Usuario"
 
 #. module: delivery_tnt_oca
-#: model:product.packaging,weight_uom_name:delivery_tnt_oca.product_packaging_tnt_default
-msgid "kg"
+#: model:ir.model.fields.selection,name:delivery_tnt_oca.selection__delivery_carrier__tnt_service_option__xbb
+msgid "XBB"
 msgstr ""
-
-#. module: delivery_tnt_oca
-#: model:product.packaging,volume_uom_name:delivery_tnt_oca.product_packaging_tnt_default
-msgid "m³"
-msgstr ""
-
-#~ msgid "'TNT-%s' % object.carrier_tracking_ref"
-#~ msgstr "'TNT-%s' % object.carrier_tracking_ref"

--- a/delivery_tnt_oca/models/delivery_carrier.py
+++ b/delivery_tnt_oca/models/delivery_carrier.py
@@ -18,6 +18,16 @@ class DeliveryCarrier(models.Model):
     tnt_oca_ws_password = fields.Char(string="WS Password")
     tnt_oca_ws_account = fields.Char(string="WS Account")
     # Misc
+    tnt_service_option = fields.Selection(
+        selection=[
+            ("PR", "PR"),
+            ("EQ", "EQ"),
+            ("XBB", "XBB"),
+            ("HZ", "HZ"),
+            ("BB", "BB"),
+        ],
+        string="Service option",
+    )
     tnt_product_type = fields.Selection(
         selection=[
             ("D", "Document (paper/manuals/reports)"),

--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -24,6 +24,7 @@ class TntRequest(object):
         self.product_type = self.carrier.tnt_product_type
         self.product_code = self.carrier.tnt_product_code
         self.product_service = self.carrier.tnt_product_service
+        self.service_option = self.carrier.tnt_service_option
         self.username = self.carrier.tnt_oca_ws_username
         self.password = self.carrier.tnt_oca_ws_password
         self.account = self.carrier.tnt_oca_ws_account
@@ -261,7 +262,7 @@ class TntRequest(object):
                         "TOTALWEIGHT": data_total["weight"],
                         "TOTALVOLUME": data_total["volume"],
                         "SERVICE": self.product_code,
-                        "OPTION": "PR",
+                        "OPTION": self.service_option or "",
                         "DESCRIPTION": "",
                         "DELIVERYINST": "",
                         "PACKAGE": package,

--- a/delivery_tnt_oca/views/delivery_carrier_view.xml
+++ b/delivery_tnt_oca/views/delivery_carrier_view.xml
@@ -34,6 +34,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                             />
                         </group>
                         <group string="Misc">
+                            <field name="tnt_service_option" />
                             <field
                                 name="tnt_product_type"
                                 attrs="{'required': [('delivery_type', '=', 'tnt_oca')]}"


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/delivery-carrier/pull/582

Add the `tnt_service_option` field in the carrier to send that value to the API.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40767