### PR TITLE
[15.0][FIX] delivery_cttexpress: disable tests

### DIFF
--- a/delivery_cttexpress/tests/__init__.py
+++ b/delivery_cttexpress/tests/__init__.py
@@ -1,1 +1,2 @@
-from . import test_delivery_cttexpress
+# Disabled as the provider's test environment isn't stable enough
+# from . import test_delivery_cttexpress


### PR DESCRIPTION
Addresses issue: https://github.com/OCA/delivery-carrier/issues/806

CTT's test environment isn't reliable. Let's disable this module tests to avoid recurrent annoyances.

cc @Tecnativa @pedrobaeza 

fyi @rousseldenis 