### PR TITLE
[13.0][FIX] delivery_multi_destination: Get properly subcarrier price on based on rules

### DIFF
--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -98,12 +98,19 @@ class DeliveryCarrier(models.Model):
                             break
                     else:
                         try:
+                            # on base_on_rule_send_shipping, the method
+                            # _get_price_available is called using p.carrier_id,
+                            # ignoring the self arg, so we need to temporarily replace
+                            # it with the subcarrier
+                            p.carrier_id = subcarrier.id
                             picking_res = super(
                                 DeliveryCarrier, subcarrier,
-                            ).send_shipping(pickings)
+                            ).send_shipping(p)
                             break
                         except Exception:
                             pass
+                        finally:
+                            p.carrier_id = carrier
                 if not picking_res:
                     raise ValidationError(_("There is no matching delivery rule."))
                 res += picking_res


### PR DESCRIPTION
If the destination carrier line is based on rules, the price is not correctly fetched, as it's hardcoded to call `_get_price_available` using picking's carrier, no matter the recordset from which you call it (the self argument).

Thus, the only solution to get the proper value is to temporarily replace the carrier on the picking on the calls chain, to restore it before returning.

@Tecnativa TT42862