### PR TITLE
[16.0][FIX] delivery_package_fee: call map_tax in fiscal.position properly

### DIFF
--- a/delivery_package_fee/models/sale_order.py
+++ b/delivery_package_fee/models/sale_order.py
@@ -57,10 +57,8 @@ class SaleOrder(models.Model):
             lambda t: t.company_id.id == self.company_id.id
         )
         taxes_ids = taxes.ids
-        if self.partner_id and self.fiscal_position_id:
-            taxes_ids = self.fiscal_position_id.map_tax(
-                taxes, fee_product, self.partner_id
-            ).ids
+        if self.fiscal_position_id:
+            taxes_ids = self.fiscal_position_id.map_tax(taxes).ids
 
         # line description
         if fee_product.description_sale:


### PR DESCRIPTION
# Context
delivery_package_fee/models/sale_order.py", line 55, in _prepare_package_fee_line taxes_ids = self.fiscal_position_id.map_tax( TypeError: map_tax() takes 2 positional arguments but 4 were given

# TODO
- fix calling map_tax method
- add test case for using fiscal.position