### PR TITLE
[16.0][FIX] partner_delivery_zone: add the same class style as in the base report

### DIFF
--- a/partner_delivery_zone/views/report_deliveryslip.xml
+++ b/partner_delivery_zone/views/report_deliveryslip.xml
@@ -4,12 +4,9 @@
 <odoo>
     <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <div
-                t-if="o.picking_type_id.code == 'outgoing' and o.delivery_zone_id"
-                class="col-auto"
-            >
+            <div class="col-auto col-3 mw-100 mb-2">
                 <strong>Zone</strong>
-                <p t-field="o.delivery_zone_id" />
+                <p t-field="o.delivery_zone_id" class="m-0" />
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
This [PR](https://github.com/odoo/odoo/pull/172366) accepts a change that fixes how the information section looks like.

It is necessary to change the views that add changes in this section.

Without the change:

![Selección_1013](https://github.com/OCA/delivery-carrier/assets/6359121/688ad6cc-2054-427f-88bf-eab9ceddb2a7)

With the change:

![Selección_1014](https://github.com/OCA/delivery-carrier/assets/6359121/0087d577-1497-425a-80cb-433d39f87e6c)


