### PR TITLE
[16.0][FIX] delivery_auto_refresh: Fallback to load CoA

### DIFF
--- a/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
+++ b/delivery_auto_refresh/tests/test_delivery_auto_refresh.py
@@ -17,6 +17,15 @@ class TestDeliveryAutoRefresh(common.TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.env.user.write(
             {
                 "groups_id": [


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa