### PR TITLE
[16.0][IMP] delivery_package_number: add field for auto printing

### DIFF
--- a/delivery_package_number/__manifest__.py
+++ b/delivery_package_number/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock Picking Package Number",
     "summary": "Set or compute number of packages for a picking",
-    "version": "16.0.2.1.0",
+    "version": "16.0.3.0.0",
     "category": "Delivery",
     "website": "https://github.com/OCA/delivery-carrier",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/delivery_package_number/migrations/16.0.3.0.0/post-migration.py
+++ b/delivery_package_number/migrations/16.0.3.0.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Studio73 - Ferran Mora
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    ptypes = env["stock.picking.type"].search([("print_label", "=", True)])
+    if ptypes:
+        ptypes.write({"print_label_on_validate": True})

--- a/delivery_package_number/models/stock_picking_type.py
+++ b/delivery_package_number/models/stock_picking_type.py
@@ -6,6 +6,10 @@ from odoo import fields, models
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
+    print_label_on_validate = fields.Boolean(
+        string="Print label on validate",
+        help="Print the number of packages label when validating a picking of this type",
+    )
     force_set_number_of_packages = fields.Boolean()
     report_number_of_packages = fields.Many2one(
         "ir.actions.report",

--- a/delivery_package_number/views/stock_picking_type_views.xml
+++ b/delivery_package_number/views/stock_picking_type_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='default_location_src_id']/.." position="after">
                 <group string="Number of packages">
+                    <field name="print_label_on_validate" />
                     <field name="force_set_number_of_packages" />
                     <field name="report_number_of_packages" />
                 </group>

--- a/delivery_package_number/wizard/stock_number_package_validate_wiz.py
+++ b/delivery_package_number/wizard/stock_number_package_validate_wiz.py
@@ -25,7 +25,9 @@ class StockNumberPackageValidateWiz(models.TransientModel):
     @api.depends("pick_ids")
     def _compute_print_package_label(self):
         for item in self:
-            item.print_package_label = item.pick_ids.picking_type_id.print_label
+            item.print_package_label = (
+                item.pick_ids.picking_type_id.print_label_on_validate
+            )
 
     @api.depends("pick_ids")
     def _compute_stock_number_package_validation_line_ids(self):


### PR DESCRIPTION
I know this may be a bit counterintuitive but the print_label base field is used for sending to shipper so making these labels auto printed by this field has caused an issue in some clients that want to have the shipper feature but don't want the number of packages label.
Best way I've found to resolve the issue is by creating a dedicated field to configure the auto-printing.