### PR TITLE
[14.0][FIX] commercialName is mandatory for dropoff site so we can add it every time

### DIFF
--- a/delivery_roulier_laposte_fr/models/stock_picking.py
+++ b/delivery_roulier_laposte_fr/models/stock_picking.py
@@ -146,6 +146,6 @@ class StockPicking(models.Model):
 
     def _laposte_fr_get_service(self, account, package=None):
         vals = self._roulier_get_service(account, package=package)
-
+        vals["commercialName"] = account.company_id.name
         vals["returnTypeChoice"] = 3  # do not return to sender
         return vals


### PR DESCRIPTION

commercialName is not an mandatory field in basic case but mandatoiry for dropoff site delivery.

I propose to send it every time to avoid other delivery types issues instead of adding it in only in laposte_dropoff_site module