### PR TITLE
[15.0][OU-ADD] delivery_auto_refresh: Migration script to delete deactivated parameters

### DIFF
--- a/delivery_auto_refresh/migrations/15.0.1.0.0/pre-migration.py
+++ b/delivery_auto_refresh/migrations/15.0.1.0.0/pre-migration.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Remove system parameter records of 'delivery_auto_refresh' with value 0 or False,
+    to avoid their activation during migration due to their presence in the database."""
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM ir_config_parameter
+        WHERE key LIKE '%delivery_auto_refresh%'
+        AND (value = '0' OR value = 'False')
+        """,
+    )


### PR DESCRIPTION
In v15 the module does not set the default parameters to any value as was the case in v14. In v15 when a parameter is activated from settings a record is created in the database and when it is deactivated the record is deleted. For this reason and to avoid possible problems with the configuration of the parameters, those that are deactivated are deleted from the database.

cc @Tecnativa TT43515

@chienandalu @CarlosRoca13 please review