### PR TITLE
[14.0][ADD] delivery_purchase_label

### DIFF
--- a/delivery_purchase_label/__init__.py
+++ b/delivery_purchase_label/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_purchase_label/__manifest__.py
+++ b/delivery_purchase_label/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Delivery Purchase Label",
+    "summary": "Allows printing carrier delivery labels for a dropshipping vendor.",
+    "version": "14.0.1.0.0",
+    "category": "Delivery",
+    "website": "https://github.com/OCA/delivery-carrier",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
+    "maintainers": ["TDu", "jbaudoux"],
+    "installable": True,
+    "license": "AGPL-3",
+    "depends": ["delivery", "purchase"],
+    "data": [
+        "data/stock_picking_type.xml",
+        "views/delivery_carrier.xml",
+        "views/purchase_order_views.xml",
+    ],
+}

--- a/delivery_purchase_label/data/stock_picking_type.xml
+++ b/delivery_purchase_label/data/stock_picking_type.xml
@@ -1,0 +1,9 @@
+<odoo noupdate="1">
+    <record id="picking_type_send_label" model="stock.picking.type">
+        <field name="name">Dropship Carrier Label</field>
+        <field name="code">internal</field>
+        <field name="sequence_code">LBL</field>
+        <field name="default_location_dest_id" ref="stock.stock_location_suppliers" />
+        <field name="default_location_src_id" ref="stock.stock_location_suppliers" />
+    </record>
+</odoo>

--- a/delivery_purchase_label/models/__init__.py
+++ b/delivery_purchase_label/models/__init__.py
@@ -1,3 +1,4 @@
 from . import delivery_carrier
 from . import mail_compose_message
 from . import purchase_order
+from . import stock_picking

--- a/delivery_purchase_label/models/__init__.py
+++ b/delivery_purchase_label/models/__init__.py
@@ -1,0 +1,3 @@
+from . import delivery_carrier
+from . import mail_compose_message
+from . import purchase_order

--- a/delivery_purchase_label/models/delivery_carrier.py
+++ b/delivery_purchase_label/models/delivery_carrier.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    purchase_label_picking_type = fields.Many2one(
+        string="Operation Type For Purchase Label", comodel_name="stock.picking.type"
+    )

--- a/delivery_purchase_label/models/mail_compose_message.py
+++ b/delivery_purchase_label/models/mail_compose_message.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, models
+
+
+class MailComposer(models.TransientModel):
+    _inherit = "mail.compose.message"
+
+    @api.model
+    def generate_email_for_composer(self, template_id, res_ids, fields):
+        res = super().generate_email_for_composer(template_id, res_ids, fields)
+        if self.model != "purchase.order":
+            return res
+        if (
+            template_id
+            in self.env["purchase.order"]._mail_templates_to_not_attach_labels()
+        ):
+            return
+        purchase_orders = self.env["purchase.order"].browse(res_ids)
+        for order in purchase_orders:
+            # Add the labels generated when sending the order by email
+            label_picking = order.delivery_label_picking_id
+            if not label_picking:
+                continue
+            attachments = self.env["ir.attachment"].search(
+                [
+                    ("res_model", "=", label_picking._name),
+                    ("res_id", "=", label_picking.id),
+                ]
+            )
+            if attachments:
+                attachment_ids = (
+                    res[order.id].get("attachment_ids", []) + attachments.ids
+                )
+                res[order.id]["attachment_ids"] = attachment_ids
+        return res

