### PR TITLE
[16.0][IMP] delivery_deliverea: add exchange attribute in serviceAttributes 

### DIFF
--- a/delivery_deliverea/models/delivery_carrier.py
+++ b/delivery_deliverea/models/delivery_carrier.py
@@ -107,6 +107,12 @@ class DeliveryCarrier(models.Model):
         comodel_name="carrier.deliverea.service",
         domain="[('deliverea_distribution_center_id', '=', deliverea_distribution_center_id)]",
     )
+    deliverea_exchange = fields.Boolean(
+        string="Exchange",
+        help="Mark expedition as exchange (when delivering the package,"
+        " another package has to be picked up from the final client and will be sent"
+        " back to the original sender. Availability depends on carrier and service)",
+    )
 
     def deliverea_get_distribution_centers(self):
         deliverea_request = DelivereaRequest(self)
@@ -357,6 +363,7 @@ class DeliveryCarrier(models.Model):
             "returnProofOfDelivery": carrier.deliverea_return_label,
             "hideSender": carrier.deliverea_hide_sender,
             "insuranceValue": "0.0 EUR",
+            "exchange": carrier.deliverea_exchange,
         }
         for parameter in service.deliverea_parameters:
             if parameter.name in values.keys():

--- a/delivery_deliverea/views/delivery_carrier_views.xml
+++ b/delivery_deliverea/views/delivery_carrier_views.xml
@@ -105,6 +105,7 @@
                             <field name="deliverea_return_label" />
                             <field name="deliverea_return_proof_delivery" />
                             <field name="deliverea_saturday_delivery" />
+                            <field name="deliverea_exchange" />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
Add exchange service attribute in _get_service_attributes method. 

![Selección_245](https://github.com/OCA/delivery-carrier/assets/62312240/c305942b-2be0-4603-8286-a2ea451c08e8)
