### PR TITLE
[16.0][IMP-FIX] delivery_auto_refresh - performance & compatibility & cleanup

### DIFF
--- a/delivery_auto_refresh/__manifest__.py
+++ b/delivery_auto_refresh/__manifest__.py
@@ -11,6 +11,8 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["delivery", "sale_order_carrier_auto_assign"],
+    "depends": ["delivery"],
+    # Migration Note 17.0: Add dependency to sale_order_carrier_auto_assign
+    # "depends": ["delivery", "sale_order_carrier_auto_assign"],
     "data": ["views/sale_order_views.xml", "views/res_config_settings_views.xml"],
 }

--- a/delivery_auto_refresh/__manifest__.py
+++ b/delivery_auto_refresh/__manifest__.py
@@ -4,13 +4,13 @@
 {
     "name": "Auto-refresh delivery",
     "summary": "Auto-refresh delivery price in sales orders",
-    "version": "16.0.1.0.1",
+    "version": "16.0.2.0.0",
     "category": "Delivery",
     "website": "https://github.com/OCA/delivery-carrier",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["delivery"],
+    "depends": ["delivery", "sale_order_carrier_auto_assign"],
     "data": ["views/sale_order_views.xml", "views/res_config_settings_views.xml"],
 }

--- a/delivery_auto_refresh/migrations/16.0.2.0.0/post-migration.py
+++ b/delivery_auto_refresh/migrations/16.0.2.0.0/post-migration.py
@@ -8,7 +8,7 @@ def _migrate_setting_to_company(env):
     if env["ir.config_parameter"].get_param(
         "delivery_auto_refresh.set_default_carrier"
     ):
-        env["res.company"].search([]).carrier_auto_assign_on_create = True
+        env["res.company"].search([]).sale_auto_assign_carrier_on_create = True
 
 
 def migrate(cr, version):

--- a/delivery_auto_refresh/migrations/16.0.2.0.0/post-migration.py
+++ b/delivery_auto_refresh/migrations/16.0.2.0.0/post-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def _migrate_setting_to_company(env):
+    if env["ir.config_parameter"].get_param(
+        "delivery_auto_refresh.set_default_carrier"
+    ):
+        env["res.company"].search([]).carrier_auto_assign_on_create = True
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _migrate_setting_to_company(env)

--- a/delivery_auto_refresh/migrations/16.0.2.0.0/post-migration.py
+++ b/delivery_auto_refresh/migrations/16.0.2.0.0/post-migration.py
@@ -10,6 +10,21 @@ def _migrate_setting_to_company(env):
     ):
         env["res.company"].search([]).sale_auto_assign_carrier_on_create = True
 
+    if env["ir.config_parameter"].get_param(
+        "delivery_auto_refresh.auto_add_delivery_line"
+    ):
+        env["res.company"].search([]).sale_auto_add_delivery_line = True
+
+    if env["ir.config_parameter"].get_param(
+        "delivery_auto_refresh.refresh_after_picking"
+    ):
+        env["res.company"].search([]).sale_refresh_delivery_after_picking = True
+
+    if env["ir.config_parameter"].get_param(
+        "delivery_auto_refresh.auto_void_delivery_line"
+    ):
+        env["res.company"].search([]).sale_auto_void_delivery_line = True
+
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})

--- a/delivery_auto_refresh/models/__init__.py
+++ b/delivery_auto_refresh/models/__init__.py
@@ -1,3 +1,4 @@
 from . import sale_order
 from . import stock_picking
+from . import res_company
 from . import res_config_settings

--- a/delivery_auto_refresh/models/res_company.py
+++ b/delivery_auto_refresh/models/res_company.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    # Migration Note 17.0: move this to module sale_order_carrier_auto_assign
+    sale_auto_assign_carrier_on_create = fields.Boolean(
+        "Set default shipping method automatically"
+    )
+    # End migration note

--- a/delivery_auto_refresh/models/res_company.py
+++ b/delivery_auto_refresh/models/res_company.py
@@ -12,3 +12,13 @@ class ResCompany(models.Model):
         "Set default shipping method automatically"
     )
     # End migration note
+
+    sale_auto_add_delivery_line = fields.Boolean(
+        "Refresh shipping cost line automatically",
+    )
+    sale_refresh_delivery_after_picking = fields.Boolean(
+        "Refresh delivery after picking automatically",
+    )
+    sale_auto_void_delivery_line = fields.Boolean(
+        "Void delivery lines automatically",
+    )

--- a/delivery_auto_refresh/models/res_config_settings.py
+++ b/delivery_auto_refresh/models/res_config_settings.py
@@ -14,15 +14,15 @@ class ResConfigSettings(models.TransientModel):
     )
     # End migration note
 
