### PR TITLE
[16.0][FIX] delivery_auto_refresh: don't try to create lines over a new id

### DIFF
--- a/delivery_auto_refresh/models/sale_order.py
+++ b/delivery_auto_refresh/models/sale_order.py
@@ -121,6 +121,12 @@ class SaleOrder(models.Model):
         if new_vals:
             delivery_line.write(new_vals)
 
+    def _create_delivery_line(self, carrier, price_unit):
+        # If the order isn't stored in the db the line creation is going to fail
+        if not self._origin:
+            return self.env["sale.order.line"]
+        return super()._create_delivery_line(carrier, price_unit)
+
     def _auto_refresh_delivery(self):
         self.ensure_one()
         if (


### PR DESCRIPTION
Some other modules could trigger the autorefresh even when the order record isn't in the db, and making the line creation fail. We only need it when the record is saved.

cc @Tecnativa TT55206

please review @pilarvargas-tecnativa @pedrobaeza 