### PR TITLE
[14.0][IMP] delivery_cttexpress: configurable label delay

### DIFF
--- a/delivery_cttexpress/models/delivery_carrier.py
+++ b/delivery_cttexpress/models/delivery_carrier.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import time
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -42,6 +43,13 @@ class DeliveryCarrier(models.Model):
         string="Document format",
     )
     cttexpress_document_offset = fields.Integer(string="Document Offset")
+    cttexpress_label_delay = fields.Float(
+        string="Label Fetch Delay (seconds)",
+        help="The server might not be ready to deliver the label right after the "
+        "shipping is saved. We need to introduce a little delay. Tipacally 1 s will be "
+        "enough",
+        default=1,
+    )
 
     def _ctt_request(self):
         """Get CTT Request object
@@ -254,6 +262,7 @@ class DeliveryCarrier(models.Model):
         if not reference:
             return False
         ctt_request = self._ctt_request()
+        time.sleep(self.cttexpress_label_delay)
         try:
             error, label = ctt_request.get_documents_multi(
                 reference,

--- a/delivery_cttexpress/views/delivery_cttexpress_view.xml
+++ b/delivery_cttexpress/views/delivery_cttexpress_view.xml
@@ -72,6 +72,7 @@
                                 name="cttexpress_document_offset"
                                 attrs="{'required': [('delivery_type', '=', 'cttexpress')]}"
                             />
+                            <field name="cttexpress_label_delay" />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
fw of https://github.com/OCA/delivery-carrier/pull/735

When we recod a shipping in the CTT Express backend the label API could not be ready in the moment to retrieve the labels. As CTT Express stated, a little delay would add the needed time for the API to be ready.

cc @Tecnativa TT46443

please review @pedrobaeza @victoralmau 