--- a/delivery_purchase_label/models/purchase_order.py
+++ b/delivery_purchase_label/models/purchase_order.py
@@ -1,0 +1,150 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import SUPERUSER_ID, _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    vendor_label_carrier_id = fields.Many2one(
+        "delivery.carrier",
+        "Vendor Label Carrier",
+        domain=[("purchase_label_picking_type", "!=", False)],
+    )
+    delivery_label_picking_id = fields.Many2one(
+        "stock.picking",
+        "Delivery Label Picking",
+        store=True,
+        readonly=True,
+    )
+
+    @api.model
+    def _states_to_generate_delivery_label(self):
+        """Labels will be (re)generated only if the PO is in one of these states."""
+        return ["draft", "sent"]
+
+    @api.model
+    def _mail_templates_to_not_attach_labels(self):
+        return self.env.ref("purchase.email_template_edi_purchase_reminder").ids
+
+    def action_rfq_send(self):
+        self.ensure_one()
+        self._generate_purchase_delivery_label()
+        return super().action_rfq_send()
+
+    def button_cancel(self):
+        self._cancel_purchase_delivery_label_picking()
+        return super().button_cancel()
+
+    def _is_valid_for_vendor_labels(self):
+        self.ensure_one()
+        if self.state not in self._states_to_generate_delivery_label():
+            return False
+        if not self.dest_address_id:
+            return False
+        if not any(
+            product.type in ["product", "consu"]
+            for product in self.order_line.product_id
+        ):
+            return False
+        if not self.vendor_label_carrier_id.purchase_label_picking_type:
+            return False
+        return True
+
+    def _is_picking_label_uptodate(self):
+        """Check if the picking label needs to be regenerated."""
+        self.ensure_one()
+        if not self.delivery_label_picking_id:
+            return False
+        if self.delivery_label_picking_id.state != "done":
+            return False
+        pick = self.delivery_label_picking_id
+        moves_new = []
+        for line in self.order_line:
+            for value in line._prepare_stock_moves(self.delivery_label_picking_id):
+                moves_new.append(
+                    {key: value[key] for key in ("product_id", "product_uom_qty")}
+                )
+        move_prev = [
+            {"product_id": move.product_id.id, "product_uom_qty": move.product_uom_qty}
+            for move in pick.move_lines
+        ]
+        if len(move_prev) == len(moves_new):
+            if [
+                move_value for move_value in move_prev if move_value not in moves_new
+            ] == []:
+                return True
+        return False
+
+    def _generate_purchase_delivery_label(self):
+        """Create a transfer to generate the carrier labels."""
+        self.ensure_one()
+        if not self._is_valid_for_vendor_labels():
+            return
+        if not self.partner_id.property_stock_supplier.id:
+            raise UserError(
+                _(
+                    "You must set a Vendor Location for this partner %s",
+                    self.partner_id.name,
+                )
+            )
+        if self._is_picking_label_uptodate():
+            return
+
+        order = self.with_company(self.company_id)
+        picking = order._create_purchase_delivery_label_picking(carrier)
+
+        if order.delivery_label_picking_id:
+            order._cancel_purchase_delivery_label_picking()
+
+        order.delivery_label_picking_id = picking
+        picking.message_post_with_view(
+            "mail.message_origin_link",
+            values={"self": picking, "origin": self},
+            subtype_id=self.env.ref("mail.mt_note").id,
+        )
+
+    def _create_purchase_delivery_label_picking(self, carrier):
+        self.ensure_one()
+        values = self._get_purchase_delivery_label_picking_value(carrier)
+        picking = self.env["stock.picking"].with_user(SUPERUSER_ID).create(values)
+        moves = self.order_line._create_stock_moves(picking)
+        moves.location_id = picking.location_id
+        moves.location_dest_id = picking.location_dest_id
+        # Remove the link on the sale and purchase
+        # To not impact the delivered quantity on them
+        picking.sale_id = False
+        moves.sale_line_id = False
+        moves.purchase_line_id = False
+        picking.action_assign()
+        for move in picking.move_lines:
+            move.quantity_done = move.product_uom_qty
+        picking._action_done()
+        return picking
+
+    def _cancel_purchase_delivery_label_picking(self):
+        delivery_label_pickings = self.delivery_label_picking_id
+        for picking in delivery_label_pickings:
+            picking.cancel_shipment()
+        # Using wirte to by pass internal checks, not a problem
+        # because this is a fake move (Vendor to Vendor)
+        delivery_label_pickings.move_line_ids.write({"state": "cancel"})
+        delivery_label_pickings.move_lines.write({"state": "cancel"})
+        delivery_label_pickings.write({"state": "cancel"})
+
+    def _get_purchase_delivery_label_picking_value(self, carrier):
+        return {
+            "picking_type_id": carrier.purchase_label_picking_type.id,
+            "partner_id": self.dest_address_id.id,
+            "user_id": False,
+            "date": fields.Datetime.now(),
+            "origin": " - ".join(
+                [origin for origin in [self.origin, self.name] if origin]
+            ),
+            "location_dest_id": self.partner_id.property_stock_supplier.id,
+            "location_id": self.partner_id.property_stock_supplier.id,
+            "company_id": self.company_id.id,
+            "carrier_id": carrier.id,
+        }

