### PR TITLE
[16.0] delivery_roulier: raise when no pack found and fix tests

### DIFF
--- a/delivery_roulier/__manifest__.py
+++ b/delivery_roulier/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "16.0.1.0.0",
     "author": "Akretion,Odoo Community Association (OCA)",
     "summary": "Integration of multiple carriers",
-    "maintainers": ["florian-dacosta"],
+    "maintainers": ["florian-dacosta", "hparfr"],
     "category": "Delivery",
     "depends": [
         "base_delivery_carrier_label",

--- a/delivery_roulier/models/stock_quant_package.py
+++ b/delivery_roulier/models/stock_quant_package.py
@@ -91,6 +91,8 @@ class StockQuantPackage(models.Model):
     def _roulier_generate_labels(self, picking):
         # send all packs to roulier. It will decide if it makes one call per pack or
         # one call for all pack depending on the carrier.
+        if not self:
+            raise UserError(_("No pack found for picking %s", picking.name))
         response = self._call_roulier_api(picking)
         self._handle_attachments(picking, response)
         return self._parse_response(picking, response)


### PR DESCRIPTION
Because, base_delivery_carrier_label do not create packs automatically anymore, we have to create a pack in delivery_roulier_tests

Delivery roulier still can't work without pack.

Also, add myself as a maintainer of the module.

See also:
- https://github.com/OCA/delivery-carrier/pull/642
- https://github.com/OCA/delivery-carrier/pull/854
- https://github.com/OCA/delivery-carrier/pull/853

This PR is red because it needs #853
#853 is red because it needs this PR.

#854 contains #853 and #855

To be merged with `major`