### PR TITLE
[IMP] base_delivery_carrier_label : write the parcel tracking uri if available

### DIFF
--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -39,9 +39,16 @@ class StockPicking(models.Model):
         data = self.get_shipping_label_values(label)
         if label.get("package_id"):
             data["package_id"] = label["package_id"]
+            package_tracking_vals = {}
             if label.get("tracking_number"):
+                package_tracking_vals["parcel_tracking"] = label["tracking_number"]
+            if label.get("parcel_tracking_uri"):
+                package_tracking_vals["parcel_tracking_uri"] = label[
+                    "parcel_tracking_uri"
+                ]
+            if package_tracking_vals:
                 self.env["stock.quant.package"].browse(label["package_id"]).write(
-                    {"parcel_tracking": label.get("tracking_number")}
+                    package_tracking_vals
                 )
         context_attachment = self.env.context.copy()
         # remove default_type setted for stock_picking

--- a/base_delivery_carrier_label/tests/test_send.py
+++ b/base_delivery_carrier_label/tests/test_send.py
@@ -19,6 +19,7 @@ class TestSend(TransactionCase):
         )
         picking_form.carrier_id = carrier
         picking = picking_form.save()
+        package = self.env["stock.quant.package"].create({})
 
         with mock.patch.object(type(carrier), "base_on_rule_send_shipping") as mocked:
             mocked.return_value = [
@@ -28,6 +29,9 @@ class TestSend(TransactionCase):
                             name="hello_world.pdf",
                             file=base64.b64encode(bytes("hello world", "utf8")),
                             file_type="pdf",
+                            package_id=package.id,
+                            tracking_number="Test package tracking ref",
+                            parcel_tracking_uri="https://my_package_tracking_url",
                         ),
                     ]
                 )
@@ -38,4 +42,8 @@ class TestSend(TransactionCase):
             self.assertTrue(label, "No label created")
             self.assertEqual(
                 label.mimetype, "application/pdf", "Wrong attachment created"
+            )
+            self.assertEqual(package.parcel_tracking, "Test package tracking ref")
+            self.assertEqual(
+                package.parcel_tracking_uri, "https://my_package_tracking_url"
             )


### PR DESCRIPTION
This module add the field `parcel_tracking_uri` on the package.
It seems logical that it allow to fill it in case the  specific carrier module send it in the package data along with the tracking number.

@hparfr @bealdav @bguillot A small review would be welcome