### PR TITLE
[16.0][FIX] delivery_cttexpress: add zeep as external_dependencies in maniest file

### DIFF
--- a/delivery_cttexpress/__manifest__.py
+++ b/delivery_cttexpress/__manifest__.py
@@ -10,6 +10,7 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["delivery_package_number", "delivery_state", "delivery_price_method"],
+    "external_dependencies": {"python": ["zeep"]},
     "data": [
         "security/ir.model.access.csv",
         "wizards/cttexpress_manifest_wizard_views.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # generated from manifests external_dependencies
+zeep


### PR DESCRIPTION
add zeep as external_dependencies in maniest file