### PR TITLE
[16.0][IMP] delivery_driver: Flag driver in partner

### DIFF
--- a/delivery_driver/README.rst
+++ b/delivery_driver/README.rst
@@ -58,24 +58,27 @@ To use this module, you need to:
 
 1. Go to Inventory / Configuration / Shipping Methods.
 2. Create new Shipping Method o choose one already created.
-3. Choose Default Driver.
+3. Choose a partner as default driver.
+4. Click on partner choosen.
+5. Go to page Sale & Purchase.
+6. Check Driver is marked.
 
 Sale Flow:
 
-4. Go to Sales / Orders / Quotations.
-5. Create new Sale Order with non Service product with Quantity > 1.
-6. Confirm Sale Order.
-7. Go to Delivery in Delivery smart button.
-8. Driver was automatically assigned in picking from Carrier.
-9. You can change the driver without changing the carrier.
+1. Go to Sales / Orders / Quotations.
+2. Create new Sale Order with non Service product with Quantity > 1.
+3. Confirm Sale Order.
+4. Go to Delivery in Delivery smart button.
+5. Driver was automatically assigned in picking from Carrier.
+6. You can change the driver without changing the carrier.
 
 Stock Flow:
 
-10. Go to Inventory / Operations / Transfer.
-11. Create new Transfer.
-12. Choose carrier.
-13. The driver is automatically assigned.
-14. You can change the driver without changing the carrier.
+7.  Go to Inventory / Operations / Transfer.
+8.  Create new Transfer.
+9.  Choose carrier.
+10. The driver is automatically assigned.
+11. You can change the driver without changing the carrier.
 
 Bug Tracker
 ===========

--- a/delivery_driver/__manifest__.py
+++ b/delivery_driver/__manifest__.py
@@ -20,5 +20,6 @@
         "views/delivery_carrier.xml",
         "views/stock_picking.xml",
         "views/stock_move_line.xml",
+        "views/res_partner.xml",
     ],
 }

--- a/delivery_driver/i18n/delivery_driver.pot
+++ b/delivery_driver/i18n/delivery_driver.pot
@@ -4,14 +4,21 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-27 14:14+0000\n"
+"PO-Revision-Date: 2024-02-27 14:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: delivery_driver
+#: model:ir.model,name:delivery_driver.model_res_partner
+msgid "Contact"
+msgstr ""
 
 #. module: delivery_driver
 #: model:ir.model.fields,field_description:delivery_driver.field_delivery_carrier__driver_id
@@ -24,9 +31,12 @@ msgid "Default driver for this delivery method"
 msgstr ""
 
 #. module: delivery_driver
+#: model:ir.model.fields,field_description:delivery_driver.field_res_partner__is_driver
+#: model:ir.model.fields,field_description:delivery_driver.field_res_users__is_driver
 #: model:ir.model.fields,field_description:delivery_driver.field_stock_move_line__driver_id
 #: model:ir.model.fields,field_description:delivery_driver.field_stock_picking__driver_id
 #: model_terms:ir.ui.view,arch_db:delivery_driver.view_delivery_carrier_search_inherit_delivery_driver
+#: model_terms:ir.ui.view,arch_db:delivery_driver.view_partner_form_inherit_delivery_driver
 #: model_terms:ir.ui.view,arch_db:delivery_driver.view_picking_internal_search_inherit_delivery_driver
 msgid "Driver"
 msgstr ""
@@ -44,4 +54,13 @@ msgstr ""
 #. module: delivery_driver
 #: model:ir.model,name:delivery_driver.model_stock_picking
 msgid "Transfer"
+msgstr ""
+
+#. module: delivery_driver
+#. odoo-python
+#: code:addons/delivery_driver/models/res_partner.py:0
+#, python-format
+msgid ""
+"You can't remove the driver flag from a partner that is set as driver in a "
+"delivery method."
 msgstr ""

--- a/delivery_driver/i18n/es.po
+++ b/delivery_driver/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-03 10:00+0000\n"
-"PO-Revision-Date: 2024-01-03 11:02+0100\n"
+"POT-Creation-Date: 2024-02-27 14:14+0000\n"
+"PO-Revision-Date: 2024-02-27 15:19+0100\n"
 "Last-Translator: Emilio Pascual <emilio@moduom.team>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. module: delivery_driver
+#: model:ir.model,name:delivery_driver.model_res_partner
+msgid "Contact"
+msgstr ""
 
 #. module: delivery_driver
 #: model:ir.model.fields,field_description:delivery_driver.field_delivery_carrier__driver_id
@@ -28,9 +33,12 @@ msgid "Default driver for this delivery method"
 msgstr "Conductor por defecto para este método de envío"
 
 #. module: delivery_driver
