### PR TITLE
[14.0][IMP] delivery_price_product_domain, delivery_price_collection_cost_product_domain: use context order_id for product domain application in price computation

### DIFF
--- a/delivery_price_collection_cost_product_domain/models/delivery_carrier.py
+++ b/delivery_price_collection_cost_product_domain/models/delivery_carrier.py
@@ -19,10 +19,13 @@ class DeliveryCarrier(models.Model):
             return super()._get_price_from_picking(total, weight, volume, quantity)
         price_dict = self._get_price_dict(total, weight, volume, quantity)
         untaxed_in_dict = "untaxed_price" in price_dict
+        order = (
+            self.env["sale.order"].sudo().browse(self._context.get("order_id", False))
+        )
         for line in self.price_rule_ids:
             apply_product_domain_char = line.apply_product_domain
-            if apply_product_domain_char and self.order_id:
-                apply_product = self.order_id.order_line.product_id.search(
+            if apply_product_domain_char and order:
+                apply_product = order.order_line.product_id.search(
                     ast.literal_eval(apply_product_domain_char)
                 )
                 self.recompute_price_available(


### PR DESCRIPTION
The changes try to avoid concurrent write like this:

```
2025-02-03 08:15:41,301 2015296 ERROR detest odoo.sql_db: bad query: UPDATE "delivery_carrier" SET "order_id"=69411,"write_uid"=613,"write_date"=(now() at time zone 'UTC') WHERE id IN (79)
ERROR: could not serialize access due to concurrent update
```

Basically each time a computation is needed the sale order_id is changed on delivery carrier; if you get multiple user working on different orders with same carrier this ends on concurrent connection trying to change the order id.