### PR TITLE
[16.0][FIX] delivery_postlogistics: splitting package label by package

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -568,7 +568,7 @@ class PostlogisticsWebService(object):
             res["success"] = True
             res["value"].append(
                 {
-                    "item_id": item_list[0]["itemID"],
+                    "item_id": item["itemID"],
                     "binary": binary,
                     "tracking_number": response_dict["item"]["identCode"],
                     "file_type": file_type,


### PR DESCRIPTION
### Problem : 

In a picking, if we create 2 or more packages, after generating the postlogistic labels, all tracking numbers are concatenated on the first package.

![image](https://github.com/OCA/delivery-carrier/assets/18470913/017f711b-1891-44b6-b820-555cca22797a)

![image](https://github.com/OCA/delivery-carrier/assets/18470913/dbc4abd1-f397-4068-a79c-13309da884d3)

It seems that this behavior was added here :
https://github.com/OCA/delivery-carrier/commit/5504c9f26dae2739abb68314bab7ffb2756f332d

More precisely here : https://github.com/OCA/delivery-carrier/blob/5504c9f26dae2739abb68314bab7ffb2756f332d/delivery_postlogistics/postlogistics/web_service.py#L511C1-L518C14

and here : 
https://github.com/OCA/delivery-carrier/pull/323/files#diff-d3c06dad2d58ebdeb558386909ed5b2ad9ed22d84b8476e5fb2658ae4308d61f

I didn't identify why the code was changed before versions, but now we are always taking the first package when preparing the label values that will be used on ``write_tracking_number_label`` method.