### PR TITLE
[16.0][FIX] delivery_deliverea: Generate a deliverea return when sending to shipper

### DIFF
--- a/delivery_deliverea/i18n/es.po
+++ b/delivery_deliverea/i18n/es.po
@@ -185,6 +185,19 @@ msgstr "Error de Deliverea"
 
 #. module: delivery_deliverea
 #. odoo-python
+#: code:addons/delivery_deliverea/models/delivery_carrier.py:0
+#, python-format
+msgid ""
+"Deliverea Error:\n"
+"\n"
+"%s"
+msgstr ""
+"Error de Deliverea:\n"
+"\n"
+"%s"
+
+#. module: delivery_deliverea
+#. odoo-python
 #: code:addons/delivery_deliverea/models/deliverea_request.py:0
 #, python-format
 msgid "Deliverea Error. Uncontrolled error, it is necessary to check the log"
@@ -530,6 +543,13 @@ msgstr "Uuid"
 #: model:ir.model.fields.selection,name:delivery_deliverea.selection__deliverea_state__delivery_state__warehouse_delivered
 msgid "Warehouse delivered"
 msgstr "Entregado por almacén"
+
+#. module: delivery_deliverea
+#. odoo-python
+#: code:addons/delivery_deliverea/models/delivery_carrier.py:0
+#, python-format
+msgid "References missing in response.\n"
+msgstr "Faltan referencias en la respuesta.\n"
 
 #. module: delivery_deliverea
 #: model:ir.model.fields,help:delivery_deliverea.field_delivery_carrier__deliverea_saturday_delivery

--- a/delivery_deliverea/models/deliverea_request.py
+++ b/delivery_deliverea/models/deliverea_request.py
@@ -30,6 +30,7 @@ class DelivereaRequest(object):
             "create_return": path + "returns",
             "get_shipment_tracking": path + "shipments/{delivereaReference}/trackings",
             "get_return_tracking": path + "returns/{delivereaReference}/trackings",
+            "get_return_label": path + "returns/{delivereaReference}/label",
         }
 
     def _send_api_request(self, request_type, url, data=None, skip_auth=False):
@@ -158,6 +159,15 @@ class DelivereaRequest(object):
         res = self._send_api_request(
             request_type="GET",
             url=self.urls["get_shipment_label"].format(
+                delivereaReference=deliverea_reference,
+            ),
+        )
+        return res.json()
+
+    def get_return_label(self, deliverea_reference):
+        res = self._send_api_request(
+            request_type="GET",
+            url=self.urls["get_return_label"].format(
                 delivereaReference=deliverea_reference,
             ),
         )

--- a/delivery_deliverea/models/stock_picking.py
+++ b/delivery_deliverea/models/stock_picking.py
@@ -19,6 +19,13 @@ class StockPicking(models.Model):
             return
         return self.carrier_id.deliverea_get_label(self)
 
+    def send_to_shipper(self):
+        self.ensure_one()
+        if self.delivery_type == "deliverea":
+            self.carrier_id.deliverea_return_shipping(self)
+            self.carrier_id.deliverea_get_return_label(self)
+        return super().send_to_shipper()
+
     @api.model
     def deliverea_update_tracking_state(self, data):
         if data.get("delivereaReference"):

--- a/delivery_deliverea/views/stock_picking_views.xml
+++ b/delivery_deliverea/views/stock_picking_views.xml
@@ -27,6 +27,11 @@
                     name="attrs"
                 >{'invisible': ['|','|','|',('carrier_tracking_ref','=',False),('delivery_type','in', ['fixed', 'base_on_rule']),('delivery_type','=',False),('state','not in',('done', 'assigned'))]}</attribute>
             </xpath>
+            <xpath expr="//button[@name='print_return_label']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible':['|', '|', '|', ('is_return_picking', '=', False),('state', '=', 'done'),('picking_type_code', '!=', 'incoming'),('delivery_type','=', 'deliverea')]}</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Changed send_to_shipper method to generate the return.

The Print Label button was generating the return instead of the Generate Return button and the Label wasn't being saved.

Now the Generate Return actually generates the return.