--- a/delivery_purchase_label/models/purchase_order.py
+++ b/delivery_purchase_label/models/purchase_order.py
@@ -6,6 +6,10 @@ from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import UserError
 
 
+class SameDeliveryLabelGenerated(Exception):
+    pass
+
+
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
@@ -54,30 +58,16 @@ class PurchaseOrder(models.Model):
             return False
         return True
 
-    def _is_picking_label_uptodate(self):
-        """Check if the picking label needs to be regenerated."""
-        self.ensure_one()
-        if not self.delivery_label_picking_id:
+    def _are_delivery_label_equivalent(self, pick_1, pick_2):
+        if len(pick_1.move_lines) != len(pick_2.move_lines):
             return False
-        if self.delivery_label_picking_id.state != "done":
-            return False
-        pick = self.delivery_label_picking_id
-        moves_new = []
-        for line in self.order_line:
-            for value in line._prepare_stock_moves(self.delivery_label_picking_id):
-                moves_new.append(
-                    {key: value[key] for key in ("product_id", "product_uom_qty")}
-                )
-        move_prev = [
-            {"product_id": move.product_id.id, "product_uom_qty": move.product_uom_qty}
-            for move in pick.move_lines
-        ]
-        if len(move_prev) == len(moves_new):
-            if [
-                move_value for move_value in move_prev if move_value not in moves_new
-            ] == []:
-                return True
-        return False
+        for move_old, move_new in zip(pick_1.move_lines, pick_2.move_lines):
+            if (
+                move_old.product_id != move_new.product_id
+                or move_old.product_uom_qty != move_new.product_uom_qty
+            ):
+                return False
+        return True
 
     def _generate_purchase_delivery_label(self):
         """Create a transfer to generate the carrier labels."""
@@ -91,19 +81,31 @@ class PurchaseOrder(models.Model):
                     self.partner_id.name,
                 )
             )
-        if self._is_picking_label_uptodate():
-            return
-
+        carrier = self.vendor_label_carrier_id
         order = self.with_company(self.company_id)
-        picking = order._create_purchase_delivery_label_picking(carrier)
-
+        new_label_picking = None
+        try:
+            with self.env.cr.savepoint():
+                # Using a savepoint for generating the transfer for the label
+                # and keep the new one only if it is different
+                new_label_picking = order._create_purchase_delivery_label_picking(
+                    carrier
+                )
+                if self._are_delivery_label_equivalent(
+                    new_label_picking, order.delivery_label_picking_id
+                ):
+                    new_label_picking = None
+                    raise SameDeliveryLabelGenerated
+        except SameDeliveryLabelGenerated:
+            pass
+        if not new_label_picking:
+            return
         if order.delivery_label_picking_id:
             order._cancel_purchase_delivery_label_picking()
-
-        order.delivery_label_picking_id = picking
-        picking.message_post_with_view(
+        order.delivery_label_picking_id = new_label_picking
+        new_label_picking.message_post_with_view(
             "mail.message_origin_link",
-            values={"self": picking, "origin": self},
+            values={"self": new_label_picking, "origin": self},
             subtype_id=self.env.ref("mail.mt_note").id,
         )
 

--- a/delivery_purchase_label/models/purchase_order.py
+++ b/delivery_purchase_label/models/purchase_order.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import SUPERUSER_ID, _, api, fields, models
@@ -147,4 +148,5 @@ class PurchaseOrder(models.Model):
             "location_id": self.partner_id.property_stock_supplier.id,
             "company_id": self.company_id.id,
             "carrier_id": carrier.id,
+            "delivery_label_purchase_id": self.id,
         }

