### PR TITLE
[IMP] delivery_purchase_label: Label Stock Move Field to Source PO Line

### DIFF
--- a/delivery_purchase_label/models/__init__.py
+++ b/delivery_purchase_label/models/__init__.py
@@ -1,4 +1,5 @@
 from . import delivery_carrier
 from . import mail_compose_message
 from . import purchase_order
+from . import stock_move
 from . import stock_picking

--- a/delivery_purchase_label/models/purchase_order.py
+++ b/delivery_purchase_label/models/purchase_order.py
@@ -109,11 +109,20 @@ class PurchaseOrder(models.Model):
             subtype_id=self.env.ref("mail.mt_note").id,
         )
 
+    def _create_stock_moves_for_delivery_label_picking(self, picking):
+        res = self.env["stock.move"]
+        for line in self.order_line:
+            moves = line._create_stock_moves(picking)
+            moves.delivery_label_purchase_line_id = line
+            res |= moves
+
+        return res
+
     def _create_purchase_delivery_label_picking(self, carrier):
         self.ensure_one()
         values = self._get_purchase_delivery_label_picking_value(carrier)
         picking = self.env["stock.picking"].with_user(SUPERUSER_ID).create(values)
-        moves = self.order_line._create_stock_moves(picking)
+        moves = self._create_stock_moves_for_delivery_label_picking(picking)
         moves.location_id = picking.location_id
         moves.location_dest_id = picking.location_dest_id
         # Remove the link on the sale and purchase

--- a/delivery_purchase_label/models/stock_move.py
+++ b/delivery_purchase_label/models/stock_move.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Raumschmiede GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    delivery_label_purchase_line_id = fields.Many2one(
+        "purchase.order.line",
+        string="Delivery Label Purchase Order Line",
+        ondelete="cascade",
+    )
+
+    # Prevent merging delivery label moves
+    # from different purchase order lines
+    def _prepare_merge_moves_distinct_fields(self):
+        distinct_fields = super()._prepare_merge_moves_distinct_fields()
+        distinct_fields.append("delivery_label_purchase_line_id")
+        return distinct_fields

--- a/delivery_purchase_label/tests/test_delivery_purchase_label.py
+++ b/delivery_purchase_label/tests/test_delivery_purchase_label.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Camptocamp SA
+# Copyright 2025 Raumschmiede GmbH
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.tests.common import SavepointCase
@@ -22,7 +23,12 @@ class TestDeliveryPurchaseLabel(SavepointCase):
         cls.carrier.purchase_label_picking_type = cls.picking_type
 
         cls.product = cls.env.ref("product.product_product_5")
-        cls.order = cls.env["purchase.order"].create(
+        cls.product2 = cls.env.ref("product.product_product_6")
+        cls.order = cls._create_purchase_order(cls.product)
+
+    @classmethod
+    def _create_purchase_order(cls, products):
+        po = cls.env["purchase.order"].create(
             {
                 "partner_id": cls.supplier.id,
                 "dest_address_id": cls.customer.id,
@@ -32,17 +38,21 @@ class TestDeliveryPurchaseLabel(SavepointCase):
                         0,
                         0,
                         {
-                            "name": cls.product.name,
-                            "product_id": cls.product.id,
+                            "name": product.name,
+                            "product_id": product.id,
                             "product_qty": 5.0,
-                            "product_uom": cls.product.uom_id.id,
+                            "product_uom": product.uom_id.id,
                             "price_unit": 10,
                         },
                     )
+                    for product in products
                 ],
             }
         )
-        cls.order.order_line._onchange_quantity()
+        for line in po.order_line:
+            line._onchange_quantity()
+
+        return po
 
     def _create_fake_label_attachment(self, linked_to):
         return self.env["ir.attachment"].create(
@@ -98,3 +108,36 @@ class TestDeliveryPurchaseLabel(SavepointCase):
         self.order._generate_purchase_delivery_label()
         self.order.button_cancel()
         self.assertTrue(self.order.delivery_label_picking_id.state == "cancel")
+
+    def test_label_picking_stock_moves(self):
+        self.order._generate_purchase_delivery_label()
+        self.assertEqual(
+            self.order.delivery_label_picking_id.move_lines.delivery_label_purchase_line_id,
+            self.order.order_line,
+        )
+        self.order = self._create_purchase_order(self.product2 | self.product)
+        self.order._generate_purchase_delivery_label()
+        moves = self.order.delivery_label_picking_id.move_lines
+        self.assertEqual(
+            moves[0].delivery_label_purchase_line_id, self.order.order_line[0]
+        )
+        self.assertEqual(
+            moves[1].delivery_label_purchase_line_id, self.order.order_line[1]
+        )
+
+        self.order = self._create_purchase_order(
+            [self.product, self.product2, self.product]
+        )
+        self.order._generate_purchase_delivery_label()
+        moves = self.order.delivery_label_picking_id.move_lines
+        # Moves must not be merged because they reference different label PO lines
+        self.assertEqual(len(moves), 3)
+        self.assertEqual(
+            moves[0].delivery_label_purchase_line_id, self.order.order_line[0]
+        )
+        self.assertEqual(
+            moves[1].delivery_label_purchase_line_id, self.order.order_line[1]
+        )
+        self.assertEqual(
+            moves[2].delivery_label_purchase_line_id, self.order.order_line[2]
+        )


### PR DESCRIPTION
Hi.  

It is complicated to get from the label picking stock move to the corresponding PO line in code,With a BOM in the PO and its components in the moves it is even more complicated to have a loop to search for the right line.

With this new field it is easier. And the label picking behaves more like a normal picking

@TDu , @mt-software-de 