### PR TITLE
[16][IMP] delivery_package_number: changes on delivery_package_number_document

### DIFF
--- a/delivery_package_number/reports/report_package_number.xml
+++ b/delivery_package_number/reports/report_package_number.xml
@@ -11,8 +11,8 @@
                 t-value="doc.move_ids.browse(move_ids).filtered('sale_line_id')[:1].picking_id"
             />
             <t t-foreach="doc.number_of_packages" t-as="pack_num">
-                <div class="page">
-                    <div class="row">
+                <div class="page" style="page-break-inside:avoid;">
+                    <div class="row mt-5">
                         <div class="col-5" name="logo">
                             <img
                                 t-if="doc.company_id.logo"
@@ -38,7 +38,10 @@
                             style="padding: 60px 0;"
                             name="client"
                         >
-                            <span t-field="dest_picking.partner_id" />
+                            <span
+                                t-field="dest_picking.partner_id"
+                                t-options="{'widget': 'contact', 'fields': ['address', 'name', 'mobile'], 'no_marker': True}"
+                            />
                         </div>
                         <div class="col-2" />
                         <div
@@ -46,16 +49,16 @@
                             name="package_number"
                         >
                             <h6>Number of packages:</h6>
-                            <div style="font-size: 4em" class="text-center">
-                                <span t-out="pack_num + 1" />/<span
-                                    t-field="doc.number_of_packages"
-                                />
+                            <div
+                                style="font-size: 4em;padding:auto;margin:auto;"
+                                class="text-center"
+                            >
+                                <span t-out="pack_num + 1" />/
+                                <span t-field="doc.number_of_packages" />
                             </div>
                         </div>
                     </div>
-
                 </div>
-                <div style="page-break-before:always;" />
             </t>
         </t>
     </template>


### PR DESCRIPTION
Good morning, I suggest this change to allow configuring the report with a different paper format than the default one. For example, if you need to create labels on an A4 sheet, the line break forced by ```<div style="page-break-before:always;" />```  wastes space unnecessarily.

The proposed change forces a page break if the label is cut off.