### PR TITLE
[14.0][FIX] delivery_purchase: Change the position of the carrier to the purchase order header

### DIFF
--- a/delivery_purchase/views/purchase_order_view.xml
+++ b/delivery_purchase/views/purchase_order_view.xml
@@ -5,22 +5,19 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='company_id']/.." position="inside">
+            <field name="origin" position="after">
                 <label for="carrier_id" />
-                <div>
-                    <field
-                        name="carrier_id"
-                        class="oe_inline"
-                        style="margin-right: 3.0em;"
-                    />
+                <div class="d-flex">
+                    <field name="carrier_id" options="{'no_open': True}" />
+                    <span class="o_form_label mx-3" />
                     <field
                         name="delivery_price"
-                        class="oe_inline"
                         widget='monetary'
                         options="{'currency_field': 'currency_id'}"
+                        attrs="{'invisible': [('carrier_id', '=', False)]}"
                     />
                 </div>
-            </xpath>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Change the position of the carrier to the purchase order header.

**v13**:
![purchase-order-v13](https://github.com/OCA/delivery-carrier/assets/4117568/1c8a7c37-fa1e-4188-ac8c-7736f35cf8c8)

**Before**:
![purchase-order-antes](https://github.com/OCA/delivery-carrier/assets/4117568/aa45dab4-6506-4a8f-8340-43b76b151a28)

**After**:
![purchase-order-ahora](https://github.com/OCA/delivery-carrier/assets/4117568/cc77da07-6c9f-40a2-8868-123219c86f1f)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45656