### PR TITLE
[12.0][FIX] delivery_multi_destination: Return dict when delivery is not available

### DIFF
--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -71,6 +71,14 @@ class DeliveryCarrier(models.Model):
                     return super(
                         DeliveryCarrier, subcarrier,
                     ).rate_shipment(order)
+        return {
+            "success": False,
+            "price": 0.0,
+            "error_message": _(
+                "Error: this delivery method is not available for this address."
+            ),
+            "warning_message": False,
+        }
 
     def send_shipping(self, pickings):
         """We have to override this method for redirecting the result to the


### PR DESCRIPTION
When the rate_shipment (https://github.com/OCA/delivery-carrier/blob/12.0/delivery_multi_destination/models/delivery_carrier.py#L61) method doesn't return any value, the get_delivery_price method from [addons/delivery/models/sale_order](https://github.com/OCA/OCB/blob/12.0/addons/delivery/models/sale_order.py#L36) fails because it expects to receive a dictionary, not a None object.

```python
    def get_delivery_price(self):
        for order in self.filtered(lambda o: o.state in ('draft', 'sent') and len(o.order_line) > 0):
            # We do not want to recompute the shipping price of an already validated/done SO
            # or on an SO that has no lines yet
            order.delivery_rating_success = False
            res = order.carrier_id.rate_shipment(order)
            if res['success']:             <-------------------------------------- ERROR
                order.delivery_rating_success = True
                order.delivery_price = res['price']
                order.delivery_message = res['warning_message']
            else:
                order.delivery_rating_success = False
                order.delivery_price = 0.0
                order.delivery_message = res['error_message']
```