### PR TITLE
[14.0][FIX] delivery_purchase : fix module install on demo data

### DIFF
--- a/delivery_purchase/models/delivery_carrier.py
+++ b/delivery_purchase/models/delivery_carrier.py
@@ -1,4 +1,5 @@
 # Copyright 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -22,6 +23,7 @@ class DeliveryCarrier(models.Model):
                        'warning_message': a string containing a warning message}
         """
         self.ensure_one()
+        order.ensure_one()
         if hasattr(self, "purchase_%s_rate_shipment" % self.delivery_type):
             res = getattr(self, "purchase_%s_rate_shipment" % self.delivery_type)(order)
             # apply margin on computed price
@@ -39,6 +41,7 @@ class DeliveryCarrier(models.Model):
                 ) % (self.amount)
                 res["price"] = 0.0
             return res
+        return {}
 
     def purchase_send_shipping(self, pickings):
         """Send the package to the service provider

--- a/delivery_purchase/models/purchase_order.py
+++ b/delivery_purchase/models/purchase_order.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # Copyright 2016 Tecnativa - Pedro M. Baeza
 # Copyright 2023 Tecnativa - Víctor Martínez
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -34,9 +35,10 @@ class PurchaseOrder(models.Model):
             if delivery_lines:
                 item.delivery_price = sum(delivery_lines.mapped("price_unit"))
             else:
-                item.delivery_price = item.carrier_id.purchase_rate_shipment(self)[
-                    "price"
-                ]
+                item.delivery_price = item.carrier_id.purchase_rate_shipment(item).get(
+                    "price",
+                    0,
+                )
 
     @api.model
     def _prepare_picking(self):

--- a/delivery_purchase/models/stock_picking.py
+++ b/delivery_purchase/models/stock_picking.py
@@ -16,7 +16,10 @@ class StockPicking(models.Model):
 
     def purchase_send_to_shipper(self):
         self.ensure_one()
-        res = self.carrier_id.purchase_send_shipping(self)[0]
+        res = self.carrier_id.purchase_send_shipping(self)
+        if not res:
+            return
+        res = res[0]
         if (
             self.carrier_id.free_over
             and self.purchase_id

--- a/delivery_purchase/readme/CONTRIBUTORS.rst
+++ b/delivery_purchase/readme/CONTRIBUTORS.rst
@@ -4,3 +4,5 @@
   * Pedro M. Baeza
   * Vicent Cubells
   * Víctor Martínez
+
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>


### PR DESCRIPTION
While testing this module, I encountered some issues during installation and testing with demo data:
* initialization of PO delivery price is mixing POs in the loop
* if you have installed a carrier delivery_xxx module that does not implement purchase price, then PO confirmation was crashing

cc @pedrobaeza 