+#: model:ir.model.fields,field_description:delivery_driver.field_res_partner__is_driver
+#: model:ir.model.fields,field_description:delivery_driver.field_res_users__is_driver
 #: model:ir.model.fields,field_description:delivery_driver.field_stock_move_line__driver_id
 #: model:ir.model.fields,field_description:delivery_driver.field_stock_picking__driver_id
 #: model_terms:ir.ui.view,arch_db:delivery_driver.view_delivery_carrier_search_inherit_delivery_driver
+#: model_terms:ir.ui.view,arch_db:delivery_driver.view_partner_form_inherit_delivery_driver
 #: model_terms:ir.ui.view,arch_db:delivery_driver.view_picking_internal_search_inherit_delivery_driver
 msgid "Driver"
 msgstr "Conductor"
@@ -49,3 +57,14 @@ msgstr "Métodos de envío"
 #: model:ir.model,name:delivery_driver.model_stock_picking
 msgid "Transfer"
 msgstr "Albarán"
+
+#. module: delivery_driver
+#. odoo-python
+#: code:addons/delivery_driver/models/res_partner.py:0
+#, python-format
+msgid ""
+"You can't remove the driver flag from a partner that is set as driver in a "
+"delivery method."
+msgstr ""
+"No se puede eliminar el indicador de conductor de un contacto que esté "
+"establecido como conductor en un método de entrega."

--- a/delivery_driver/migrations/16.0.1.0.1/post-migration.py
+++ b/delivery_driver/migrations/16.0.1.0.1/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Moduon Team S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        partners = (
+            env["carrier.driver"]
+            .search([("driver_id", "!=", False)])
+            .mapped("driver_id")
+        )
+        partners.write({"is_driver": True})

--- a/delivery_driver/models/__init__.py
+++ b/delivery_driver/models/__init__.py
@@ -1,3 +1,4 @@
 from . import delivery_carrier
 from . import stock_picking
 from . import stock_move_line
+from . import res_partner

--- a/delivery_driver/models/delivery_carrier.py
+++ b/delivery_driver/models/delivery_carrier.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class DeliveryCarrier(models.Model):
@@ -14,3 +14,17 @@ class DeliveryCarrier(models.Model):
         domain="[('is_company', '=', False)]",
         help="Default driver for this delivery method",
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        carriers = super().create(vals_list)
+        partners = carriers.mapped("driver_id")
+        if partners:
+            partners.write({"is_driver": True})
+        return carriers
+
+    def write(self, vals):
+        partner = self.env["res.partner"].browse(vals.get("driver_id", False))
+        if partner:
+            partner.write({"is_driver": True})
+        return super().write(vals)

--- a/delivery_driver/models/res_partner.py
+++ b/delivery_driver/models/res_partner.py
@@ -1,0 +1,33 @@
+# Copyright 2024 Moduon Team S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    is_driver = fields.Boolean("Driver")
+
+    @api.constrains("is_driver")
+    def _check_is_driver(self):
+        drivers_in_carrier = self.env["delivery.carrier"].search(
+            [("driver_id", "in", self.ids)]
+        )
+        if drivers_in_carrier and not self.is_driver:
+            raise ValidationError(
+                _(
+                    "You can't remove the driver flag from a partner that"
+                    " is set as driver in a delivery method."
+                )
+            )
+
+    def _get_name(self):
+        """When you see the driver in a list view, the display name is too long.
+        With this you can see only the name"""
+        if self.env.context.get("show_driver"):
+            name = self.name or ""
+            return f"{name}"
+        return super()._get_name()

--- a/delivery_driver/models/stock_move_line.py
+++ b/delivery_driver/models/stock_move_line.py
@@ -10,6 +10,6 @@ class StockMoveLine(models.Model):
 
     driver_id = fields.Many2one(
         related="picking_id.driver_id",
-        domain="[('is_company', '=', False)]",
+        domain="[('is_driver', '=', True)]",
         store="True",
     )

--- a/delivery_driver/readme/USAGE.md
+++ b/delivery_driver/readme/USAGE.md
@@ -2,22 +2,25 @@ To use this module, you need to:
 
 1. Go to Inventory / Configuration / Shipping Methods.
 2. Create new Shipping Method o choose one already created.
-3. Choose Default Driver.
+3. Choose a partner as default driver.
+4. Click on partner choosen.
+5. Go to page Sale & Purchase.
+6. Check Driver is marked.
 
 Sale Flow:
 
-4. Go to Sales / Orders / Quotations.
-5. Create new Sale Order with non Service product with Quantity > 1.
-6. Confirm Sale Order.
-7. Go to Delivery in Delivery smart button.
-8. Driver was automatically assigned in picking from Carrier.
-9. You can change the driver without changing the carrier.
+1. Go to Sales / Orders / Quotations.
+2. Create new Sale Order with non Service product with Quantity > 1.
+3. Confirm Sale Order.
+4. Go to Delivery in Delivery smart button.
+5. Driver was automatically assigned in picking from Carrier.
+6. You can change the driver without changing the carrier.
 
 Stock Flow:
 
