### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/delivery_carrier_return_barcode_pattern/__manifest__.py
+++ b/delivery_carrier_return_barcode_pattern/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "14.0.1.0.1",
     "category": "Delivery",
     "website": "https://github.com/OCA/delivery-carrier",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon"],
     "license": "AGPL-3",
     "auto_install": False,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.