### PR TITLE
[16.0][IMP] delivery_package_number: shortend delivery_package_number document height

### DIFF
--- a/delivery_package_number/reports/report_package_number.xml
+++ b/delivery_package_number/reports/report_package_number.xml
@@ -35,7 +35,7 @@
                     <div class="row mt-3">
                         <div
                             class="col-5 border border-dark rounded text-center"
-                            style="padding: 60px 0;"
+                            style="padding: 10px"
                             name="client"
                         >
                             <span
@@ -46,6 +46,7 @@
                         <div class="col-2" />
                         <div
                             class="col-5 border border-dark rounded"
+                            style="padding: 10px"
                             name="package_number"
                         >
                             <h6>Number of packages:</h6>


### PR DESCRIPTION
There are cases when a address is too big and it overflows to having 2 pages, when it only should have one.

This PR reduces the box vertical padding to fix that

After
![image](https://github.com/user-attachments/assets/6f6450af-de85-47e1-b980-b940ebb77dd3)

Before
![image](https://github.com/user-attachments/assets/9ce3f83c-f802-4b62-93d7-7eeb4cee4f34)

I-7193
