### PR TITLE
[16.0][FIX] delivery_auto_refresh: fix auto_add_delivery_line setting

### DIFF
--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -66,7 +66,8 @@ class SaleOrder(models.Model):
         if self._get_param_auto_add_delivery_line() and self.carrier_id:
             if self.state in {"draft", "sent"}:
                 price_unit = self.carrier_id.rate_shipment(self)["price"]
-                self._create_delivery_line(self.carrier_id, price_unit)
+                if not self.is_all_service:
+                    self._create_delivery_line(self.carrier_id, price_unit)
                 self.with_context(auto_refresh_delivery=True).write(
                     {"recompute_delivery_price": False}
                 )

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -308,3 +308,20 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         sale_form.order_line.remove(0)
         sale_form.save()
         self.assertFalse(delivery_line.exists())
+
+    def test_auto_add_delivery_line_add_service(self):
+        """Delivery line should not be created because
+        there are only service products in SO"""
+        service = self.env["product.product"].create(
+            {"name": "Service Test", "type": "service"}
+        )
+        order_form = Form(self.env["sale.order"])
+        order_form.partner_id = self.partner
+        order_form.partner_invoice_id = self.partner
+        order_form.partner_shipping_id = self.partner
+        with order_form.order_line.new() as ol_form:
+            ol_form.product_id = service
+            ol_form.product_uom_qty = 2
+        order = order_form.save()
+        delivery_line = order.order_line.filtered("is_delivery")
+        self.assertFalse(delivery_line.exists())


### PR DESCRIPTION
Now when creating a new SO consisting of product services, the delivery line is not added.