### PR TITLE
[14.0] Fix access to not-existing record self after rollback

### DIFF
--- a/delivery_postlogistics/models/stock_picking.py
+++ b/delivery_postlogistics/models/stock_picking.py
@@ -219,6 +219,7 @@ class StockPicking(models.Model):
         # Case when there is a failed label, rollback odoo data
         if failed_label_results:
             self._cr.rollback()
+            self = self.exists()
 
         labels = self.write_tracking_number_label(success_label_results, packages)
 
@@ -231,7 +232,7 @@ class StockPicking(models.Model):
             # This ensures the label pushed recored correctly in Odoo
             self._cr.commit()  # pylint: disable=invalid-commit
             error_message = "\n".join(label["errors"] for label in failed_label_results)
-            raise exceptions.Warning(error_message)
+            raise exceptions.UserError(error_message)
         return labels
 
     def generate_postlogistics_shipping_labels(self, package_ids=None):


### PR DESCRIPTION
If a stock.picking is created and in the same transaction we generate a label, when the webservice returns an error, the module rollbacks the transaction, so 'self' is empty and will fail with:

Record does not exist or has been deleted. (Record: stock.picking(8211067,), User: 6)

When trying to write the tracking number, and will therefore not raise the details of the error.

Out of scope here, but I wonder if we really need to commit / rollback, if we rollback and we "lose" a label, we can generate a new one, there is no fee per generated label.