### PR TITLE
[16.0][FIX] postlogistics: use parent name on customer if not set

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -168,10 +168,11 @@ class PostlogisticsWebService(object):
         if picking.picking_type_id.code != "outgoing":
             partner = picking.partner_id
 
-        if not partner.name:
+        partner_name = partner.name or partner.parent_id.name
+        if not partner_name:
             raise exceptions.UserError(_("Customer name is required."))
         customer = {
-            "name1": self._sanitize_string(partner.name)[:35],
+            "name1": self._sanitize_string(partner_name)[:35],
             "street": self._sanitize_string(partner.street)[:35],
             "zip": self._sanitize_string(partner.zip)[:10],
             "city": self._sanitize_string(partner.city)[:35],


### PR DESCRIPTION
In the case of a return, do as it is done with outgoing pickings, use parent's name if not set on the partner.