### PR TITLE
[16.0][FIX] delivery_price_method: the price rules field in the carrier when a supplier is selected

### DIFF
--- a/delivery_price_method/views/delivery_carrier_views.xml
+++ b/delivery_price_method/views/delivery_carrier_views.xml
@@ -28,7 +28,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                         name="general"
                         attrs="{'invisible':[('price_method', '!=', 'base_on_rule')]}"
                     >
-                        <field name="price_rule_ids" nolabel="1" />
+                        <field name="price_rule_ids" nolabel="1" colspan="2" />
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
In the view the field does not fit the width
![image](https://github.com/user-attachments/assets/d336a3fd-df10-40c7-885a-a0b6b00e11ec)

This change will correct
![image](https://github.com/user-attachments/assets/0af199bf-2d98-4a1b-80ba-3f14542d15d3)
