### PR TITLE
[14.0][FIX] Unittests base_delivery_carrier_label: Separate github test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,18 @@ jobs:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
             name: test with Odoo
+            exclude: "base_delivery_carrier_label,delivery_carrier_label_batch,delivery_roulier,delivery_roulier_option,delivery_roulier_laposte_fr,delivery_roulier_chronopost_fr,carrier_account_environment"
           - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
             name: test with OCB
             makepot: "true"
+            exclude: "base_delivery_carrier_label,delivery_carrier_label_batch,delivery_roulier,delivery_roulier_option,delivery_roulier_laposte_fr,delivery_roulier_chronopost_fr,carrier_account_environment"
+          - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            name: test with Odoo
+            include: "base_delivery_carrier_label,delivery_carrier_label_batch,delivery_roulier,delivery_roulier_option,delivery_roulier_laposte_fr,delivery_roulier_chronopost_fr,carrier_account_environment"
+          - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            name: test with OCB
+            makepot: "true"
+            include: "base_delivery_carrier_label,delivery_carrier_label_batch,delivery_roulier,delivery_roulier_option,delivery_roulier_laposte_fr,delivery_roulier_chronopost_fr,carrier_account_environment"
     services:
       postgres:
         image: postgres:9.6
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/delivery_cttexpress/models/delivery_carrier.py
+++ b/delivery_cttexpress/models/delivery_carrier.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Tecnativa - David Vidal
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -168,7 +169,7 @@ class DeliveryCarrier(models.Model):
         return {
             "ClientReference": reference,  # Optional
             "ClientDepartmentCode": None,  # Optional (no core field matches)
-            "ItemsCount": picking.number_of_packages,
+            "ItemsCount": picking.number_of_packages or 1,
             "IsClientPodScanRequired": None,  # Optional
             "RecipientAddress": recipient.street,
             "RecipientCountry": recipient.country_id.code,

--- a/delivery_cttexpress/readme/CONTRIBUTORS.rst
+++ b/delivery_cttexpress/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * David Vidal
+
+* Michael Tietz (MT Software) <mtietz@mt-software.de>

--- a/delivery_package_fee/readme/CONTRIBUTORS.rst
+++ b/delivery_package_fee/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>

--- a/delivery_package_fee/tests/test_package_fee.py
+++ b/delivery_package_fee/tests/test_package_fee.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import Form, SavepointCase
@@ -322,7 +323,7 @@ class TestPackageFee(SavepointCase):
         self.assertEqual(picking.state, "assigned")
         picking.move_line_ids[0].qty_done = 10.0
         picking.move_line_ids[1].qty_done = 10.0
-        picking.with_context(set_default_package=False)._action_done()
+        picking._action_done()
         self.assertEqual(picking.state, "done")
 
         self.assertRecordValues(

--- a/delivery_package_number/readme/CONTRIBUTORS.rst
+++ b/delivery_package_number/readme/CONTRIBUTORS.rst
@@ -8,3 +8,5 @@
  * `Sygel <https://www.sygel.es>`_:
 
   * Ángel García de la Chica Herrera <angel.garcia@sygel.es>
+
+* Michael Tietz (MT Software) <mtietz@mt-software.de>

--- a/delivery_package_number/wizard/stock_backorder_confirmation.py
+++ b/delivery_package_number/wizard/stock_backorder_confirmation.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Ángel García de la Chica Herrera <angel.garcia@sygel.es>
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -24,7 +25,4 @@ class StockBackorderConfirmation(models.TransientModel):
     def process(self):
         if self.number_of_packages:
             self.pick_ids.write({"number_of_packages": self.number_of_packages})
-        # put context key for avoiding `base_delivery_carrier_label` auto-packaging feature
-        return super(
-            StockBackorderConfirmation, self.with_context(set_default_package=False)
-        ).process()
+        return super().process()

--- a/delivery_package_number/wizard/stock_inmediate_transfer.py
+++ b/delivery_package_number/wizard/stock_inmediate_transfer.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Tecnativa - David Vidal
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
 
@@ -23,7 +24,4 @@ class StockImmediateTransfer(models.TransientModel):
     def process(self):
         if self.number_of_packages:
             self.pick_ids.write({"number_of_packages": self.number_of_packages})
-        # put context key for avoiding `base_delivery_carrier_label` auto-packaging feature
-        return super(
-            StockImmediateTransfer, self.with_context(set_default_package=False)
-        ).process()
+        return super().process()

--- a/delivery_schenker/__manifest__.py
+++ b/delivery_schenker/__manifest__.py
@@ -11,7 +11,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["delivery_package_number", "delivery_state"],
+    "depends": ["delivery_state"],
     "external_dependencies": {"python": ["zeep"]},
     "data": [
         "views/delivery_schenker_view.xml",


### PR DESCRIPTION
Since base_delivery_carrier_label introduced a logic,
to a default stock.quant.package on stock.move.lines.
We always have to deal with it, in other not dependent addons. 
The context key `set_default_package` is used in multiple modules which do not have a dependency to base_delivery_carrier_label