### PR TITLE
[FIX] delivery_driver: wrong model name

### DIFF
--- a/delivery_driver/migrations/16.0.1.0.1/post-migration.py
+++ b/delivery_driver/migrations/16.0.1.0.1/post-migration.py
@@ -12,7 +12,7 @@ def migrate(cr, version):
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})
         partners = (
-            env["carrier.driver"]
+            env["delivery.carrier"]
             .search([("driver_id", "!=", False)])
             .mapped("driver_id")
         )


### PR DESCRIPTION
Regression from https://github.com/OCA/delivery-carrier/pull/774:

```

  File "/opt/odoo/auto/addons/delivery_driver/migrations/16.0.1.0.1/post-migration.py", line 15, in migrate
    env["carrier.driver"]
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 549, in __getitem__
    return self.registry[model_name](self, (), ())
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 190, in __getitem__
    return self.models[model_name]
KeyError: 'carrier.driver'
Error: 'carrier.driver'
```

@moduon MT-5232