### PR TITLE
[FIX] delivery_package_type_number_parcels: make number of parcels computed

### DIFF
--- a/delivery_package_type_number_parcels/models/stock_quant_package.py
+++ b/delivery_package_type_number_parcels/models/stock_quant_package.py
@@ -1,13 +1,17 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockQuantPackage(models.Model):
     _inherit = "stock.quant.package"
 
     number_of_parcels = fields.Integer(
-        related="package_type_id.number_of_parcels",
-        store=True,
+        compute="_compute_number_of_parcels", store=True, readonly=False
     )
+
+    @api.depends("package_type_id")
+    def _compute_number_of_parcels(self):
+        for rec in self:
+            rec.number_of_parcels = rec.package_type_id.number_of_parcels

--- a/delivery_package_type_number_parcels/tests/test_package_type_number_parcels.py
+++ b/delivery_package_type_number_parcels/tests/test_package_type_number_parcels.py
@@ -97,3 +97,15 @@ class TestStockQuantPackageDelivery(TestPackingCommon):
         self.assertEqual(
             package1.number_of_parcels, self.package_type.number_of_parcels
         )
+        return package1
+
+    def test_manual_number_of_parcels(self):
+        package = self.test_put_in_pack_choose_carrier_wizard()
+        self.assertEqual(package.number_of_parcels, 7)
+        self.package_type.number_of_parcels = 8
+        self.assertEqual(package.number_of_parcels, 7)
+        package.number_of_parcels = 9
+        self.assertEqual(package.number_of_parcels, 9)
+        self.assertEqual(self.package_type.number_of_parcels, 8)
+        package.package_type_id = self.package_type.copy({"number_of_parcels": 10})
+        self.assertEqual(package.number_of_parcels, 10)


### PR DESCRIPTION
avoid related for this field as we don't want to change the pakcage type value when it changes in the package

cc/ @lmignon 