-10. Go to Inventory / Operations / Transfer.
-11. Create new Transfer.
-12. Choose carrier.
-13. The driver is automatically assigned.
-14. You can change the driver without changing the carrier.
+7. Go to Inventory / Operations / Transfer.
+8. Create new Transfer.
+9. Choose carrier.
+10. The driver is automatically assigned.
+11. You can change the driver without changing the carrier.
 

--- a/delivery_driver/static/description/index.html
+++ b/delivery_driver/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -406,10 +405,13 @@ notes independently of the delivery method.</p>
 <ol class="arabic simple">
 <li>Go to Inventory / Configuration / Shipping Methods.</li>
 <li>Create new Shipping Method o choose one already created.</li>
-<li>Choose Default Driver.</li>
+<li>Choose a partner as default driver.</li>
+<li>Click on partner choosen.</li>
+<li>Go to page Sale &amp; Purchase.</li>
+<li>Check Driver is marked.</li>
 </ol>
 <p>Sale Flow:</p>
-<ol class="arabic simple" start="4">
+<ol class="arabic simple">
 <li>Go to Sales / Orders / Quotations.</li>
 <li>Create new Sale Order with non Service product with Quantity &gt; 1.</li>
 <li>Confirm Sale Order.</li>
@@ -418,7 +420,7 @@ notes independently of the delivery method.</p>
 <li>You can change the driver without changing the carrier.</li>
 </ol>
 <p>Stock Flow:</p>
-<ol class="arabic simple" start="10">
+<ol class="arabic simple" start="7">
 <li>Go to Inventory / Operations / Transfer.</li>
 <li>Create new Transfer.</li>
 <li>Choose carrier.</li>

--- a/delivery_driver/tests/test_delivery_driver.py
+++ b/delivery_driver/tests/test_delivery_driver.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -32,6 +33,14 @@ class TestDeliverDriver(TransactionCase):
                 "driver_id": cls.driver_test.id,
             }
         )
+
+    def test_partner_is_driver(self):
+        self.assertTrue(self.driver_test.is_driver)
+        self.assertFalse(self.partner_test.is_driver)
+        with self.assertRaises(ValidationError):
+            self.driver_test.write({"is_driver": False})
+        self.delivery_test.write({"driver_id": self.partner_test.id})
+        self.assertTrue(self.partner_test.is_driver)
 
     def test_sale_flow(self):
         sale_order = self.env["sale.order"].create(

--- a/delivery_driver/views/res_partner.xml
+++ b/delivery_driver/views/res_partner.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Moduon Team S.L.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0) -->
+<odoo>
+    <record id="view_partner_form_inherit_delivery_driver" model="ir.ui.view">
+        <field name="name">Partner Delivery Driver</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales_purchases']/group" position="inside">
+                <group name="Driver" string="Driver">
+                    <field name="is_driver" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/delivery_driver/views/stock_move_line.xml
+++ b/delivery_driver/views/stock_move_line.xml
@@ -11,7 +11,12 @@
         <field name="inherit_id" ref="delivery.view_move_line_tree_detailed_delivery" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='carrier_id']" position="after">
-                <field name="driver_id" optional="hide" />
+                <field
+                    name="driver_id"
+                    optional="hide"
+                    context="{'show_driver': True}"
+                    options='{"always_reload": True}'
+                />
             </xpath>
         </field>
     </record>
@@ -21,7 +26,12 @@
         <field name="inherit_id" ref="stock.view_move_line_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='location_dest_id']" position="after">
-                <field name="driver_id" optional="hide" />
+                <field
+                    name="driver_id"
+                    optional="hide"
+                    context="{'show_driver': True}"
+                    options='{"always_reload": True}'
+                />
             </xpath>
         </field>
     </record>

--- a/delivery_driver/views/stock_picking.xml
+++ b/delivery_driver/views/stock_picking.xml
@@ -11,7 +11,11 @@
         <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='carrier_data']" position="inside">
-                <field name="driver_id" />
+                <field
+                    name="driver_id"
+                    context="{'show_driver': True}"
+                    options='{"always_reload": True}'
+                />
             </xpath>
         </field>
     </record>
@@ -21,7 +25,12 @@
         <field name="inherit_id" ref="delivery.vpicktree_view_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='carrier_id']" position="after">
-                <field name="driver_id" optional="hide" />
+                <field
+                    name="driver_id"
+                    optional="hide"
+                    context="{'show_driver': True}"
+                    options='{"always_reload": True}'
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- When a driver is assigned in a shipping method, the partner is marked as a driver.
- Unmarking partners as drivers is not allowed if it is associated with a sending method.
- In pickings and move lines add domain in driver. Only partners marked as driver.
- When selecting a partner driver, only the name of the partner is displayed.
- If driver is changed in picking, also it's changed in origin picking (if you activated multi-steps routes)

MT-5232 @moduon

@rafaelbn @yajo @shide @gelojr please review.