### PR TITLE
[14.0][FIX] delivery_send_to_shipper_at_operation

### DIFF
--- a/delivery_send_to_shipper_at_operation/models/stock_picking.py
+++ b/delivery_send_to_shipper_at_operation/models/stock_picking.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from lxml import etree
@@ -16,7 +17,7 @@ from odoo.addons.base.models.ir_ui_view import (
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    delivery_notification_sent = fields.Boolean(default=False)
+    delivery_notification_sent = fields.Boolean(default=False, copy=False)
 
     def _send_confirmation_email(self):
         for picking in self:

--- a/delivery_send_to_shipper_at_operation/readme/CONTRIBUTORS.rst
+++ b/delivery_send_to_shipper_at_operation/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Sébastien Alix <sebastien.alix@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
     * Nguyen Hoang Hiep <hiepnh@trobz.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>


### PR DESCRIPTION
When duplicating an already send picking, allow to register it at the shipper

Includes: https://github.com/OCA/delivery-carrier/pull/734