### PR TITLE
[16.0][FIX] stock_picking_delivery_link: Error on _set_delivery_packge_type override

### DIFF
--- a/stock_picking_delivery_link/models/stock_picking.py
+++ b/stock_picking_delivery_link/models/stock_picking.py
@@ -55,9 +55,9 @@ class StockPicking(models.Model):
         else:
             return res
 
-    def _set_delivery_package_type(self):
+    def _set_delivery_package_type(self, batch_pack=False):
         self.ensure_one()
-        res = super()._set_delivery_package_type()
+        res = super()._set_delivery_package_type(batch_pack=batch_pack)
         context = dict(
             self.env.context,
             current_package_carrier_type=self.ship_carrier_id.delivery_type,


### PR DESCRIPTION
When the method _set_delivery_package_type is called from _pre_put_in_pack_hook in the stock.picking model in the Odoo delivery module with the parameter batch_pack this error is raised

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 1633, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 1660, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 1864, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/addons/stock/models/stock_picking.py", line 1536, in action_put_in_pack
    res = self._pre_put_in_pack_hook(move_line_ids)
  File "/mnt/extra-addons/delivery-carrier/stock_picking_delivery_link/models/stock_picking.py", line 48, in _pre_put_in_pack_hook
    res = super()._pre_put_in_pack_hook(move_line_ids)
  File "/usr/lib/python3/dist-packages/odoo/addons/delivery/models/stock_picking.py", line 203, in _pre_put_in_pack_hook
    return self._set_delivery_package_type(batch_pack=len(move_line_ids.picking_id) > 1)
TypeError: _set_delivery_package_type() got an unexpected keyword argument 'batch_pack'