-    auto_add_delivery_line = fields.Boolean(
-        "Refresh shipping cost line automatically",
-        config_parameter="delivery_auto_refresh.auto_add_delivery_line",
+    sale_auto_add_delivery_line = fields.Boolean(
+        related="company_id.sale_auto_add_delivery_line",
+        readonly=False,
     )
-    refresh_after_picking = fields.Boolean(
-        "Refresh after picking automatically",
-        config_parameter="delivery_auto_refresh.refresh_after_picking",
+    sale_refresh_delivery_after_picking = fields.Boolean(
+        related="company_id.sale_refresh_delivery_after_picking",
+        readonly=False,
     )
-    auto_void_delivery_line = fields.Boolean(
-        "Void delivery lines automatically",
-        config_parameter="delivery_auto_refresh.auto_void_delivery_line",
+    sale_auto_void_delivery_line = fields.Boolean(
+        related="company_id.sale_auto_void_delivery_line",
+        readonly=False,
     )

--- a/delivery_auto_refresh/models/res_config_settings.py
+++ b/delivery_auto_refresh/models/res_config_settings.py
@@ -7,16 +7,12 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    set_default_carrier = fields.Boolean(
-        "Set Default Carrier Automatically",
-        config_parameter="delivery_auto_refresh.set_default_carrier",
-    )
     auto_add_delivery_line = fields.Boolean(
-        "Add Delivery Line Automatically",
+        "Refresh shipping cost line automatically",
         config_parameter="delivery_auto_refresh.auto_add_delivery_line",
     )
     refresh_after_picking = fields.Boolean(
-        "Refresh After Picking Automatically",
+        "Refresh after picking automatically",
         config_parameter="delivery_auto_refresh.refresh_after_picking",
     )
     auto_void_delivery_line = fields.Boolean(

--- a/delivery_auto_refresh/models/res_config_settings.py
+++ b/delivery_auto_refresh/models/res_config_settings.py
@@ -7,6 +7,13 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
+    # Migration Note 17.0: move this to module sale_order_carrier_auto_assign
+    sale_auto_assign_carrier_on_create = fields.Boolean(
+        related="company_id.sale_auto_assign_carrier_on_create",
+        readonly=False,
+    )
+    # End migration note
+
     auto_add_delivery_line = fields.Boolean(
         "Refresh shipping cost line automatically",
         config_parameter="delivery_auto_refresh.auto_add_delivery_line",

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -57,18 +57,32 @@ class SaleOrder(models.Model):
             .get_param("delivery_auto_refresh.auto_add_delivery_line")
         )
 
+    def _get_delivery_discount(self):
+        self.ensure_one()
+        delivery_lines = self.order_line.filtered("is_delivery")
+        return delivery_lines[-1:].discount
+
     def _auto_refresh_delivery(self):
         self.ensure_one()
+        if self.env.context.get("auto_refresh_delivery"):
+            return
+        if not self._get_param_auto_add_delivery_line():
+            return
+
+        delivery_discount = self._get_delivery_discount()
+
         # Make sure that if you have removed the carrier, the line is gone
         if self.state in {"draft", "sent"}:
             # Context added to avoid the recursive calls and save the new
             # value of carrier_id
             self.with_context(auto_refresh_delivery=True)._remove_delivery_line()
-        if self._get_param_auto_add_delivery_line() and self.carrier_id:
+        if self.carrier_id:
             if self.state in {"draft", "sent"}:
                 price_unit = self.carrier_id.rate_shipment(self)["price"]
                 if not self.is_all_service:
-                    self._create_delivery_line(self.carrier_id, price_unit)
+                    sol = self._create_delivery_line(self.carrier_id, price_unit)
+                    if delivery_discount and sol:
+                        sol.discount = delivery_discount
                 self.with_context(auto_refresh_delivery=True).write(
                     {"recompute_delivery_price": False}
                 )
@@ -82,25 +96,13 @@ class SaleOrder(models.Model):
         return orders
 
     def write(self, vals):
-        # Create or refresh delivery line after saving
-        res = super().write(vals)
-        if self._get_param_auto_add_delivery_line() and not self.env.context.get(
-            "auto_refresh_delivery"
-        ):
-            for order in self:
-                delivery_line = order.order_line.filtered("is_delivery")
-                order.with_context(
-                    delivery_discount=delivery_line[-1:].discount,
-                )._auto_refresh_delivery()
+        # Prevent to refresh delivery in the call to super
+        res = super(SaleOrder, self.with_context(auto_refresh_delivery=True)).write(
+            vals
+        )
+        for order in self:
+            order._auto_refresh_delivery()
         return res
-
-    def _create_delivery_line(self, carrier, price_unit):
-        # Allow users to keep discounts to delivery lines. Unit price will be recomputed anyway
-        sol = super()._create_delivery_line(carrier, price_unit)
-        discount = self.env.context.get("delivery_discount")
-        if discount and sol:
-            sol.discount = discount
-        return sol
 
     def set_delivery_line(self, carrier, amount):
         if self._get_param_auto_add_delivery_line() and self.state in {"draft", "sent"}:

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -72,12 +72,12 @@ class SaleOrder(models.Model):
         delivery_discount = self._get_delivery_discount()
 
         # Make sure that if you have removed the carrier, the line is gone
-        if self.state in {"draft", "sent"}:
+        if self.state in ("draft", "sent"):
             # Context added to avoid the recursive calls and save the new
             # value of carrier_id
             self.with_context(auto_refresh_delivery=True)._remove_delivery_line()
         if self.carrier_id:
-            if self.state in {"draft", "sent"}:
+            if self.state in ("draft", "sent"):
                 price_unit = self.carrier_id.rate_shipment(self)["price"]
                 if not self.is_all_service:
                     sol = self._create_delivery_line(self.carrier_id, price_unit)
@@ -105,7 +105,7 @@ class SaleOrder(models.Model):
         return res
 
     def set_delivery_line(self, carrier, amount):
-        if self._get_param_auto_add_delivery_line() and self.state in {"draft", "sent"}:
+        if self._get_param_auto_add_delivery_line() and self.state in ("draft", "sent"):
             self.carrier_id = carrier.id
         else:
             return super().set_delivery_line(carrier, amount)
@@ -133,7 +133,7 @@ class SaleOrder(models.Model):
         # nothing to be done either. If there are more than one delivery lines
         # we won't be doing anything as well.
         if (
-            self.state not in {"done", "sale"}
+            self.state not in ("done", "sale")
             or self.invoice_ids
             or not self.order_line.filtered("is_delivery")
             or len(self.order_line.filtered("is_delivery")) > 1

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -57,10 +57,37 @@ class SaleOrder(models.Model):
             .get_param("delivery_auto_refresh.auto_add_delivery_line")
         )
 
-    def _get_delivery_discount(self):
-        self.ensure_one()
-        delivery_lines = self.order_line.filtered("is_delivery")
-        return delivery_lines[-1:].discount
+    def _update_delivery_line(self, delivery_line, price_unit):
+        """Update the existing delivery line"""
+        values = self._prepare_delivery_line_vals(self.carrier_id, price_unit)
+        new_vals = {}
+        for f, val in values.items():
+            field_def = delivery_line._fields.get(f)
+            if isinstance(field_def, (fields.One2many, fields.Many2many)):
+                # Tax is set with a SET command
+                clear = update = False
+                for cmd in val:
+                    if cmd[0] == fields.Command.SET:
+                        if delivery_line[f].ids != cmd[2]:
+                            update = True
+                    else:
+                        clear = True
+                if clear:
+                    new_vals[f] = [fields.Command.CLEAR] + val
+                elif update:
+                    new_vals[f] = val
+            elif isinstance(field_def, fields.Many2one):
+                if delivery_line[f].id != val:
+                    new_vals[f] = val
+            elif f == "sequence":
+                # sequence is last sequence + 1. As the delivery line already
+                # exists, substract 1
+                if delivery_line[f] != val - 1:
+                    new_vals[f] = val
+            elif delivery_line[f] != val:
+                new_vals[f] = val
+        if new_vals:
+            delivery_line.write(new_vals)
 
     def _auto_refresh_delivery(self):
         self.ensure_one()
@@ -68,29 +95,40 @@ class SaleOrder(models.Model):
             return
         if not self._get_param_auto_add_delivery_line():
             return
+        if self.state not in ("draft", "sent"):
+            return
 
-        delivery_discount = self._get_delivery_discount()
+        self = self.with_context(auto_refresh_delivery=True)
 
-        # Make sure that if you have removed the carrier, the line is gone
-        if self.state in ("draft", "sent"):
-            # Context added to avoid the recursive calls and save the new
-            # value of carrier_id
-            self.with_context(auto_refresh_delivery=True)._remove_delivery_line()
-        if self.carrier_id:
-            if self.state in ("draft", "sent"):
-                price_unit = self.carrier_id.rate_shipment(self)["price"]
-                if not self.is_all_service:
-                    sol = self._create_delivery_line(self.carrier_id, price_unit)
-                    if delivery_discount and sol:
-                        sol.discount = delivery_discount
-                self.with_context(auto_refresh_delivery=True).write(
-                    {"recompute_delivery_price": False}
-                )
+        if not self.carrier_id:
+            self._set_delivery_carrier()
+
+        if not self.carrier_id or self.is_all_service:
+            self._remove_delivery_line()
+        else:
+            price_unit = self.carrier_id.rate_shipment(self)["price"]
+            delivery_lines = self.order_line.filtered("is_delivery")
+            if not delivery_lines:
+                self._create_delivery_line(self.carrier_id, price_unit)
+            elif len(delivery_lines) > 1:
+                delivery_discount = delivery_lines[-1:].discount
+                self._remove_delivery_line()
+                sol = self._create_delivery_line(self.carrier_id, price_unit)
+                if delivery_discount and sol:
+                    sol.discount = delivery_discount
+            else:
+                self._update_delivery_line(delivery_lines[0], price_unit)
+        if self.recompute_delivery_price:
+            self.recompute_delivery_price = False
 
     @api.model_create_multi
     def create(self, vals_list):
-        # Create or refresh delivery line on create
-        orders = super().create(vals_list)
+        # Prevent to refresh delivery in the call to super
+        orders = (
+            super(SaleOrder, self.with_context(auto_refresh_delivery=True))
+            .create(vals_list)
+            .with_context(auto_refresh_delivery=False)
+        )
         for order in orders:
             order._auto_refresh_delivery()
         return orders
@@ -109,12 +147,6 @@ class SaleOrder(models.Model):
             self.carrier_id = carrier.id
         else:
             return super().set_delivery_line(carrier, amount)
-
-    def _remove_delivery_line(self):
-        current_carrier = self.carrier_id
-        res = super()._remove_delivery_line()
-        self.carrier_id = current_carrier
-        return res
 
     def _is_delivery_line_voidable(self):
         """If the picking is returned before being invoiced, like when the picking

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -164,3 +164,20 @@ class SaleOrderLine(models.Model):
         if self.env.context.get("delivery_auto_refresh_override_locked"):
             return [x for x in fields if x not in ["product_uom_qty", "price_unit"]]
         return fields
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super(
+            SaleOrderLine, self.with_context(auto_refresh_delivery=True)
+        ).create(vals_list)
+        for order in lines.order_id:
+            order._auto_refresh_delivery()
+        return lines
+
+    def write(self, vals):
+        res = super(SaleOrderLine, self.with_context(auto_refresh_delivery=True)).write(
+            vals
+        )
+        for order in self.order_id:
+            order._auto_refresh_delivery()
+        return res

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -74,13 +74,13 @@ class SaleOrder(models.Model):
 
     @api.model
     def create(self, vals):
-        """Create or refresh delivery line on create."""
+        # Create or refresh delivery line on create
         order = super().create(vals)
         order._auto_refresh_delivery()
         return order
 
     def write(self, vals):
-        """Create or refresh delivery line after saving."""
+        # Create or refresh delivery line after saving
         res = super().write(vals)
         if self._get_param_auto_add_delivery_line() and not self.env.context.get(
             "auto_refresh_delivery"
@@ -93,8 +93,7 @@ class SaleOrder(models.Model):
         return res
 
     def _create_delivery_line(self, carrier, price_unit):
-        """Allow users to keep discounts to delivery lines. Unit price will
-        be recomputed anyway"""
+        # Allow users to keep discounts to delivery lines. Unit price will be recomputed anyway
         sol = super()._create_delivery_line(carrier, price_unit)
         discount = self.env.context.get("delivery_discount")
         if discount and sol:
@@ -145,8 +144,7 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     def _get_protected_fields(self):
-        """Avoid locked orders validation error when voiding the
-        delivery line"""
+        # Avoid locked orders validation error when voiding the delivery line
         fields = super()._get_protected_fields()
         if self.env.context.get("delivery_auto_refresh_override_locked"):
             return [x for x in fields if x not in ["product_uom_qty", "price_unit"]]

--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # Copyright 2021 Tecnativa - Carlos Roca
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -72,12 +73,13 @@ class SaleOrder(models.Model):
                     {"recompute_delivery_price": False}
                 )
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         # Create or refresh delivery line on create
-        order = super().create(vals)
-        order._auto_refresh_delivery()
-        return order
+        orders = super().create(vals_list)
+        for order in orders:
+            order._auto_refresh_delivery()
+        return orders
 
     def write(self, vals):
         # Create or refresh delivery line after saving

--- a/delivery_auto_refresh/models/stock_picking.py
+++ b/delivery_auto_refresh/models/stock_picking.py
@@ -13,15 +13,9 @@ class StockPicking(models.Model):
         # based on rules doesn't refresh with real picking data, only with SO
         # ones.
         res = super()._add_delivery_cost_to_so()
-        refresh_after_picking = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("delivery_auto_refresh.refresh_after_picking")
-        )
-        if not refresh_after_picking:
-            return res
-        self.ensure_one()
         sale_order = self.sale_id
+        if not sale_order.company_id.sale_refresh_delivery_after_picking:
+            return res
         if not sale_order or not self.carrier_id:  # pragma: no cover
             return res
         so_line = sale_order.order_line.filtered(lambda x: x.is_delivery)[:1]
@@ -65,13 +59,6 @@ class StockPicking(models.Model):
         # If configured, we want to set to 0 automatically the delivery line
         # when we have a returned picking that isn't invoiced so we don't have
         # it as invoiceable line. Otherwise, the salesman has to do it by hand.
-        auto_void_delivery_line = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("delivery_auto_refresh.auto_void_delivery_line")
-        )
-        if not auto_void_delivery_line:
-            return res
         sales_to_void_delivery = self.filtered(
             lambda x: x.sale_id
             and x.picking_type_code == "incoming"

--- a/delivery_auto_refresh/models/stock_picking.py
+++ b/delivery_auto_refresh/models/stock_picking.py
@@ -8,10 +8,10 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def _add_delivery_cost_to_so(self):
-        """Update delivery price in SO (no matter the type of carrier invoicing policy)
-        and in picking from picking data if indicated so. Carriers based on rules
-        doesn't refresh with real picking data, only with SO ones.
-        """
+        # Update delivery price in SO (no matter the type of carrier invoicing
+        # policy) and in picking from picking data if indicated so. Carriers
+        # based on rules doesn't refresh with real picking data, only with SO
+        # ones.
         res = super()._add_delivery_cost_to_so()
         refresh_after_picking = (
             self.env["ir.config_parameter"]

--- a/delivery_auto_refresh/readme/CONFIGURE.rst
+++ b/delivery_auto_refresh/readme/CONFIGURE.rst
@@ -1,11 +1,9 @@
-* Go to *Sales > Settings > Shipping*.
-* Locate the setting "Set Default Carrier Automatically" and activate it
-  if you want to have default carrier computed automatically.
-* Locate the setting "Add Delivery Line Automatically" and activate it
-  if you want to add automatically the
-  delivery line on save.
-* Locate the setting "Refresh After Picking Automatically" and activate it
-  if you want to refresh delivery price after transferring.
-* Locate the setting "Void delivery lines automatically" and activate it
-  if you want to void the delivery line values (price, units ordered, units delivered)
-  in the sale order when the delivered picking is returned to refund prior to be invoiced.
+Go to *Settings > Sales > Shipping*:
+* Enable "Refresh shipping cost line automatically" if you want to add automatically the
+  delivery line on save and refresh the cost. This will also set the shipping method.
+* Enable "Refresh After Picking Automatically" if you want to refresh delivery
+  price after delivering based on what has been delivered.
+* Enable "Void delivery lines automatically" if you want to void the delivery
+  line values (price, units ordered, units delivered) in the sale order when
+  the delivery is returned to refund prior to be invoiced.
+

--- a/delivery_auto_refresh/readme/CONFIGURE.rst
+++ b/delivery_auto_refresh/readme/CONFIGURE.rst
@@ -1,4 +1,5 @@
 Go to *Settings > Sales > Shipping*:
+
 * Enable "Refresh shipping cost line automatically" if you want to add automatically the
   delivery line on save and refresh the cost. This will also set the shipping method.
 * Enable "Refresh After Picking Automatically" if you want to refresh delivery
@@ -6,4 +7,3 @@ Go to *Settings > Sales > Shipping*:
 * Enable "Void delivery lines automatically" if you want to void the delivery
   line values (price, units ordered, units delivered) in the sale order when
   the delivery is returned to refund prior to be invoiced.
-

--- a/delivery_auto_refresh/readme/CONFIGURE.rst
+++ b/delivery_auto_refresh/readme/CONFIGURE.rst
@@ -1,5 +1,7 @@
 Go to *Settings > Sales > Shipping*:
 
+* Enable "Set default shipping method automalically" if you want to add
+  automatically the carrier on the sales quotation creation.
 * Enable "Refresh shipping cost line automatically" if you want to add automatically the
   delivery line on save and refresh the cost. This will also set the shipping method.
 * Enable "Refresh After Picking Automatically" if you want to refresh delivery

--- a/delivery_auto_refresh/readme/CONTRIBUTORS.rst
+++ b/delivery_auto_refresh/readme/CONTRIBUTORS.rst
@@ -7,3 +7,5 @@
 * Camptocamp <https://www.camptocamp.com>:
   * Maksym Yankin
   * Simone Orsi
+
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/delivery_auto_refresh/readme/ROADMAP.rst
+++ b/delivery_auto_refresh/readme/ROADMAP.rst
@@ -1,8 +1,6 @@
 * After confirming the sales order, the price of the delivery line (if exists)
   will be only updated after the picking is transferred, but not when you
   might modify the order lines.
-* There can be some duplicate delivery unset/set for assuring that the refresh
-  is done on all cases.
 * On multiple deliveries, second and successive pickings update the delivery
   price, but you can't invoice the new delivery price.
 * This is only working from user interface, as there's no way of making

--- a/delivery_auto_refresh/readme/ROADMAP.rst
+++ b/delivery_auto_refresh/readme/ROADMAP.rst
@@ -3,6 +3,3 @@
   might modify the order lines.
 * On multiple deliveries, second and successive pickings update the delivery
   price, but you can't invoice the new delivery price.
-* This is only working from user interface, as there's no way of making
-  compatible the auto-refresh intercepting create/write methods from sale order
-  lines.

--- a/delivery_auto_refresh/tests/__init__.py
+++ b/delivery_auto_refresh/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_delivery_auto_refresh
+from . import test_sale_order_carrier_auto_assign

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -294,8 +294,8 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         self.assertFalse(delivery_line.exists())
 
     def test_auto_add_delivery_line_add_service(self):
-        """Delivery line should not be created because
-        there are only service products in SO"""
+        """No delivery line when service only"""
+        self.env["ir.config_parameter"].sudo().set_param(self.auto_add_delivery_line, 1)
         service = self.env["product.product"].create(
             {"name": "Service Test", "type": "service"}
         )
@@ -309,3 +309,11 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         order = order_form.save()
         delivery_line = order.order_line.filtered("is_delivery")
         self.assertFalse(delivery_line.exists())
+
+    def test_auto_refresh_so_and_manually_unlink_delivery_line(self):
+        """Manually remove the delivery line"""
+        self._test_autorefresh_unlink_line()
+        sale_form = Form(self.order)
+        # Deleting the delivery line
+        sale_form.order_line.remove(1)
+        sale_form.save()

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -74,9 +74,6 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
                 "property_product_pricelist": pricelist.id,
             }
         )
-        cls.auto_add_delivery_line = "delivery_auto_refresh.auto_add_delivery_line"
-        cls.refresh_after_picking = "delivery_auto_refresh.refresh_after_picking"
-        cls.auto_void_delivery_line = "delivery_auto_refresh.auto_void_delivery_line"
         cls.settings = cls.env["res.config.settings"].create({})
         cls.settings.execute()
         order_form = Form(cls.env["sale.order"])
@@ -90,7 +87,7 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
 
     def test_auto_refresh_so(self):
         self.assertFalse(self.order.order_line.filtered("is_delivery"))
-        self.settings.auto_add_delivery_line = True
+        self.settings.sale_auto_add_delivery_line = True
         self.settings.execute()
         self.order.write(
             {"order_line": [(1, self.order.order_line.id, {"product_uom_qty": 3})]}
@@ -128,7 +125,7 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         self.assertEqual(line_delivery.name, "Test carrier 1")
 
     def test_auto_refresh_picking(self):
-        self.settings.refresh_after_picking = True
+        self.settings.sale_refresh_delivery_after_picking = True
         self.settings.execute()
         self.order.order_line.product_uom_qty = 3
         wiz = Form(
@@ -147,7 +144,7 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         self.assertEqual(line_delivery.price_unit, 50)
 
     def test_auto_refresh_picking_fixed_price(self):
-        self.settings.refresh_after_picking = True
+        self.settings.sale_refresh_delivery_after_picking = True
         self.settings.execute()
         product_fixed_price = self.env["product.product"].create(
             {
@@ -178,7 +175,7 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         self.assertEqual(line_delivery.price_unit, 2)
 
     def test_no_auto_refresh_picking(self):
-        self.settings.refresh_after_picking = False
+        self.settings.sale_refresh_delivery_after_picking = False
         self.settings.execute()
         self.order.order_line.product_uom_qty = 3
         wiz = Form(
@@ -232,8 +229,8 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
     def _test_autorefresh_void_line(self, lock=False, to_refund=True, invoice=False):
         """Helper method to test the possible cases for voiding the line"""
         self.assertFalse(self.order.order_line.filtered("is_delivery"))
-        self.settings.auto_add_delivery_line = True
-        self.settings.auto_void_delivery_line = True
+        self.settings.sale_auto_add_delivery_line = True
+        self.settings.sale_auto_void_delivery_line = True
         self.settings.execute()
         line_delivery = self._confirm_sale_order(self.order)
         self._validate_picking(self.order.picking_ids)
@@ -274,7 +271,7 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
     def _test_autorefresh_unlink_line(self):
         """Helper method to test the possible cases for voiding the line"""
         self.assertFalse(self.order.order_line.filtered("is_delivery"))
-        self.settings.auto_add_delivery_line = True
+        self.settings.sale_auto_add_delivery_line = True
         self.settings.execute()
         sale_form = Form(self.order)
         # Force the delivery line creation
@@ -295,7 +292,8 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
 
     def test_auto_add_delivery_line_add_service(self):
         """No delivery line when service only"""
-        self.env["ir.config_parameter"].sudo().set_param(self.auto_add_delivery_line, 1)
+        self.settings.sale_auto_add_delivery_line = True
+        self.settings.set_values()
         service = self.env["product.product"].create(
             {"name": "Service Test", "type": "service"}
         )

--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -78,7 +78,6 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         cls.refresh_after_picking = "delivery_auto_refresh.refresh_after_picking"
         cls.auto_void_delivery_line = "delivery_auto_refresh.auto_void_delivery_line"
         cls.settings = cls.env["res.config.settings"].create({})
-        cls.settings.set_default_carrier = True
         cls.settings.execute()
         order_form = Form(cls.env["sale.order"])
         order_form.partner_id = cls.partner
@@ -196,21 +195,6 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
         picking._action_done()
         line_delivery = self.order.order_line.filtered("is_delivery")
         self.assertEqual(line_delivery.price_unit, 60)
-
-    def test_compute_carrier_id(self):
-        order_form_1 = Form(self.env["sale.order"])
-        order_form_1.partner_id = self.partner
-        self.assertEqual(order_form_1.carrier_id, self.carrier_1)
-        partner_without_carrier = self.env["res.partner"].create(
-            {
-                "name": "Test partner without carrier",
-                "property_delivery_carrier_id": False,
-            }
-        )
-        no_carrier = self.env["delivery.carrier"]
-        order_form_2 = Form(self.env["sale.order"])
-        order_form_2.partner_id = partner_without_carrier
-        self.assertEqual(order_form_2.carrier_id, no_carrier)
 
     def _confirm_sale_order(self, order):
         sale_form = Form(order)

--- a/delivery_auto_refresh/tests/test_sale_order_carrier_auto_assign.py
+++ b/delivery_auto_refresh/tests/test_sale_order_carrier_auto_assign.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+# MIGRATION NOTE for 17.0: Move this to module sale_order_carrier_auto_assign
+
+from odoo.tests import Form, TransactionCase
+
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+
+
+class TestSaleOrderCarrierAutoAssignCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env["base"].with_context(**DISABLED_MAIL_CONTEXT).env
+
+        cls.partner = cls.env.ref("base.res_partner_2")
+        cls.product_storable = cls.env.ref("product.product_product_9")
+        cls.delivery_local_delivery = cls.env.ref("delivery.delivery_local_delivery")
+        cls.delivery_local_delivery.fixed_price = 10
+
+
+class TestSaleOrderCarrierAutoAssignOnCreate(TestSaleOrderCarrierAutoAssignCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.settings = cls.env["res.config.settings"].create({})
+
+    def test_sale_order_carrier_auto_assign_onchange(self):
+        self.assertEqual(
+            self.partner.property_delivery_carrier_id, self.delivery_local_delivery
+        )
+        self.settings.sale_auto_assign_carrier_on_create = True
+        self.settings.set_values()
+        sale_order_form = Form(self.env["sale.order"])
+        sale_order_form.partner_id = self.partner
+        sale_order = sale_order_form.save()
+        self.assertEqual(sale_order.carrier_id, self.delivery_local_delivery)
+
+    def test_sale_order_carrier_auto_assign_create(self):
+        self.assertEqual(
+            self.partner.property_delivery_carrier_id, self.delivery_local_delivery
+        )
+        self.settings.sale_auto_assign_carrier_on_create = True
+        self.settings.set_values()
+        sale_order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        self.assertEqual(sale_order.carrier_id, self.delivery_local_delivery)
+
+    def test_sale_order_carrier_auto_assign_disabled(self):
+        self.assertEqual(
+            self.partner.property_delivery_carrier_id, self.delivery_local_delivery
+        )
+        self.settings.sale_auto_assign_carrier_on_create = False
+        self.settings.set_values()
+        sale_order_form = Form(self.env["sale.order"])
+        sale_order_form.partner_id = self.partner
+        sale_order = sale_order_form.save()
+        self.assertFalse(sale_order.carrier_id)
+
+    def test_sale_order_carrier_auto_assign_no_carrier(self):
+        self.partner.property_delivery_carrier_id = False
+        self.settings.sale_auto_assign_carrier_on_create = True
+        self.settings.set_values()
+        sale_order_form = Form(self.env["sale.order"])
+        sale_order_form.partner_id = self.partner
+        sale_order = sale_order_form.save()
+        self.assertFalse(sale_order.carrier_id)
+
+    def test_sale_order_carrier_auto_assign_carrier_already_set(self):
+        self.assertEqual(
+            self.partner.property_delivery_carrier_id, self.delivery_local_delivery
+        )
+        self.settings.sale_auto_assign_carrier_on_create = True
+        carrier = self.env.ref("delivery.delivery_carrier")
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "carrier_id": carrier.id,
+            }
+        )
+        self.assertEqual(sale_order.carrier_id, carrier)

--- a/delivery_auto_refresh/views/res_config_settings_views.xml
+++ b/delivery_auto_refresh/views/res_config_settings_views.xml
@@ -19,6 +19,7 @@
                         On the sales quotation, refresh the shipping cost line when saving
                     </div>
                 </div>
+
                 <div class="o_setting_left_pane">
                     <field name="refresh_after_picking" />
                 </div>
@@ -28,6 +29,7 @@
                         After delivering a sales order, update the shipping cost line based on what has been delivered
                     </div>
                 </div>
+
                 <div class="o_setting_left_pane">
                     <field name="auto_void_delivery_line" />
                 </div>

--- a/delivery_auto_refresh/views/res_config_settings_views.xml
+++ b/delivery_auto_refresh/views/res_config_settings_views.xml
@@ -4,12 +4,30 @@
         <field name="name">res.config.settings.view.form.inherit.sale</field>
         <field name="model">res.config.settings</field>
         <field name="priority" eval="9" />
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <!-- Migration note 17.0: depend on sale_order_carrier_auto_assign
         <field
             name="inherit_id"
             ref="sale_order_carrier_auto_assign.res_config_settings_view_form_sale"
         />
+        -->
         <field name="arch" type="xml">
+            <xpath expr="//div[@name='shipping_setting_container']" position="inside">
+            <!-- Migration note 17.0: depend on sale_order_carrier_auto_assign
             <xpath expr="//div[@id='carrier_auto_assign']" position="inside">
+            -->
+                <!-- Migration note 17.0: move this to module sale_order_carrier_auto_assign -->
+                <div class="o_setting_left_pane">
+                    <field name="sale_auto_assign_carrier_on_create" />
+                </div>
+                <div class="o_setting_right_pane">
+                    <label for="sale_auto_assign_carrier_on_create" />
+                    <div class="text-muted">
+                        On the sales quotation, add the shipping method on creation.
+                    </div>
+                </div>
+                <!-- End Migratio note -->
+
                 <div class="o_setting_left_pane">
                     <field name="auto_add_delivery_line" />
                 </div>

--- a/delivery_auto_refresh/views/res_config_settings_views.xml
+++ b/delivery_auto_refresh/views/res_config_settings_views.xml
@@ -29,30 +29,30 @@
                 <!-- End Migratio note -->
 
                 <div class="o_setting_left_pane">
-                    <field name="auto_add_delivery_line" />
+                    <field name="sale_auto_add_delivery_line" />
                 </div>
                 <div class="o_setting_right_pane">
-                    <label for="auto_add_delivery_line" />
+                    <label for="sale_auto_add_delivery_line" />
                     <div class="text-muted">
                         On the sales quotation, refresh the shipping cost line when saving
                     </div>
                 </div>
 
                 <div class="o_setting_left_pane">
-                    <field name="refresh_after_picking" />
+                    <field name="sale_refresh_delivery_after_picking" />
                 </div>
                 <div class="o_setting_right_pane">
-                    <label for="refresh_after_picking" />
+                    <label for="sale_refresh_delivery_after_picking" />
                     <div class="text-muted">
                         After delivering a sales order, update the shipping cost line based on what has been delivered
                     </div>
                 </div>
 
                 <div class="o_setting_left_pane">
-                    <field name="auto_void_delivery_line" />
+                    <field name="sale_auto_void_delivery_line" />
                 </div>
                 <div class="o_setting_right_pane">
-                    <label for="auto_void_delivery_line" />
+                    <label for="sale_auto_void_delivery_line" />
                     <div class="text-muted">
                         Void the shipping cost line when the delivery is returned before invoicing
                     </div>

--- a/delivery_auto_refresh/views/res_config_settings_views.xml
+++ b/delivery_auto_refresh/views/res_config_settings_views.xml
@@ -4,51 +4,37 @@
         <field name="name">res.config.settings.view.form.inherit.sale</field>
         <field name="model">res.config.settings</field>
         <field name="priority" eval="9" />
-        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field
+            name="inherit_id"
+            ref="sale_order_carrier_auto_assign.res_config_settings_view_form_sale"
+        />
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='shipping_costs_easypost']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box" id="set_default_carrier">
-                    <div class="o_setting_left_pane">
-                        <field name="set_default_carrier" />
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="set_default_carrier" />
-                        <div class="text-muted">
-                            Set default carrier automatically
-                        </div>
+            <xpath expr="//div[@id='carrier_auto_assign']" position="inside">
+                <div class="o_setting_left_pane">
+                    <field name="auto_add_delivery_line" />
+                </div>
+                <div class="o_setting_right_pane">
+                    <label for="auto_add_delivery_line" />
+                    <div class="text-muted">
+                        On the sales quotation, refresh the shipping cost line when saving
                     </div>
                 </div>
-                <div class="col-12 col-lg-6 o_setting_box" id="auto_add_delivery_line">
-                    <div class="o_setting_left_pane">
-                        <field name="auto_add_delivery_line" />
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="auto_add_delivery_line" />
-                        <div class="text-muted">
-                            Add delivery line automatically
-                        </div>
+                <div class="o_setting_left_pane">
+                    <field name="refresh_after_picking" />
+                </div>
+                <div class="o_setting_right_pane">
+                    <label for="refresh_after_picking" />
+                    <div class="text-muted">
+                        After delivering a sales order, update the shipping cost line based on what has been delivered
                     </div>
                 </div>
-                <div class="col-12 col-lg-6 o_setting_box" id="refresh_after_picking">
-                    <div class="o_setting_left_pane">
-                        <field name="refresh_after_picking" />
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="refresh_after_picking" />
-                        <div class="text-muted">
-                            Refresh after picking automatically
-                        </div>
-                    </div>
+                <div class="o_setting_left_pane">
+                    <field name="auto_void_delivery_line" />
                 </div>
-                <div class="col-12 col-lg-6 o_setting_box" id="auto_void_delivery_line">
-                    <div class="o_setting_left_pane">
-                        <field name="auto_void_delivery_line" />
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="auto_void_delivery_line" />
-                        <div class="text-muted">
-                            Auto void delivery line
-                        </div>
+                <div class="o_setting_right_pane">
+                    <label for="auto_void_delivery_line" />
+                    <div class="text-muted">
+                        Void the shipping cost line when the delivery is returned before invoicing
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
In summary:
* Cleanup code (use a single context variable to prevent re-execution, make dedicated methods for each purpose).
* Increase performance (there was many recursive execution of the same delete/add line - code is now executed once and only what needs to be modified). 
* Make the module compatible with sale_order_carrier_auto_assign. ~~Move carrier assignment to that module so that this module concentrate on cost delivery line update (i.e. refresh as from its name). See https://github.com/OCA/sale-workflow/pull/3081~~ Marked as migration v17.0 improvement
* Make module more robust. Implement SO line create/write

Depends on:
* ~~https://github.com/OCA/sale-workflow/pull/3081~~

Settings:
![image](https://github.com/OCA/delivery-carrier/assets/7802725/57ed0f89-0fee-4cc2-ba49-b0d7371ae156)

In details (one commit for each) - in reverse order:
* config parameters moved to company. "sale_" prefix added to the parameters
* add tests from https://github.com/OCA/delivery-carrier/pull/790 & https://github.com/OCA/delivery-carrier/pull/791
* improve help & readme
* refresh on SO line create/write
* set carrier: ~~use https://github.com/OCA/sale-workflow/pull/3081~~ integrated here and marked to move on v17.0
* refresh the minimum: Create or delete line only if necessary. Update existing line if necessary
* iterate over list, not set
* fix write & discount
* Don't pass discount variable in context
* fix create in batch (api.model_create_multi instead of api.model)
* docstring: Don't modify standard method docstring

Compatibility checks/fixes with other modules triggering refresh on SO create/write:
- [x] https://github.com/OCA/sale-workflow/tree/16.0/sale_product_packaging_container_deposit
    https://github.com/OCA/product-attribute/pull/1583
- [x] https://github.com/OCA/sale-workflow/tree/16.0/sale_order_carrier_auto_assign
   Solved
- [x] https://github.com/OCA/sale-promotion/pull/208
    Looks good
- [x] https://github.com/OCA/sale-workflow/tree/16.0/sale_product_multi_add
    https://github.com/OCA/sale-workflow/pull/3084

cc @pedrobaeza @santostelmo @yvaucher @simahawk @francesco-ooops @renda-dev 