### PR TITLE
[FIX] base_delibery_carrier_label test helper

### DIFF
--- a/base_delivery_carrier_label/tests/carrier_label_case.py
+++ b/base_delivery_carrier_label/tests/carrier_label_case.py
@@ -9,6 +9,7 @@ class CarrierLabelCase(TransactionCase):
     """Base class for carrier label tests. Inherit and override _get_carrier
     to return the carrier you want to test"""
 
+    @classmethod
     def setUpClass(self):
         super().setUpClass(self)
         self._create_order_picking()


### PR DESCRIPTION
The migration to 17 of the test helper carrier_label_case was missing the classmethod decorator on the setUpClass method