### PR TITLE
[14.0][FIX] delivery_ups_oca: update delivery state

### DIFF
--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -388,8 +388,10 @@ class UpsRequest(object):
                             activity.get("status").get("description"),
                         )
                     )
+                if shipment["package"][0]["activity"]:
                     delivery_state = static_states.get(
-                        activity["status"]["type"], "incidence"
+                        shipment["package"][0]["activity"][0]["status"]["type"],
+                        "incidence",
                     )
             else:
                 for warning in shipment.get("warnings"):


### PR DESCRIPTION
Before this fix, the delivery state was not properly updated, as the first UPS state was taken instead of the last one.