--- a/delivery_purchase_label/models/stock_picking.py
+++ b/delivery_purchase_label/models/stock_picking.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    delivery_label_purchase_id = fields.Many2one(
+        "purchase.order", string="Delivery label purchase order", ondelete="cascade"
+    )

--- a/delivery_purchase_label/readme/CONFIGURE.rst
+++ b/delivery_purchase_label/readme/CONFIGURE.rst
@@ -1,0 +1,8 @@
+On the partner form a new field `Purchase Delivery Method` allows to select
+the carrier that will be used by the supplier to send the goods.
+
+In "Inventory > Configuration > Delivery > Shipping Methods", a new field
+`Operation Type for Sending Labels`
+allows to select the operation type to use for the stock transfer that will
+generate the required labels.
+If that field is not set, there will be no changes to the normal flow.

--- a/delivery_purchase_label/readme/CONTRIBUTORS.rst
+++ b/delivery_purchase_label/readme/CONTRIBUTORS.rst
@@ -1,4 +1,5 @@
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>
 
 Design
 ~~~~~~

--- a/delivery_purchase_label/readme/CONTRIBUTORS.rst
+++ b/delivery_purchase_label/readme/CONTRIBUTORS.rst
@@ -1,0 +1,6 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>
+
+Design
+~~~~~~
+
+* Jacques-Etienne Baudoux <je@bcim.be>

--- a/delivery_purchase_label/readme/DESCRIPTION.rst
+++ b/delivery_purchase_label/readme/DESCRIPTION.rst
@@ -1,0 +1,15 @@
+Print delivery labels for dropshipping purchase order.
+Useful when the vendor that will process the order does not have the
+capabilities to print the transporter labels needed for the delivery.
+
+This is done by creating and processing a stock transfer with the source
+and destination location set as the vendor location. And the carrier set.
+
+The transporter being used is the one set on the `Purchase Delivery Method` of the
+vendor in the "Sales & Purchase" tab.
+
+A new operation type is created by the module and used for the transfer.
+All attachment (should be only the labels) on the transfer are then attached
+to the email send to the vendor (rfq or po).
+When the purchase order is still in draft the labels are regenerated everytime
+the email is sent.

--- a/delivery_purchase_label/tests/__init__.py
+++ b/delivery_purchase_label/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_delivery_purchase_label

--- a/delivery_purchase_label/tests/test_delivery_purchase_label.py
+++ b/delivery_purchase_label/tests/test_delivery_purchase_label.py
@@ -63,11 +63,15 @@ class TestDeliveryPurchaseLabel(SavepointCase):
         # Does not change the picking label
         self.order._generate_purchase_delivery_label()
         self.assertEqual(label_picking, self.order.delivery_label_picking_id)
+        self.assertEqual(label_picking.delivery_label_purchase_id, self.order)
         # Changing the PO
         self.order.order_line[0].product_qty = 10
         self.order._generate_purchase_delivery_label()
         self.assertTrue(label_picking.state == "cancel")
         self.assertTrue(label_picking != self.order.delivery_label_picking_id)
+        self.assertEqual(
+            self.order.delivery_label_picking_id.delivery_label_purchase_id, self.order
+        )
 
     def test_transfer_label_not_generated(self):
         self.carrier.purchase_label_picking_type = False

