### PR TITLE
[16.0][FIX] delivery_postlogistics: if street2 is defined, show it after street on shipping label

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -112,8 +112,9 @@ class PostlogisticsWebService(object):
             recipient["country"] = country_code
 
         if partner.street2:
-            addr_suffix = self._sanitize_string(partner.street2[:35])
-            recipient["addressSuffix"] = addr_suffix
+            # addressSuffix is shown before street on label
+            recipient["addressSuffix"] = recipient["street"]
+            recipient["street"] = self._sanitize_string(partner.street2[:35])
 
         company_partner_name = partner.commercial_company_name
         if company_partner_name and company_partner_name != partner_name:


### PR DESCRIPTION
Currently, street 2 is printed before street 1 on the shipping label, this fix suggest that street1 will shown in front of street 2

![image](https://github.com/OCA/delivery-carrier/assets/76513233/deff1874-7a40-4280-961b-a8e8c2c691fe)
![image](https://github.com/OCA/delivery-carrier/assets/76513233/68daf782-a250-49c3-a05a-573768fc630e)
