### PR TITLE
[MIG][IMP] delivery_multi_destination: Introduce 'based on destination' delivery type

### DIFF
--- a/delivery_multi_destination/__init__.py
+++ b/delivery_multi_destination/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards

--- a/delivery_multi_destination/__manifest__.py
+++ b/delivery_multi_destination/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Multiple destinations for the same delivery method",
-    "version": "16.0.1.0.1",
+    "version": "16.0.2.0.0",
     "category": "Delivery",
     "website": "https://github.com/OCA/delivery-carrier",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/delivery_multi_destination/demo/delivery_carrier_demo.xml
+++ b/delivery_multi_destination/demo/delivery_carrier_demo.xml
@@ -8,6 +8,7 @@
         <field name="name">International Carrier Inc.</field>
         <field name="sequence">4</field>
         <field name="destination_type">multi</field>
+        <field name="delivery_type">base_on_destination</field>
         <field name="product_id" ref="product_product_delivery_carrier_multi" />
     </record>
     <record id="product_product_delivery_carrier_multi_child_1" model="product.product">

--- a/delivery_multi_destination/migrations/16.0.2.0.0/pre-migration.py
+++ b/delivery_multi_destination/migrations/16.0.2.0.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Coop IT Easy SC
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE delivery_carrier
+        SET delivery_type = 'base_on_destination'
+        WHERE destination_type = 'multi'
+        """,
+    )

--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -62,14 +62,14 @@ class DeliveryCarrier(models.Model):
         if self.destination_type == "multi" and self.child_ids and not self.product_id:
             self.product_id = fields.first(self.child_ids.product_id)
 
-    def search(self, args, offset=0, limit=None, order=None, count=False):
-        """Don't show by default children carriers."""
+    def search(self, domain, offset=0, limit=None, order=None, count=False):
+        """Don't show children carriers by default."""
         if not self.env.context.get("show_children_carriers"):
