### PR TITLE
[16.0][BC] base_delivery_carrier_label: remove _set_a_default_package

### DIFF
--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -59,21 +59,8 @@ class StockPicking(models.Model):
             self.env["shipping.label"].with_context(**context_attachment).create(data)
         )
 
-    def _set_a_default_package(self):
-        """Pickings using this module must have a package
-        If not this method put it one silently
-        """
-        for picking in self:
-            move_lines = picking.move_line_ids.filtered(
-                lambda s: not s.result_package_id
-            )
-            if move_lines:
-                picking._put_in_pack(move_lines)
-
     def send_to_shipper(self):
         self.ensure_one()
-        if self.env.context.get("set_default_package", True):
-            self._set_a_default_package()
         # We consider that label has already been generated in case we have a
         # carrier tracking ref, this way we may print the labels before shipping
         # and not generated in second time during shipment

--- a/base_delivery_carrier_label/readme/CONTRIBUTORS.rst
+++ b/base_delivery_carrier_label/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Dave Lasley <dave@laslabs.com>
 * Timothée Ringeard <timothee.ringeard@camptocamp.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Raphaël Reverdy <raphael.reverdy@akretion.com>

--- a/delivery_roulier/__manifest__.py
+++ b/delivery_roulier/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "16.0.1.0.0",
     "author": "Akretion,Odoo Community Association (OCA)",
     "summary": "Integration of multiple carriers",
-    "maintainers": ["florian-dacosta"],
+    "maintainers": ["florian-dacosta", "hparfr"],
     "category": "Delivery",
     "depends": [
         "base_delivery_carrier_label",

--- a/delivery_roulier/models/stock_quant_package.py
+++ b/delivery_roulier/models/stock_quant_package.py
@@ -91,6 +91,8 @@ class StockQuantPackage(models.Model):
     def _roulier_generate_labels(self, picking):
         # send all packs to roulier. It will decide if it makes one call per pack or
         # one call for all pack depending on the carrier.
+        if not self:
+            raise UserError(_("No pack found for picking %s", picking.name))
         response = self._call_roulier_api(picking)
         self._handle_attachments(picking, response)
         return self._parse_response(picking, response)


### PR DESCRIPTION
This functionality adds a burden on other modules tests like (delivery_package_fee or delivery_package_number).

In some contexts, you want to require a package to be always explicitly created.

This functionality is also now implemented in `delivery_automatic_package` module.


To be merged with `major`

EDIT:

Contains and replace:
- [ ] #855

~~This PR remove set_a_default_package from base_delivery_carrier_label.
Tests are red because it needs some changes in delivery_roulier  #855 
And tests in #855 are also red because it needs this PR.~~
