### PR TITLE
[16.0][FIX] delivery_roulier : get_tracking_link should return an url instead of a list of urls

### DIFF
--- a/delivery_roulier/models/delivery_carrier.py
+++ b/delivery_roulier/models/delivery_carrier.py
@@ -37,17 +37,14 @@ class DeliveryCarrier(models.Model):
     # is on picking. An we could have multiple urls for 1 picking, if there
     # are multiple package...
     # Maybe we will merge all this in future versions
-    def get_tracking_link(self, pickings):
-        if self._is_roulier():
-            trackings = []
-            for picking in pickings:
-                packages = picking.package_ids
-                first_package = packages and packages[0]
-                if first_package:
-                    trackings.append(first_package._get_tracking_link())
-            return trackings
-        else:
-            return super().get_tracking_link(pickings)
+    def get_tracking_link(self, picking):
+        if not self._is_roulier():
+            return super().get_tracking_link(picking)
+        packages = picking.package_ids
+        if not packages:
+            return ""
+        first_package = packages[0]
+        return first_package._get_tracking_link()
 
     def rate_shipment(self, order):
         res = super().rate_shipment(order)


### PR DESCRIPTION
@hparfr @yankinmax 