### PR TITLE
[14.0][FIX]delivery_state: stock.picking delivery_state field invalid option

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -65,7 +65,7 @@ class StockPicking(models.Model):
                     ["customer_delivered", "canceled_shipment", "no_update"],
                 ),
                 # These won't ever autoupdate, so we don't want to evaluate them
-                ("delivery_type", "not in", [False, "fixed", "base_one_rule"]),
+                ("delivery_type", "not in", [False, "fixed", "base_on_rule"]),
             ]
         )
         pickings.tracking_state_update()

--- a/delivery_state/views/stock_picking_views.xml
+++ b/delivery_state/views/stock_picking_views.xml
@@ -24,7 +24,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                         string="Update tracking state"
                         type="object"
                         class="oe_inline"
-                        attrs="{'invisible': ['|', ('delivery_state', 'in', ['customer_delivered', 'canceled_shipment']), ('delivery_type', 'in', ['base_one_rule', 'fixed'])]}"
+                        attrs="{'invisible': ['|', ('delivery_state', 'in', ['customer_delivered', 'canceled_shipment']), ('delivery_type', 'in', ['base_on_rule', 'fixed'])]}"
                     />
                     <field name="tracking_state_history" colspan="3" />
                 </group>


### PR DESCRIPTION
Before this fix, there was an invalid option for field delivery_type in model stock.picking in use. The used option was base_one_rule, which does not exist. The right option is base_on_rule (without the "e").

T-6288