### PR TITLE
[14.0][IMP] delivery_purchase: Set carrier_price when creating a picking

### DIFF
--- a/delivery_purchase/models/purchase_order.py
+++ b/delivery_purchase/models/purchase_order.py
@@ -43,6 +43,7 @@ class PurchaseOrder(models.Model):
         res = super()._prepare_picking()
         if self.carrier_id:
             res["carrier_id"] = self.carrier_id.id
+            res["carrier_price"] = self.delivery_price
         return res
 
     def _create_delivery_line(self, carrier, price_unit):

--- a/delivery_purchase/tests/test_delivery_purchase.py
+++ b/delivery_purchase/tests/test_delivery_purchase.py
@@ -105,9 +105,11 @@ class TestDeliveryPurchase(common.SavepointCase):
         self.assertEqual(self.purchase.delivery_price, 30)
 
     def test_picking_carrier_01(self):
+        self.assertEqual(self.purchase.delivery_price, 20)
         self.purchase.button_confirm()
         picking = self.purchase.picking_ids
         self.assertEqual(picking.carrier_id, self.carrier_fixed)
+        self.assertEqual(picking.carrier_price, 20)
         picking.carrier_id = self.carrier_rules.id
         self._action_picking_validate(picking)
         self.assertEqual(picking.carrier_price, 10)

--- a/delivery_purchase/tests/test_delivery_purchase.py
+++ b/delivery_purchase/tests/test_delivery_purchase.py
@@ -3,7 +3,7 @@
 from odoo.tests import Form, common
 
 
-class TestDeliveryPurchase(common.SavepointCase):
+class TestDeliveryPurchaseBase(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -77,6 +77,8 @@ class TestDeliveryPurchase(common.SavepointCase):
         model = self.env[res["res_model"]].with_context(**res["context"])
         model.create({}).process()
 
+
+class TestDeliveryPurchase(TestDeliveryPurchaseBase):
     def test_onchange_partner_id(self):
         self.assertEqual(self.purchase.carrier_id, self.carrier_fixed)
 


### PR DESCRIPTION
Set `carrier_price` when creating a picking

If we have a delivery price of 10 on the order, it is expected to show 10 on the picking (without needing to be set to that amount when set the picking as done).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45656