### PR TITLE
[14.0][IMP] delivery_state: set carrier with no updatable states

### DIFF
--- a/delivery_state/README.rst
+++ b/delivery_state/README.rst
@@ -54,6 +54,13 @@ confirmed:
   #. Enable the option *Email Confirmation*.
   #. Choose the template "Delivery State Notification to Customer".
 
+In order to deactivate the automatic update of the carrier state in a shipping
+method:
+
+  #. Go to *Inventory > Configuration > Shipping Methods*.
+  #. Go to the form view of the shipping method.
+  #. Uncheck the "Track Carrier State" option.
+
 Usage
 =====
 
@@ -122,6 +129,10 @@ Contributors
   * Pedro M. Baeza
   * David Vidal
 * Marçal Isern <marsal.isern@qubiq.es>
+* `Sygel <https://www.sygel.es>`_:
+
+  * Manuel Regidor
+  * Valentín Vinagre
 
 Maintainers
 ~~~~~~~~~~~

--- a/delivery_state/__manifest__.py
+++ b/delivery_state/__manifest__.py
@@ -19,5 +19,6 @@
         "data/ir_cron_data.xml",
         "data/mail_template.xml",
         "views/stock_picking_views.xml",
+        "views/delivery_carrier_views.xml",
     ],
 }

--- a/delivery_state/models/delivery_carrier.py
+++ b/delivery_state/models/delivery_carrier.py
@@ -7,12 +7,16 @@ from odoo import fields, models
 class DeliveryCarrier(models.Model):
     _inherit = "delivery.carrier"
 
+    track_carrier_state = fields.Boolean(default=True)
+
     def send_shipping(self, pickings):
         res = super().send_shipping(pickings)
         pickings.write(
             {
-                "delivery_state": "shipping_recorded_in_carrier",
                 "date_shipped": fields.Date.today(),
+                "delivery_state": "shipping_recorded_in_carrier"
+                if self.track_carrier_state
+                else "no_update",
             }
         )
         return res

--- a/delivery_state/readme/CONFIGURE.rst
+++ b/delivery_state/readme/CONFIGURE.rst
@@ -10,3 +10,10 @@ confirmed:
   #. Go to *Inventory > Configuration > Settings*.
   #. Enable the option *Email Confirmation*.
   #. Choose the template "Delivery State Notification to Customer".
+
+In order to deactivate the automatic update of the carrier state in a shipping
+method:
+
+  #. Go to *Inventory > Configuration > Shipping Methods*.
+  #. Go to the form view of the shipping method.
+  #. Uncheck the "Track Carrier State" option.

--- a/delivery_state/readme/CONTRIBUTORS.rst
+++ b/delivery_state/readme/CONTRIBUTORS.rst
@@ -10,3 +10,7 @@
   * Pedro M. Baeza
   * David Vidal
 * Marçal Isern <marsal.isern@qubiq.es>
+* `Sygel <https://www.sygel.es>`_:
+
+  * Manuel Regidor
+  * Valentín Vinagre

--- a/delivery_state/static/description/index.html
+++ b/delivery_state/static/description/index.html
@@ -403,6 +403,15 @@ confirmed:</p>
 <li>Choose the template “Delivery State Notification to Customer”.</li>
 </ol>
 </blockquote>
+<p>In order to deactivate the automatic update of the carrier state in a shipping
+method:</p>
+<blockquote>
+<ol class="arabic simple">
+<li>Go to <em>Inventory &gt; Configuration &gt; Shipping Methods</em>.</li>
+<li>Go to the form view of the shipping method.</li>
+<li>Uncheck the “Track Carrier State” option.</li>
+</ol>
+</blockquote>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -482,6 +491,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Marçal Isern &lt;<a class="reference external" href="mailto:marsal.isern&#64;qubiq.es">marsal.isern&#64;qubiq.es</a>&gt;</li>
+<li><a class="reference external" href="https://www.sygel.es">Sygel</a>:<ul>
+<li>Manuel Regidor</li>
+<li>Valentín Vinagre</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/delivery_state/views/delivery_carrier_views.xml
+++ b/delivery_state/views/delivery_carrier_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright 2024 Manuel Regidor <manuel.regidor@sygel.es>
+License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="delivery_state_view_delivery_carrier_form" model="ir.ui.view">
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form" />
+        <field name="arch" type="xml">
+            <field name="amount" position="after">
+                <field name="track_carrier_state" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this IMP, the delivery_state was always set to shipping_recorded_in_carrier once the expedition was created. The _update_delivery_state method in stock.picking tries to update the delivery state for those pickings in that state. Because not all the carriers APIs or carrier modules support the state update functionality, this IMP makes it optional by setting the delivery state to no_update instead of shipping_recorded_in_carrier if the new cehckbox track_carrier_state in delivery.carrier model is disabled.

T-6303