### PR TITLE
[14.0][IMP] base_delivery_carrier_label: show weight field in tree and form view of stock.move.line

### DIFF
--- a/base_delivery_carrier_label/views/stock.xml
+++ b/base_delivery_carrier_label/views/stock.xml
@@ -26,6 +26,31 @@
             </field>
         </field>
     </record>
+    <record id="view_stock_move_line_detailed_operation_tree" model="ir.ui.view">
+        <field name="model">stock.move.line</field>
+        <field
+            name="inherit_id"
+            ref="stock.view_stock_move_line_detailed_operation_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="package_id" position="before">
+                <field name="weight" optional="hide" />
+            </field>
+        </field>
+    </record>
+    <record id="view_move_line_form" model="ir.ui.view">
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_move_line_form" />
+        <field name="arch" type="xml">
+            <field name="package_id" position="before">
+                <label for="weight" />
+                <div name="weight">
+                    <field name="weight" class="oe_inline" /> kg
+                    </div>
+            </field>
+        </field>
+    </record>
+
     <record id="view_quant_package_form" model="ir.ui.view">
         <field name="model">stock.quant.package</field>
         <field name="inherit_id" ref="stock.view_quant_package_form" />


### PR DESCRIPTION
base_delivery_carrier_label adds a weight field on stock.move.line (https://github.com/OCA/delivery-carrier/blob/14.0/base_delivery_carrier_label/models/stock_move_line.py#L15), but it's doesn't show it in the view! This PR adds the field in the tree and form view of stock.move.line.

With the field displayed in the user interface, you will see that it's value is always 0... and, when you look at the code, you see that the method get_weight() is only called to write the weight on the package... but it is not used to write the weight on stock.move.line. This PR doesn't fix this, but we need to do something about it !