### PR TITLE
[18.0][FIX] partner_delivery_schedule: Incorrect module dependency

### DIFF
--- a/partner_delivery_schedule/__manifest__.py
+++ b/partner_delivery_schedule/__manifest__.py
@@ -11,7 +11,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["delivery"],
+    "depends": ["stock_delivery"],
     "data": [
         "security/ir.model.access.csv",
         "views/partner_delivery_schedule_view.xml",


### PR DESCRIPTION
@Tecnativa

There is an issue in the migration https://github.com/OCA/delivery-carrier/pull/942 i have changed the module dependency so that it can be installed correctly.

@sergio-teruel @CarlosRoca13  take a look when you can, please