### PR TITLE
[14.0] delivery_postlogistics: fix 'sanitize_strings' to always return strings

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -455,9 +455,9 @@ class PostlogisticsWebService(object):
 
     def _sanitize_string(self, value):
         """Removes disallowed chars ("|", "\", "<", ">", "’", "‘") from strings."""
-        if isinstance(value, str):
-            for char, repl in DISALLOWED_CHARS_MAPPING.items():
-                value = value.replace(char, repl)
+        value = value or ""
+        for char, repl in DISALLOWED_CHARS_MAPPING.items():
+            value = value.replace(char, repl)
         return value
 
     def generate_label(self, picking, packages):

--- a/delivery_postlogistics/tests/test_sanitize_values.py
+++ b/delivery_postlogistics/tests/test_sanitize_values.py
@@ -22,7 +22,7 @@ class TestSanitizeValues(TestPostlogisticsCommon):
                 "street": "42\\|<>whateverstraße",
                 "street2": "42\\|<>whateverstraße",
                 "zip": "43123\\",
-                "city": "Mouais\\<>|",
+                "city": False,
             }
         )
 


### PR DESCRIPTION
Still an open question about this one: should the city of the partner be mandatory when it comes to send data to the delivery carrier about a shipment? (in a general manner, not only for PostLogistics)

ref 4054