### PR TITLE
[Fix] delivery_auto_refresh manually delete delivery line

### DIFF
--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -325,3 +325,11 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         order = order_form.save()
         delivery_line = order.order_line.filtered("is_delivery")
         self.assertFalse(delivery_line.exists())
+
+    def test_auto_refresh_so_and_manually_unlink_delivery_line(self):
+        """Test that we are able to manually remove the delivery line"""
+        self._test_autorefresh_unlink_line()
+        sale_form = Form(self.order)
+        # Deleting the delivery line
+        sale_form.order_line.remove(1)
+        sale_form.save()


### PR DESCRIPTION
# Context
When deleting manually delivery line we get the following:
![delivery_line_delete_error](https://github.com/OCA/delivery-carrier/assets/67733397/6b580508-9961-49e0-9ba1-f259bed1f2b8)
