### PR TITLE
[FIX] delivery_auto_refresh: compatibility with sale_tier_validation

### DIFF
--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -82,8 +82,10 @@ class SaleOrder(models.Model):
     def write(self, vals):
         """Create or refresh delivery line after saving."""
         res = super().write(vals)
-        if self._get_param_auto_add_delivery_line() and not self.env.context.get(
-            "auto_refresh_delivery"
+        if (
+            "order_line" in vals
+            and self._get_param_auto_add_delivery_line()
+            and not self.env.context.get("auto_refresh_delivery")
         ):
             for order in self:
                 delivery_line = order.order_line.filtered("is_delivery")


### PR DESCRIPTION
Fix https://github.com/OCA/server-ux/issues/875 by actually implementing this sentence:

https://github.com/OCA/delivery-carrier/blob/3a93f81bf3038e6ccb7fba4ce49376fe4f1422ee/delivery_auto_refresh/readme/DESCRIPTION.rst?plain=1#L3-L4

Now, auto-refreshing will be triggered only when modifying SO lines. Any other modifications will pass normally.

@moduon MT-5997