### PR TITLE
[14.0][FIX] delivery_schenker: correct float_round return

### DIFF
--- a/delivery_schenker/tests/common.py
+++ b/delivery_schenker/tests/common.py
@@ -54,7 +54,7 @@ class TestDeliverySchenkerCommon(common.SavepointCase):
                 "name": "Test product",
                 "type": "product",
                 "weight": 1,
-                "volume": 1,
+                "volume": 1.875,
             }
         )
         cls.sale, cls.picking = cls._create_sale_order(cls)
@@ -132,21 +132,21 @@ class TestDeliverySchenkerCommon(common.SavepointCase):
             "incotermLocation": "Test partner",
             "productCode": "CON",
             "measurementType": "METRIC",
-            "grossWeight": 1.0,
+            "grossWeight": "1.00",
             "shippingInformation": {
                 "shipmentPosition": [
                     {
                         "dgr": False,
                         "cargoDesc": picking.name,
-                        "grossWeight": 1.0,
-                        "volume": 1.0,
+                        "grossWeight": "1.00",
+                        "volume": "1.88",
                         "packageType": "CI",
                         "stackable": False,
                         "pieces": 1,
                     }
                 ],
-                "grossWeight": 1.0,
-                "volume": 1.0,
+                "grossWeight": "1.00",
+                "volume": "1.88",
             },
             "measureUnit": "VOLUME",
             "customsClearance": False,
@@ -166,7 +166,7 @@ class TestDeliverySchenkerCommon(common.SavepointCase):
             "ownPickup": True,
             "pharmaceuticals": True,
             "submitBooking": True,
-            "measureUnitVolume": 1.0,
+            "measureUnitVolume": "1.88",
         }
         res.update(vals)
         return res

--- a/delivery_schenker_quant_package_dimension/tests/test_delivery_schenker.py
+++ b/delivery_schenker_quant_package_dimension/tests/test_delivery_schenker.py
@@ -16,6 +16,13 @@ class TestDeliverySchenker(TestDeliverySchenkerCommon):
         package.width = width
         package.height = height
         expected_vals = self._prepare_schenker_shipping(picking)
+
+        # Turn dimensions into str
+        length = str(length) + "0"
+        width = str(width) + "0"
+        height = str(height) + "0"
+        volume = str(volume) + "0"
+
         expected_vals["shippingInformation"]["shipmentPosition"][0].update(
             {
                 "cargoDesc": " / ".join([picking.name, package.name]),


### PR DESCRIPTION
Because float_round as an example returns for 1.88 -> 1.880...01
we have to round it properly with float_repr 