### PR TITLE
[14.0][FIX] delivery_price_method: fix crash in send_shipping()

### DIFF
--- a/delivery_price_method/models/delivery_carrier.py
+++ b/delivery_price_method/models/delivery_carrier.py
@@ -32,7 +32,7 @@ class DeliveryCarrier(models.Model):
 
     def send_shipping(self, pickings):
         res = super().send_shipping(pickings)
-        if self.price_method in ("fixed", "base_on_rule"):
+        if isinstance(res, list) and self.price_method in ("fixed", "base_on_rule"):
             rates = getattr(self, "%s_send_shipping" % self.price_method)(pickings)
             for index, rate in enumerate(rates):
                 del rate["tracking_number"]  # remove offending key


### PR DESCRIPTION
The module "delivery_price_method" only depends on "delivery".
In the "delivery" module, send_shipping() can return nothing, cf https://github.com/odoo/odoo/blob/14.0/addons/delivery/models/delivery_carrier.py#L181

Without this fix, send_shipping() would crash when super() returns nothing.

FYI, if the OCA module base_delivery_carrier_label is installed, you may not see the crash, because base_delivery_carrier_label inherits send_shipping() and always return a list, cf https://github.com/OCA/delivery-carrier/blob/14.0/base_delivery_carrier_label/models/delivery_carrier.py#L43
But base_delivery_carrier_label and delivery_price_method don't depend on each other, so you can't know which one will be executed first.

Here is the backtrace:
```
2024-09-11 21:30:38,096 3556697 ERROR testale1 odoo.http: Exception during JSON request handling.
Traceback (most recent call last):
  File "/home/odoo/erp/odoo/src/odoo/addons/base/models/ir_http.py", line 237, in _dispatch-
    result = request.dispatch()
  File "/home/odoo/erp/odoo/src/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/home/odoo/erp/odoo/src/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/erp/odoo/src/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/erp/odoo/src/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/odoo/erp/odoo/src/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/home/odoo/erp/odoo/src/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/erp/odoo/src/addons/web/controllers/main.py", line 1374, in call_button--
    action = self._call_kw(model, method, args, kwargs)
  File "/home/odoo/erp/odoo/src/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/erp/odoo/src/odoo/api.py", line 406, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/erp/odoo/src/odoo/api.py", line 391, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/erp/odoo/external-src/stock-logistics-barcode/stock_barcodes/models/stock_picking.py", line 49, in button_validate
    res = super().button_validate()
  File "/home/odoo/erp/odoo/src/addons/stock/models/stock_picking.py", line 974, in button_validate
    pickings_to_backorder.with_context(cancel_backorder=False)._action_done()
  File "/home/odoo/erp/odoo/external-src/connector-ecommerce/connector_ecommerce/models/stock.py", line 27, in _action_done
    result = super(StockPicking, self_context)._action_done()
  File "/home/odoo/erp/odoo/src/addons/sale_stock/models/stock.py", line 91, in _action_done
    res = super()._action_done()
  File "/home/odoo/erp/odoo/src/addons/stock/models/stock_picking.py", line 801, in _action_done
    self._send_confirmation_email()
  File "/home/odoo/erp/odoo/src/addons/delivery/models/stock_picking.py", line 183, in _send_confirmation_email
    pick.sudo().send_to_shipper()
  File "/home/odoo/delivery-carrier-test/base_delivery_carrier_label/models/stock_picking.py", line 74, in send_to_shipper
    return super().send_to_shipper()
  File "/home/odoo/erp/odoo/src/addons/delivery/models/stock_picking.py", line 225, in send_to_shipper
    res = self.carrier_id.send_shipping(self)[0]
  File "/home/odoo/delivery-carrier-test/base_delivery_carrier_label/models/delivery_carrier.py", line 42, in send_shipping
    result = super().send_shipping(pickings)
  File "/home/odoo/delivery-carrier-test/delivery_price_method/models/delivery_carrier.py", line 44, in send_shipping
    res[index].update(rate)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/erp/odoo/src/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/erp/odoo/src/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: 'NoneType' object is not subscriptable
```