-            if args is None:
-                args = []
-            args += [("parent_id", "=", False)]
-        return super(DeliveryCarrier, self).search(
-            args,
+            if domain is None:
+                domain = []
+            domain += [("parent_id", "=", False)]
+        return super().search(
+            domain,
             offset=offset,
             limit=limit,
             order=order,
@@ -78,10 +78,17 @@ class DeliveryCarrier(models.Model):
 
     @api.model
     def name_search(self, name="", args=None, operator="ilike", limit=100):
-        """Don't show by default children carriers."""
-        args = args or []
-        args += [("parent_id", "=", False)]
-        return super().name_search(name=name, args=args, operator=operator, limit=limit)
+        """Don't show children carriers by default."""
+        if not self.env.context.get("show_children_carriers"):
+            if args is None:
+                args = []
+            args += [("parent_id", "=", False)]
+        return super().name_search(
+            name=name,
+            args=args,
+            operator=operator,
+            limit=limit,
+        )
 
     def available_carriers(self, partner):
         """If the carrier is multi, we test the availability on children."""

--- a/delivery_multi_destination/readme/newsfragments/540.feature.rst
+++ b/delivery_multi_destination/readme/newsfragments/540.feature.rst
@@ -1,0 +1,4 @@
+Introduced 'based on destination' delivery type. This is the delivery type used
+by all multi-destination carriers instead of 'fixed'. Consequently, destination
+type has been turned into a computed field that checks if the delivery type is
+'based on destination' or not.

--- a/delivery_multi_destination/tests/test_delivery_multi_destination.py
+++ b/delivery_multi_destination/tests/test_delivery_multi_destination.py
@@ -72,6 +72,7 @@ class TestDeliveryMultiDestination(common.TransactionCase):
             {
                 "name": "Test carrier single",
                 "destination_type": "one",
+                "fixed_price": 100,
                 "child_ids": False,
             }
         )
@@ -84,8 +85,7 @@ class TestDeliveryMultiDestination(common.TransactionCase):
         carrier_form = Form(self.env["delivery.carrier"])
         carrier_form.name = "Test carrier multi"
         carrier_form.product_id = self.product
-        carrier_form.delivery_type = "fixed"
-        carrier_form.fixed_price = 100
+        carrier_form.delivery_type = "base_on_destination"
         # this needs to be done in this order
         carrier_form.destination_type = "multi"
         for child_item in childs:
@@ -135,6 +135,20 @@ class TestDeliveryMultiDestination(common.TransactionCase):
         self._choose_delivery_carrier(order, order.carrier_id)
         sale_order_line = order.order_line.filtered("is_delivery")
         self.assertAlmostEqual(sale_order_line.price_unit, 150, 2)
+
+    def test_compute(self):
+        self.carrier_multi.delivery_type = "fixed"
+        self.assertEqual(self.carrier_multi.destination_type, "one")
+        self.carrier_multi.delivery_type = "base_on_destination"
+        self.assertEqual(self.carrier_multi.destination_type, "multi")
+
+    def test_inverse(self):
+        self.carrier_multi.destination_type = "one"
+        self.assertEqual(self.carrier_multi.destination_type, "one")
+        self.assertEqual(self.carrier_multi.delivery_type, "fixed")
+        self.carrier_multi.destination_type = "multi"
+        self.assertEqual(self.carrier_multi.destination_type, "multi")
+        self.assertEqual(self.carrier_multi.delivery_type, "base_on_destination")
 
     def test_search(self):
         carriers = self.env["delivery.carrier"].search([])

--- a/delivery_multi_destination/wizards/__init__.py
+++ b/delivery_multi_destination/wizards/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import choose_delivery_carrier

--- a/delivery_multi_destination/wizards/choose_delivery_carrier.py
+++ b/delivery_multi_destination/wizards/choose_delivery_carrier.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import api, models
+
+
+class ChooseDeliveryCarrier(models.TransientModel):
+    _inherit = "choose.delivery.carrier"
+
+    @api.onchange("carrier_id")
+    def _onchange_carrier_id(self):
+        result = super()._onchange_carrier_id()
+        if self.delivery_type == "base_on_destination":
+            vals = self._get_shipment_rate()
+            if vals.get("error_message"):
+                return {"error": vals["error_message"]}
+        return result

--- a/delivery_multi_destination/wizards/choose_delivery_carrier.py
+++ b/delivery_multi_destination/wizards/choose_delivery_carrier.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from odoo import api, models
+from odoo import _, api, models
 
 
 class ChooseDeliveryCarrier(models.TransientModel):
@@ -13,6 +13,15 @@ class ChooseDeliveryCarrier(models.TransientModel):
         result = super()._onchange_carrier_id()
         if self.delivery_type == "base_on_destination":
             vals = self._get_shipment_rate()
+            # although ._onchange_carrier_id() in the delivery module can
+            # return a dict with an "error" key and a string value, this is
+            # not handled by the caller (see BaseModel._onchange_eval()),
+            # which only handles dicts with a "warning" key and a dict as a
+            # value.
             if vals.get("error_message"):
-                return {"error": vals["error_message"]}
+                return {
+                    "warning": {"title": _("Error"), "message": vals["error_message"]}
+                }
+            if vals.get("warning_message"):
+                return {"warning": {"message": vals["warning_message"]}}
         return result


### PR DESCRIPTION
Backported from #871 
Internal task T12787

website_sale_delivery checks whether delivery_type is set to 'fixed' for some behaviours. And before this commit, multi-destination carriers effectively always had the delivery_type set to 'fixed'. However, because children of the multi-destination carrier can be something other than 'fixed', this causes some strange behaviours.

(Example, on the delivery selection page, you expect 'Select to compute delivery rate' to show up for non-'fixed' carriers, but this doesn't happen.)

We can't make website_sale_delivery aware of destination_type, but we _can_ introduce a non-'fixed' delivery type. So that's what we do here.

The choice was made to turn the destination type into a computed value dependent on the delivery type because there is strong coupling between the two values, and trying to keep the two values in sync using onchange/constrains/etc resulted in terrible spaghetti code.