### PR TITLE
[14.0][IMP] delivery_tnt_oca: Remove unnecessary BOOK tag from ACTIVITY

### DIFF
--- a/delivery_tnt_oca/models/tnt_request.py
+++ b/delivery_tnt_oca/models/tnt_request.py
@@ -279,7 +279,6 @@ class TntRequest(object):
             },
             "ACTIVITY": {
                 "CREATE": {"CONREF": self.record.name},
-                "BOOK": {"CONREF": self.record.name},
                 "SHIP": {"CONREF": self.record.name},
                 "PRINT": {
                     "CONNOTE": {"CONREF": self.record.name},


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/delivery-carrier/pull/590

Remove unnecessary `BOOK` tag from `ACTIVITY`

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40767