### PR TITLE
[14.0][IMP] delivery_schenker : submit booking

### DIFF
--- a/delivery_schenker/models/delivery_carrier.py
+++ b/delivery_schenker/models/delivery_carrier.py
@@ -179,6 +179,13 @@ class DeliveryCarrier(models.Model):
         help="If set, this contact will be sent as invoice address to Schenker."
         "\nIf Address ID is set, it will be part of it instead of the sender",
     )
+    schenker_submit_booking = fields.Boolean(
+        string="Submit Booking",
+        default=True,
+        help="Submit Booking On Schenker site."
+        "\nIf set, submits booking on site automatically."
+        "\nIf not set, user has to submit booking manually.",
+    )
 
     def _get_schenker_credentials(self):
         """Access key is mandatory for every request while group and user are
@@ -518,6 +525,11 @@ class DeliveryCarrier(models.Model):
                 "homeDelivery": self.schenker_home_delivery,
                 "ownPickup": self.schenker_own_pickup,
                 "pharmaceuticals": self.schenker_pharmaceuticals,
+                # From the Schenker docs:
+                # Defines if booking shall be submitted. If false,
+                # the booking can be edited
+                # in the frontend and MUST be submitted manually.
+                "submitBooking": self.schenker_submit_booking,
             }
         )
         vals.update(self._schenker_measures(picking, vals))

--- a/delivery_schenker/models/schenker_request.py
+++ b/delivery_schenker/models/schenker_request.py
@@ -126,10 +126,6 @@ class SchenkerRequest:
         vals = self._shipping_api_credentials()
         method_wrapper = self._scheneker_shipping_api_wrapper(method)
         vals[method_wrapper] = picking_vals
-        # From the Schenker docs:
-        # Defines if booking shall be submitted. If false, the booking can be edited
-        # in the frontend and MUST be submitted manually.
-        vals[method_wrapper].update({"submitBooking": True})
         response = self._process_reply(
             self.client.service[self._shipping_type_method(method)], vals
         )

--- a/delivery_schenker/tests/common.py
+++ b/delivery_schenker/tests/common.py
@@ -165,6 +165,7 @@ class TestDeliverySchenkerCommon(common.SavepointCase):
             "homeDelivery": True,
             "ownPickup": True,
             "pharmaceuticals": True,
+            "submitBooking": True,
             "measureUnitVolume": 1.0,
         }
         res.update(vals)

--- a/delivery_schenker/views/delivery_schenker_view.xml
+++ b/delivery_schenker/views/delivery_schenker_view.xml
@@ -53,6 +53,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
                                 name="schenker_service_land"
                                 attrs="{'required': [('delivery_type', '=', 'schenker'), ('schenker_booking_type', '=', 'land')], 'invisible': [('schenker_booking_type', '!=', 'land')]}"
                             />
+                            <field name="schenker_submit_booking" />
                             <field name="schenker_indoor_delivery" />
                             <field name="schenker_express" />
                             <field name="schenker_food_related" />


### PR DESCRIPTION
- Added field for schenker delivery carrier, where user can pick if they want to submit booking on schenker site. In case where it is turned off - user has to submit booking manually.