### PR TITLE
[FIX] stock_picking_delivery_link: Don't override context value if no ship carrier

### DIFF
--- a/stock_picking_delivery_link/models/stock_picking.py
+++ b/stock_picking_delivery_link/models/stock_picking.py
@@ -64,10 +64,13 @@ class StockPicking(models.Model):
         self.ensure_one()
         res = super()._set_delivery_package_type(batch_pack=batch_pack)
         context = res.get("context", self.env.context)
-        context = dict(
-            context,
-            current_package_carrier_type=self.ship_carrier_id.delivery_type,
-        )
+        # We don't want to overwrite the value set if carrier_id is filled in
+        # and not ship_carrier_id (e.g.: one step delivery or propagate_carrier is enabled)
+        if self.ship_carrier_id.delivery_type:
+            context = dict(
+                context,
+                current_package_carrier_type=self.ship_carrier_id.delivery_type,
+            )
         # As we pass the `delivery_type` ('fixed' or 'base_on_rule' by default) in a
         # key which corresponds to the `package_carrier_type` ('none' to default), we
         # make a conversion. No conversion needed for other carriers as the


### PR DESCRIPTION
If shipping steps is set to ship only, the ship_carrier_id on stock picking is not set. So, don't override context value in that case.