### PR TITLE
[16.0][IMP] delivery_carrier_manual_weight: allow to set `is_manual_weight` on picking

### DIFF
--- a/delivery_carrier_manual_weight/views/delivery_view.xml
+++ b/delivery_carrier_manual_weight/views/delivery_view.xml
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form" />
         <field name="arch" type="xml">
             <label for="weight" position="before">
-                <field name="is_manual_weight" invisible="1" />
+                <field name="is_manual_weight" />
                 <label
                     for="weight_manual"
                     attrs="{'invisible': [('is_manual_weight', '=', False)]}"


### PR DESCRIPTION
This update enhances the manual weight selection process by enabling a boolean option on the picking, which will take precedence over the carrier's boolean setting, allowing for more granular control.