### PR TITLE
[16.0] delivery_postlogistics: Trim return address according to API limitation

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -171,10 +171,10 @@ class PostlogisticsWebService(object):
         if not partner.name:
             raise exceptions.UserError(_("Customer name is required."))
         customer = {
-            "name1": self._sanitize_string(partner.name),
-            "street": self._sanitize_string(partner.street),
-            "zip": self._sanitize_string(partner.zip),
-            "city": self._sanitize_string(partner.city),
+            "name1": self._sanitize_string(partner.name)[:35],
+            "street": self._sanitize_string(partner.street)[:35],
+            "zip": self._sanitize_string(partner.zip)[:10],
+            "city": self._sanitize_string(partner.city)[:35],
             "country": partner.country_id.code,
             "domicilePostOffice": picking.carrier_id.postlogistics_office or None,
         }


### PR DESCRIPTION
Sender address must be trimmed to 35 characters for return labels as well (it is already done for delivery label a few lines above)