### PR TITLE
[16.0][FIX] partner_delivery_schedule: add the same class style as in the base report

### DIFF
--- a/partner_delivery_schedule/views/report_shipping.xml
+++ b/partner_delivery_schedule/views/report_shipping.xml
@@ -28,7 +28,7 @@
         <xpath expr="//div[@name='div_sched_date']" position="after">
             <div
                 t-if="o.picking_type_id.code == 'outgoing' and o.partner_id"
-                class="col-auto"
+                class="col-auto col-3 mw-100 mb-2"
             >
                 <t
                     t-set="partner"


### PR DESCRIPTION
This [PR](https://github.com/odoo/odoo/pull/172366) accepts a change that fixes how the information section looks like.

It is necessary to change the views that add changes in this section.

Without the change:

![Selección_1011](https://github.com/OCA/delivery-carrier/assets/6359121/e409c124-82b1-4ad4-94d1-c7119f7e789c)

With the change:

![Selección_1012](https://github.com/OCA/delivery-carrier/assets/6359121/ec5c0bf1-879a-449c-8a93-3a34a18c915e)

