### PR TITLE
[14.0][FIX] postlogistics delivery fix date computation

### DIFF
--- a/delivery_postlogistics/models/stock_move.py
+++ b/delivery_postlogistics/models/stock_move.py
@@ -10,13 +10,10 @@ class StockMove(models.Model):
     def _get_new_picking_values(self):
         vals = super(StockMove, self)._get_new_picking_values()
 
-        order_commitment_date = (
-            self.sale_line_id and self.sale_line_id.order_id.commitment_date
-        )
-
-        if order_commitment_date:
+        order_commitment_dates = self.sale_line_id.order_id.mapped("commitment_date")
+        if order_commitment_dates:
             user_time = fields.Datetime.context_timestamp(
-                self, order_commitment_date
+                self, max(order_commitment_dates)
             ).date()
             vals["delivery_fixed_date"] = user_time
         return vals


### PR DESCRIPTION
If there is multiple commitment dates when creating a picking. Use the date the furthest in the future.