### PR TITLE
[16.0][IMP]delivery_delivery_package_fee delivery_automatic_package delivery_package_number simplify tests

### DIFF
--- a/delivery_automatic_package/models/stock_picking.py
+++ b/delivery_automatic_package/models/stock_picking.py
@@ -26,9 +26,6 @@ class StockPicking(models.Model):
         set a new one for concerned moves.
         """
         self.ensure_one()
-        if (
-            self.carrier_id.automatic_package_creation_at_delivery
-            or self.env.context.get("set_default_package", False)
-        ):
+        if self.carrier_id.automatic_package_creation_at_delivery:
             self._set_a_default_package()
         return super().send_to_shipper()

--- a/delivery_automatic_package/tests/test_automatic_package.py
+++ b/delivery_automatic_package/tests/test_automatic_package.py
@@ -72,19 +72,6 @@ class TestAutomaticPackage(TransactionCase):
         picking._action_done()
         self.assertTrue(picking.move_line_ids.result_package_id)
 
-    def test_automatic_context(self):
-        """
-        Check that the automatic package creation is set on new carrier
-        Create a picking, fill in quantities and validate it with good
-        context key
-        The move line should contain a package
-        """
-        self.carrier.automatic_package_creation_at_delivery = False
-        picking = self._create_picking()
-        picking.move_ids.update({"quantity_done": 5.0})
-        picking.with_context(set_default_package=True)._action_done()
-        self.assertTrue(picking.move_line_ids.result_package_id)
-
     def test_no_automatic(self):
         """
         Disable the automatic package creation on carrier

--- a/delivery_package_fee/tests/test_package_fee.py
+++ b/delivery_package_fee/tests/test_package_fee.py
@@ -388,7 +388,7 @@ class TestPackageFee(TransactionCase):
         self.assertEqual(picking.state, "assigned")
         picking.move_line_ids[0].qty_done = 10.0
         picking.move_line_ids[1].qty_done = 10.0
-        picking.with_context(set_default_package=False)._action_done()
+        picking._action_done()
         self.assertEqual(picking.state, "done")
 
         self.assertRecordValues(

--- a/delivery_package_number/wizard/stock_backorder_confirmation.py
+++ b/delivery_package_number/wizard/stock_backorder_confirmation.py
@@ -11,10 +11,7 @@ class StockBackorderConfirmation(models.TransientModel):
     def process(self):
         if self.number_of_packages:
             self.pick_ids.write({"number_of_packages": self.number_of_packages})
-        # put context key for avoiding `base_delivery_carrier_label` auto-packaging feature
-        res = super(
-            StockBackorderConfirmation, self.with_context(set_default_package=False)
-        ).process()
+        res = super().process()
         if self.print_package_label:
             report = (
                 self.pick_ids.picking_type_id.report_number_of_packages

--- a/delivery_package_number/wizard/stock_inmediate_transfer.py
+++ b/delivery_package_number/wizard/stock_inmediate_transfer.py
@@ -10,10 +10,7 @@ class StockImmediateTransfer(models.TransientModel):
     def process(self):
         if self.number_of_packages:
             self.pick_ids.write({"number_of_packages": self.number_of_packages})
-        # put context key for avoiding `base_delivery_carrier_label` auto-packaging feature
-        res = super(
-            StockImmediateTransfer, self.with_context(set_default_package=False)
-        ).process()
+        res = super().process()
         if self.print_package_label:
             report = (
                 self.pick_ids.picking_type_id.report_number_of_packages

--- a/delivery_package_number/wizard/stock_number_package_validate_wiz.py
+++ b/delivery_package_number/wizard/stock_number_package_validate_wiz.py
@@ -13,10 +13,7 @@ class StockNumberPackageValidateWiz(models.TransientModel):
     def process(self):
         if self.number_of_packages:
             self.pick_ids.write({"number_of_packages": self.number_of_packages})
-        # put context key for avoiding `base_delivery_carrier_label` auto-packaging feature
-        res = self.pick_ids.with_context(
-            set_default_package=False, bypass_set_number_of_packages=True
-        ).button_validate()
+        res = self.pick_ids.button_validate()
         if self.print_package_label:
             self._print_package_label()
         return res


### PR DESCRIPTION
Simplify tests by removing the now useless context key.

Includes:
 - [x]  #853 
 - [x]  #855  (included in 853)

Tests only pass if we have all the commit (this PR).