--- a/delivery_purchase_label/tests/test_delivery_purchase_label.py
+++ b/delivery_purchase_label/tests/test_delivery_purchase_label.py
@@ -1,0 +1,96 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import SavepointCase
+
+
+class TestDeliveryPurchaseLabel(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        # Mocking to avoid a NotImplementedError
+        cls.env["delivery.carrier"]._patch_method(
+            "base_on_rule_cancel_shipment", lambda x, y: True
+        )
+        cls.picking_type = cls.env.ref(
+            "delivery_purchase_label.picking_type_send_label"
+        )
+        cls.supplier = cls.env.ref("base.res_partner_1")
+        cls.customer = cls.env.ref("base.res_partner_2")
+        cls.carrier = cls.env.ref("delivery.delivery_carrier")
+        cls.carrier.purchase_label_picking_type = cls.picking_type
+
+        cls.product = cls.env.ref("product.product_product_5")
+        cls.order = cls.env["purchase.order"].create(
+            {
+                "partner_id": cls.supplier.id,
+                "dest_address_id": cls.customer.id,
+                "vendor_label_carrier_id": cls.carrier.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": cls.product.name,
+                            "product_id": cls.product.id,
+                            "product_qty": 5.0,
+                            "product_uom": cls.product.uom_id.id,
+                            "price_unit": 10,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.order.order_line._onchange_quantity()
+
+    def _create_fake_label_attachment(self, linked_to):
+        return self.env["ir.attachment"].create(
+            {
+                "name": "Fake Label Pdf",
+                "datas": "bWlncmF0aW9uIHRlc3Q=",
+                "res_model": linked_to._name,
+                "res_id": linked_to.id,
+            }
+        )
+
+    def test_transfer_label_generated(self):
+        self.order._generate_purchase_delivery_label()
+        label_picking = self.order.delivery_label_picking_id
+        self.assertEqual(label_picking.picking_type_id, self.picking_type)
+        self.assertEqual(label_picking.state, "done")
+        # Generating a second time with no changes on the purchase
+        # Does not change the picking label
+        self.order._generate_purchase_delivery_label()
+        self.assertEqual(label_picking, self.order.delivery_label_picking_id)
+        # Changing the PO
+        self.order.order_line[0].product_qty = 10
+        self.order._generate_purchase_delivery_label()
+        self.assertTrue(label_picking.state == "cancel")
+        self.assertTrue(label_picking != self.order.delivery_label_picking_id)
+
+    def test_transfer_label_not_generated(self):
+        self.carrier.purchase_label_picking_type = False
+        self.order._generate_purchase_delivery_label()
+        self.assertFalse(self.order.picking_ids)
+
+    def test_add_label_attachment_to_email(self):
+        self.order._generate_purchase_delivery_label()
+        pdf_label = self._create_fake_label_attachment(
+            self.order.delivery_label_picking_id
+        )
+        vals = {
+            "partner_ids": [(6, 0, self.order.partner_id.ids)],
+            "model": self.order._name,
+            "res_id": self.order.id,
+        }
+        wiz = self.env["mail.compose.message"].create(vals)
+        template = self.env.ref("purchase.email_template_edi_purchase")
+        res = wiz.generate_email_for_composer(template.id, self.order.ids, ["subject"])
+        self.assertTrue(res[self.order.id].get("attachment_ids"))
+        self.assertEqual(res[self.order.id].get("attachment_ids"), pdf_label.ids)
+
+    def test_cancel_purchase_order(self):
+        self.order._generate_purchase_delivery_label()
+        self.order.button_cancel()
+        self.assertTrue(self.order.delivery_label_picking_id.state == "cancel")

--- a/delivery_purchase_label/views/delivery_carrier.xml
+++ b/delivery_purchase_label/views/delivery_carrier.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_delivery_carrier_form" model="ir.ui.view">
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='delivery_details']" position="inside">
+                <field name="purchase_label_picking_type" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/delivery_purchase_label/views/purchase_order_views.xml
+++ b/delivery_purchase_label/views/purchase_order_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.form delivery_purchase_label</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <field name="origin" position="after">
+                <field
+                    name="delivery_label_picking_id"
+                    attrs="{'invisible': [('delivery_label_picking_id','=',False)]}"
+                />
+            </field>
+            <field name="picking_type_id" position="after">
+                <field name="vendor_label_carrier_id" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/delivery_purchase_label/odoo/addons/delivery_purchase_label
+++ b/setup/delivery_purchase_label/odoo/addons/delivery_purchase_label
@@ -1,0 +1,1 @@
+../../../../delivery_purchase_label

--- a/setup/delivery_purchase_label/setup.py
+++ b/setup/delivery_purchase_label/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Print delivery labels for dropshipping purchase order. Useful when then vendor that will process the order does not have the capabilities to print the transporter labels needed for the delivery.