### PR TITLE
[16.0][IMP] partner_delivery_zone: Show delivery zone

### DIFF
--- a/partner_delivery_zone/views/report_shipping.xml
+++ b/partner_delivery_zone/views/report_shipping.xml
@@ -4,10 +4,7 @@
 <odoo>
     <template id="report_picking" inherit_id="stock.report_picking">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <div
-                t-if="o.picking_type_id.code == 'outgoing' and o.delivery_zone_id"
-                class="col-auto"
-            >
+            <div t-if="o.delivery_zone_id" class="col-auto">
                 <strong>Zone</strong>
                 <span t-field="o.delivery_zone_id" />
             </div>


### PR DESCRIPTION
The condition is modified to show the delivery zone on all prints of the report as long as it is set.

fw port of https://github.com/OCA/delivery-carrier/pull/911

cc @Tecnativa TT51791

@sergio-teruel @CarlosRoca13 please review