### PR TITLE
[IMP] delivery_package_number: number of packages in the backorder wizard

### DIFF
--- a/delivery_package_number/__manifest__.py
+++ b/delivery_package_number/__manifest__.py
@@ -14,5 +14,6 @@
     "data": [
         "views/stock_picking_views.xml",
         "wizard/stock_immediate_transfer_views.xml",
+        "wizard/stock_backorder_confirmation_views.xml",
     ],
 }

--- a/delivery_package_number/readme/CONTRIBUTORS.rst
+++ b/delivery_package_number/readme/CONTRIBUTORS.rst
@@ -3,3 +3,8 @@
   * Pedro M. Baeza
   * David Vidal
   * Marçal Isern
+
+
+ * `Sygel <https://www.sygel.es>`_:
+
+  * Ángel García de la Chica Herrera <angel.garcia@sygel.es>

--- a/delivery_package_number/wizard/__init__.py
+++ b/delivery_package_number/wizard/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_inmediate_transfer
+from . import stock_backorder_confirmation

--- a/delivery_package_number/wizard/stock_backorder_confirmation.py
+++ b/delivery_package_number/wizard/stock_backorder_confirmation.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Ángel García de la Chica Herrera <angel.garcia@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class StockBackorderConfirmation(models.TransientModel):
+    _inherit = "stock.backorder.confirmation"
+
+    number_of_packages = fields.Integer(
+        help="Set the number of packages for picking to be validated",
+    )
+    ask_number_of_packages = fields.Boolean(compute="_compute_ask_number_of_packages")
+
+    @api.depends("pick_ids")
+    def _compute_ask_number_of_packages(self):
+        for item in self:
+            item.ask_number_of_packages = bool(item.pick_ids.carrier_id)
+
+    def process(self):
+        if self.number_of_packages:
+            self.pick_ids.write({"number_of_packages": self.number_of_packages})
+        return super().process()

--- a/delivery_package_number/wizard/stock_backorder_confirmation_views.xml
+++ b/delivery_package_number/wizard/stock_backorder_confirmation_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="delivery_package_number_view_backorder_confirmation" model="ir.ui.view">
+        <field name="name">delivery.package.number.view.backorder.confirmation</field>
+        <field name="model">stock.backorder.confirmation</field>
+        <field name="inherit_id" ref="stock.view_backorder_confirmation" />
+        <field name="arch" type="xml">
+            <xpath expr="//footer" position="before">
+                <field name="ask_number_of_packages" invisible="1" />
+                <group attrs="{'invisible': [('ask_number_of_packages','=',False)]}">
+                    <field name="number_of_packages" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The number of packages is added to the backorder wizard in the same way as it appears in the wizard to validate all picking. 

![2023-09-22 13-44-53](https://github.com/OCA/delivery-carrier/assets/101106685/2767eb77-90c6-496b-bdd3-96777041cd8f)
