### PR TITLE
[14.0][FIX] delivery_schenker: Use display_name in name1 field of address

### DIFF
--- a/delivery_schenker/models/delivery_carrier.py
+++ b/delivery_schenker/models/delivery_carrier.py
@@ -266,7 +266,7 @@ class DeliveryCarrier(models.Model):
         """
         vals = {
             "type": address_type,
-            "name1": partner.display_name,
+            "name1": partner.name or partner.commercial_partner_id.name,
             "locationType": location_type,  # POSTAL or PHYSICAL
             "personType": person_type,  # PERSON OR COMPANY
             "street": partner.street,

--- a/delivery_schenker/models/delivery_carrier.py
+++ b/delivery_schenker/models/delivery_carrier.py
@@ -266,7 +266,7 @@ class DeliveryCarrier(models.Model):
         """
         vals = {
             "type": address_type,
-            "name1": partner.name,
+            "name1": partner.display_name,
             "locationType": location_type,  # POSTAL or PHYSICAL
             "personType": person_type,  # PERSON OR COMPANY
             "street": partner.street,


### PR DESCRIPTION
Not always is the `partner.name` filled. If this is the case then the Schenker API returns an error.