### PR TITLE
[16.0][FIX] stock_picking_report_delivery_cost: add the same class style as in the base report

### DIFF
--- a/stock_picking_report_delivery_cost/report/report_deliveryslip.xml
+++ b/stock_picking_report_delivery_cost/report/report_deliveryslip.xml
@@ -7,11 +7,11 @@
         <xpath expr="//div[@name='div_sched_date']" position="after">
             <div
                 t-if="o.carrier_price_for_report"
-                class="col-auto"
+                class="col-auto col-3 mw-100 mb-2"
                 name="div_carrier_price_for_report"
             >
-                <strong>Delivery cost:</strong>
-                <p t-field="o.carrier_price_for_report" />
+                <strong>Delivery cost</strong>
+                <p t-field="o.carrier_price_for_report" class="m-0" />
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
This [PR](https://github.com/odoo/odoo/pull/172366) accepts a change that fixes how the information section looks like.

It is necessary to change the views that add changes in this section.

Without the change:

![Selección_1015](https://github.com/OCA/delivery-carrier/assets/6359121/50b07ac5-867f-4b9f-8ea0-00992e911189)

With the change:

![Selección_1016](https://github.com/OCA/delivery-carrier/assets/6359121/a032048a-b7bc-463a-9c2b-5a8ba717ddf4)
