### PR TITLE
[16.0][IMP] delivery_postlogistics: shipping labels and returns

### DIFF
--- a/delivery_postlogistics/__init__.py
+++ b/delivery_postlogistics/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import postlogistics
+from . import wizard

--- a/delivery_postlogistics/models/delivery_carrier.py
+++ b/delivery_postlogistics/models/delivery_carrier.py
@@ -156,3 +156,15 @@ class DeliveryCarrier(models.Model):
             },
         }
         return message
+
+    def _compute_can_generate_return(self):
+        res = super(DeliveryCarrier, self)._compute_can_generate_return()
+        for carrier in self:
+            if carrier.delivery_type == "postlogistics":
+                carrier.can_generate_return = True
+        return res
+
+    def postlogistics_get_return_label(
+        self, picking, tracking_number=None, origin_date=None
+    ):
+        return self.postlogistics_send_shipping(picking)

--- a/delivery_postlogistics/models/stock_picking.py
+++ b/delivery_postlogistics/models/stock_picking.py
@@ -236,3 +236,9 @@ class StockPicking(models.Model):
         """Add label generation for PostLogistics"""
         self.ensure_one()
         return self._generate_postlogistics_label(package_ids=package_ids)
+
+    def action_generate_carrier_label(self):
+        self.ensure_one()
+        if not self.carrier_id:
+            raise exceptions.UserError(_("Please, set a carrier."))
+        self.env["delivery.carrier"].postlogistics_send_shipping(self)

--- a/delivery_postlogistics/views/stock.xml
+++ b/delivery_postlogistics/views/stock.xml
@@ -10,11 +10,17 @@
                 <button
                     name="action_generate_carrier_label"
                     help="Create Shipping Label 🚚"
-                    attrs="{'invisible': ['|', ('state', '!=', 'done'), ('delivery_type', '!=', 'postlogistics')]}"
+                    attrs="{'invisible': ['|', '|', ('state', '!=', 'done'), ('delivery_type', '!=', 'postlogistics'), ('picking_type_code', '=', 'incoming')]}"
                     string="Create Shipping Label 🚚"
                     type="object"
                 />
             </field>
+
+            <button name="print_return_label" position="attributes">
+                    <attribute
+                    name="attrs"
+                >{'invisible':['|', ('is_return_picking', '=', False),('picking_type_code', '!=', 'incoming')]}</attribute>
+            </button>
 
             <xpath expr="//page//group[@name='carrier_data']/.." position="after">
                 <separator

--- a/delivery_postlogistics/views/stock.xml
+++ b/delivery_postlogistics/views/stock.xml
@@ -6,6 +6,16 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form" />
         <field name="arch" type="xml">
+            <field name="state" position="before">
+                <button
+                    name="action_generate_carrier_label"
+                    help="Create Shipping Label 🚚"
+                    attrs="{'invisible': ['|', ('state', '!=', 'done'), ('delivery_type', '!=', 'postlogistics')]}"
+                    string="Create Shipping Label 🚚"
+                    type="object"
+                />
+            </field>
+
             <xpath expr="//page//group[@name='carrier_data']/.." position="after">
                 <separator
                     string="Delivery instructions"

--- a/delivery_postlogistics/wizard/__init__.py
+++ b/delivery_postlogistics/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking_return

--- a/delivery_postlogistics/wizard/stock_picking_return.py
+++ b/delivery_postlogistics/wizard/stock_picking_return.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class ReturnPicking(models.TransientModel):
+    _inherit = "stock.return.picking"
+
+    def _create_returns(self):
+        new_picking, pick_type_id = super(ReturnPicking, self)._create_returns()
+        if self.picking_id.delivery_type == "postlogistics":
+            picking = self.env["stock.picking"].browse(new_picking)
+            picking.write({"carrier_id": self.picking_id.carrier_id.id})
+        return new_picking, pick_type_id


### PR DESCRIPTION
- This is a takeover of this PR: https://github.com/OCA/delivery-carrier/pull/663
- It includes the same commit, but renamed to respect conventions (no odoo version in commits title)
- Also, it adds 2 things to improve the flow for Returns:
  - Returns will use same carrier as the original picking by default
  - native button `Print Return Labels` is shown for Returns instead of custom `Create Shipping Label`, and Return picking is properly identified as a return, with `is_return_picking = True`