### PR TITLE
[13.0][FIX] delivery_multi_destination: Filter subdestination carriers from other companies

### DIFF
--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -86,7 +86,9 @@ class DeliveryCarrier(models.Model):
             res = []
             for p in pickings:
                 picking_res = False
-                for subcarrier in carrier.child_ids:
+                for subcarrier in carrier.child_ids.filtered(
+                    lambda x: not x.company_id or x.company_id == p.company_id
+                ):
                     if subcarrier.delivery_type == "fixed":
                         if subcarrier._match_address(p.partner_id):
                             picking_res = [


### PR DESCRIPTION
In the context where `carrier.child_ids` is being examined, all existing subdestinations, no matter the company they have, are shown as being in a sudo environment, so we need to filter them out those from other companies.

@Tecnativa TT43596