### PR TITLE
[14.0][IMP] delivery_purchase: Add Original picking (delivery) (delivery_picking_orig_id) field to purchase order lines

### DIFF
--- a/delivery_purchase/i18n/delivery_purchase.pot
+++ b/delivery_purchase/i18n/delivery_purchase.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-17 06:21+0000\n"
+"PO-Revision-Date: 2024-07-17 06:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -68,6 +70,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:delivery_purchase.field_purchase_order_line____last_update
 #: model:ir.model.fields,field_description:delivery_purchase.field_stock_picking____last_update
 msgid "Last Modified on"
+msgstr ""
+
+#. module: delivery_purchase
+#: model:ir.model.fields,field_description:delivery_purchase.field_purchase_order_line__delivery_picking_orig_id
+msgid "Origin picking (delivery)"
 msgstr ""
 
 #. module: delivery_purchase

--- a/delivery_purchase/i18n/es.po
+++ b/delivery_purchase/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 09:59+0000\n"
-"PO-Revision-Date: 2023-10-31 11:00+0100\n"
+"POT-Creation-Date: 2024-07-17 06:21+0000\n"
+"PO-Revision-Date: 2024-07-17 08:22+0200\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -73,6 +73,11 @@ msgstr "Es un envío"
 #: model:ir.model.fields,field_description:delivery_purchase.field_stock_picking____last_update
 msgid "Last Modified on"
 msgstr "Última modificación el"
+
+#. module: delivery_purchase
+#: model:ir.model.fields,field_description:delivery_purchase.field_purchase_order_line__delivery_picking_orig_id
+msgid "Origin picking (delivery)"
+msgstr "Albarán origen (entrega)"
 
 #. module: delivery_purchase
 #: model:ir.model,name:delivery_purchase.model_purchase_order

--- a/delivery_purchase/models/purchase_order.py
+++ b/delivery_purchase/models/purchase_order.py
@@ -73,6 +73,9 @@ class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
     is_delivery = fields.Boolean(string="Is a Delivery", default=False)
+    delivery_picking_orig_id = fields.Many2one(
+        comodel_name="stock.picking", string="Origin picking (delivery)"
+    )
 
     @api.depends("is_delivery")
     def _compute_qty_invoiced(self):

--- a/delivery_purchase/models/stock_picking.py
+++ b/delivery_purchase/models/stock_picking.py
@@ -54,5 +54,8 @@ class StockPicking(models.Model):
                     1.0 + (float(self.carrier_id.margin) / 100.0)
                 )
             # Create delivery line allways
-            self.purchase_id._create_delivery_line(self.carrier_id, carrier_price)
+            line = self.purchase_id._create_delivery_line(
+                self.carrier_id, carrier_price
+            )
+            line.delivery_picking_orig_id = self
             self.purchase_id.write({"carrier_id": self.carrier_id})

--- a/delivery_purchase/tests/test_delivery_purchase.py
+++ b/delivery_purchase/tests/test_delivery_purchase.py
@@ -129,9 +129,8 @@ class TestDeliveryPurchase(TestDeliveryPurchaseBase):
         picking.carrier_id = self.carrier_fixed
         self._action_picking_validate(picking)
         self.assertEqual(picking.carrier_price, 20)
-        self.assertEqual(
-            len(self.purchase.order_line.filtered(lambda x: x.is_delivery)), 1
-        )
+        delivery_line = self.purchase.order_line.filtered(lambda x: x.is_delivery)
+        self.assertEqual(delivery_line.delivery_picking_orig_id, picking)
         self.assertEqual(self.purchase.delivery_price, 20)
 
     def test_picking_carrier_other(self):
@@ -172,17 +171,17 @@ class TestDeliveryPurchase(TestDeliveryPurchaseBase):
         model = self.env[res["res_model"]].with_context(**res["context"])
         model.create({}).process_cancel_backorder()
         self.assertEqual(picking.carrier_price, 20)
-        self.assertEqual(
-            len(self.purchase.order_line.filtered(lambda x: x.is_delivery)), 1
-        )
+        delivery_line = self.purchase.order_line.filtered(lambda x: x.is_delivery)
+        self.assertEqual(delivery_line.delivery_picking_orig_id, picking)
         self.assertEqual(self.purchase.delivery_price, 20)
         new_picking = self.purchase.picking_ids - picking
         new_picking.carrier_id = self.carrier_rules
         self._action_picking_validate(new_picking)
         self.assertEqual(new_picking.carrier_price, 10)
-        self.assertEqual(
-            len(self.purchase.order_line.filtered(lambda x: x.is_delivery)), 2
+        new_delivery_line = (
+            self.purchase.order_line.filtered(lambda x: x.is_delivery) - delivery_line
         )
+        self.assertEqual(new_delivery_line.delivery_picking_orig_id, new_picking)
         self.assertEqual(self.purchase.delivery_price, 30)
 
     def test_picking_carrier_invoice_policy_real(self):
@@ -195,4 +194,6 @@ class TestDeliveryPurchase(TestDeliveryPurchaseBase):
         self.assertEqual(picking.carrier_id, self.carrier_rules)
         self.assertEqual(picking.carrier_price, 10)
         self.assertEqual(self.purchase.carrier_id, self.carrier_rules)
+        delivery_line = self.purchase.order_line.filtered(lambda x: x.is_delivery)
+        self.assertEqual(delivery_line.delivery_picking_orig_id, picking)
         self.assertEqual(self.purchase.delivery_price, 10)

--- a/delivery_purchase/views/purchase_order_view.xml
+++ b/delivery_purchase/views/purchase_order_view.xml
@@ -18,6 +18,15 @@
                     />
                 </div>
             </field>
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='taxes_id']"
+                position="after"
+            >
+                <field
+                    name="delivery_picking_orig_id"
+                    attrs="{'invisible': [('delivery_picking_orig_id', '=', False)]}"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Add Original picking (delivery) (`delivery_picking_orig_id`) field to purchase order lines

If there are several pickings for an order and several have carriers, several purchase order lines (`is_delivery`) will be created but we need to know the origin (picking) that created them.

Please @pedrobaeza and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT50146