### PR TITLE
[14.0][FIX] delivery_carrier_label_batch: invalid field 

### DIFF
--- a/delivery_carrier_label_batch/models/stock_batch_picking.py
+++ b/delivery_carrier_label_batch/models/stock_batch_picking.py
@@ -16,6 +16,7 @@ class StockBatchPicking(models.Model):
     carrier_id = fields.Many2one(
         "delivery.carrier", "Carrier", states={"done": [("readonly", True)]}
     )
+    carrier_code = fields.Char(related="carrier_id.code", readonly=True)
     option_ids = fields.Many2many("delivery.carrier.option", string="Options")
 
     def action_set_options(self):
@@ -43,7 +44,6 @@ class StockBatchPicking(models.Model):
             available_options = self.carrier_id.available_option_ids
             default_options = self._get_options_to_add()
             self.option_ids = [(6, 0, default_options.ids)]
-            self.carrier_code = self.carrier_id.code
             return {
                 "domain": {
                     "option_ids": [("id", "in", available_options.ids)],


### PR DESCRIPTION
Bug already corrected once here https://github.com/OCA/delivery-carrier/pull/511, but reintroduced here https://github.com/OCA/delivery-carrier/pull/509 in the last force push https://github.com/OCA/delivery-carrier/commit/4548133072a26621ba74394473658f2da7ee3f01

Traceback
```
Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'stock.picking.batch' object has no attribute 'carrier_code'
```