### PR TITLE
[16.0][IMP] delivery_package_number: add delivery address and phone to the shipping label

### DIFF
--- a/delivery_package_number/reports/report_package_number.xml
+++ b/delivery_package_number/reports/report_package_number.xml
@@ -38,7 +38,18 @@
                             style="padding: 60px 0;"
                             name="client"
                         >
-                            <span t-field="dest_picking.partner_id" />
+                            <span t-field="dest_picking.partner_id.name" />
+                            <t t-if="dest_picking.partner_id.contact_address">
+                                <br /><span
+                                    t-raw="dest_picking.partner_id.contact_address"
+                                />
+                            </t>
+                            <t t-if="dest_picking.partner_id.phone">
+                                <br /><t t-esc="dest_picking.partner_id.phone" />
+                            </t>
+                            <t t-if="dest_picking.partner_id.mobile">
+                                <br /><t t-esc="dest_picking.partner_id.mobile" />
+                            </t>
                         </div>
                         <div class="col-2" />
                         <div


### PR DESCRIPTION
Current label, no address and no phone
![image](https://github.com/user-attachments/assets/17f6364d-506f-49c5-8b84-3de41f14b025)

with these changes the label shows address and phone number
![image](https://github.com/user-attachments/assets/5288e84a-941b-4475-ac5a-5f915308c307)
