### PR TITLE
[16.0][FIX] postlogistics: Set customer name mandatory

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -168,6 +168,8 @@ class PostlogisticsWebService(object):
         if picking.picking_type_id.code != "outgoing":
             partner = picking.partner_id
 
+        if not partner.name:
+            raise exceptions.UserError(_("Customer name is required."))
         customer = {
             "name1": self._sanitize_string(partner.name),
             "street": self._sanitize_string(partner.street),


### PR DESCRIPTION
if name1 is empty, postlogistics api returns an error.
Catch this before this is sent.