### PR TITLE
[16.0][FIX]delivery_deliverea:Fixes error when recording shipments

### DIFF
--- a/delivery_deliverea/models/delivery_carrier.py
+++ b/delivery_deliverea/models/delivery_carrier.py
@@ -458,15 +458,16 @@ class DeliveryCarrier(models.Model):
     def deliverea_return_shipping(self, pickings):
         deliverea_request = DelivereaRequest(self)
         for picking in pickings:
-            vals = self._prepare_deliverea_order(picking)
-            response = deliverea_request.create_return(vals)
-            self._deliverea_check_response(response)
-            picking.write(
-                {
-                    "carrier_tracking_ref": response.get("carrierReference", ""),
-                    "deliverea_reference": response.get("delivereaReference", ""),
-                }
-            )
+            if picking.picking_type_code == "incoming":
+                vals = self._prepare_deliverea_order(picking)
+                response = deliverea_request.create_return(vals)
+                self._deliverea_check_response(response)
+                picking.write(
+                    {
+                        "carrier_tracking_ref": response.get("carrierReference", ""),
+                        "deliverea_reference": response.get("delivereaReference", ""),
+                    }
+                )
         return True
 
     def deliverea_cancel_shipment(self, pickings):

--- a/delivery_deliverea/models/stock_picking.py
+++ b/delivery_deliverea/models/stock_picking.py
@@ -19,9 +19,16 @@ class StockPicking(models.Model):
             return
         return self.carrier_id.deliverea_get_label(self)
 
+    def is_deliverea_pickup(self):
+        self.ensure_one()
+        return (
+            self.carrier_id.delivery_type == "deliverea"
+            and self.carrier_id.deliverea_return_label
+        )
+
     def send_to_shipper(self):
         self.ensure_one()
-        if self.delivery_type == "deliverea":
+        if self.is_deliverea_pickup():
             self.carrier_id.deliverea_return_shipping(self)
             self.carrier_id.deliverea_get_return_label(self)
         return super().send_to_shipper()


### PR DESCRIPTION
When you try to record a shipment in Deliverea, it is calling the pickup URL, not allowing any shipment to be recorded and returning an error.