### PR TITLE
[15.0][FIX] delivery_multi_destination: Avoid error in creation of a multiple carrier with UX

### DIFF
--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -29,6 +29,12 @@ class DeliveryCarrier(models.Model):
         required=True,
     )
 
+    @api.onchange("destination_type", "child_ids")
+    def _onchange_destination_type(self):
+        """Define the corresponding value to avoid creation error with UX."""
+        if self.destination_type == "multi" and self.child_ids and not self.product_id:
+            self.product_id = fields.first(self.child_ids.product_id)
+
     def search(self, args, offset=0, limit=None, order=None, count=False):
         """Don't show by default children carriers."""
         if not self.env.context.get("show_children_carriers"):

--- a/delivery_multi_destination/tests/test_delivery_multi_destination.py
+++ b/delivery_multi_destination/tests/test_delivery_multi_destination.py
@@ -166,3 +166,13 @@ class TestDeliveryMultiDestination(common.TransactionCase):
         picking.move_lines.quantity_done = 1
         picking._action_done()
         self.assertAlmostEqual(picking.carrier_price, 50)
+
+    def test_delivery_carrier_multi_form(self):
+        carrier_form = Form(self.env["delivery.carrier"])
+        carrier_form.name = "Multi carrier"
+        carrier_form.destination_type = "multi"
+        with carrier_form.child_ids.new() as child_form:
+            child_form.name = "Child carrier"
+            child_form.product_id = self.product_child_1
+        carrier = carrier_form.save()
+        self.assertEqual(carrier.product_id, self.product_child_1)


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/delivery-carrier/pull/635

Avoid error in creation of a multiple carrier with UX

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT42837