### PR TITLE
[17.0] [IMP] base_delivery_carrier_label: add setting to not set default packages in shipper send

### DIFF
--- a/base_delivery_carrier_label/README.rst
+++ b/base_delivery_carrier_label/README.rst
@@ -39,6 +39,23 @@ module for other carrier-specific modules.
 .. contents::
    :local:
 
+Configuration
+=============
+
+By default, automatic packaging is enabled.
+
+You can disable it in Inventory / Configuration / Settings, by searching
+"Default Packages".
+
+When active, pickings without assigned packages will be grouped into a
+single one for shipping. This ensures compatibility with connectors that
+require at least one package to generate labels or tracking references.
+
+   **NOTE:** If the Number of Packages field is manually set but no real
+   packages are defined, this feature overrides it and creates only one
+   package. This may cause confusion when relying solely on that field
+   instead of using Odoo’s standard package objects.
+
 Usage
 =====
 

--- a/base_delivery_carrier_label/models/__init__.py
+++ b/base_delivery_carrier_label/models/__init__.py
@@ -2,6 +2,8 @@ from . import delivery_carrier
 from . import delivery_carrier_template_option
 from . import delivery_carrier_option
 from . import stock_move_line
+from . import res_company
+from . import res_config_settings
 from . import stock_picking
 from . import stock_quant_package
 from . import shipping_label

--- a/base_delivery_carrier_label/models/res_company.py
+++ b/base_delivery_carrier_label/models/res_company.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    delivery_set_default_package = fields.Boolean(
+        string="Default Packages",
+        default=True,
+    )

--- a/base_delivery_carrier_label/models/res_config_settings.py
+++ b/base_delivery_carrier_label/models/res_config_settings.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    delivery_set_default_package = fields.Boolean(
+        related="company_id.delivery_set_default_package",
+        readonly=False,
+    )

--- a/base_delivery_carrier_label/models/stock_picking.py
+++ b/base_delivery_carrier_label/models/stock_picking.py
@@ -71,7 +71,9 @@ class StockPicking(models.Model):
 
     def send_to_shipper(self):
         self.ensure_one()
-        if self.env.context.get("set_default_package", True):
+        if self.env.context.get(
+            "set_default_package", self.env.company.delivery_set_default_package
+        ):
             self._set_a_default_package()
         # We consider that label has already been generated in case we have a
         # carrier tracking ref, this way we may print the labels before shipping

--- a/base_delivery_carrier_label/readme/CONFIGURE.md
+++ b/base_delivery_carrier_label/readme/CONFIGURE.md
@@ -1,0 +1,8 @@
+By default, automatic packaging is enabled.
+
+You can disable it in Inventory / Configuration / Settings, by searching "Default Packages".
+
+When active, pickings without assigned packages will be grouped into a single one for shipping. This ensures compatibility with connectors that require at least one package to generate labels or tracking references.
+
+> **NOTE:** If the Number of Packages field is manually set but no real packages are defined, this feature overrides it and creates only one package.
+This may cause confusion when relying solely on that field instead of using Odoo’s standard package objects.

--- a/base_delivery_carrier_label/static/description/index.html
+++ b/base_delivery_carrier_label/static/description/index.html
@@ -378,18 +378,33 @@ module for other carrier-specific modules.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>By default, automatic packaging is enabled.</p>
+<p>You can disable it in Inventory / Configuration / Settings, by searching
+“Default Packages”.</p>
+<p>When active, pickings without assigned packages will be grouped into a
+single one for shipping. This ensures compatibility with connectors that
+require at least one package to generate labels or tracking references.</p>
+<blockquote>
+<strong>NOTE:</strong> If the Number of Packages field is manually set but no real
+packages are defined, this feature overrides it and creates only one
+package. This may cause confusion when relying solely on that field
+instead of using Odoo’s standard package objects.</blockquote>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>** How does it works ? **</p>
 <p>In picking UI a button “Send to shipper” trigger label generation
 calling send_to_shipper() in models/stock.picking.py</p>
@@ -412,7 +427,7 @@ form :</p>
 </pre>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/delivery-carrier/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -420,16 +435,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Camptocamp</li>
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>David BEAL &lt;<a class="reference external" href="mailto:david.beal&#64;akretion.com">david.beal&#64;akretion.com</a>&gt;</li>
 <li>Sébastien BEAU &lt;<a class="reference external" href="mailto:sebastien.beau&#64;akretion.com">sebastien.beau&#64;akretion.com</a>&gt;</li>
@@ -448,7 +463,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_delivery_carrier_label/views/res_config.xml
+++ b/base_delivery_carrier_label/views/res_config.xml
@@ -19,4 +19,26 @@
             eval="{'menu_id': ref('delivery.action_delivery_carrier_form')}"
         />
     </record>
+
+    <record
+        id="res_config_settings_view_form_inherit_delivery_carrier_label"
+        model="ir.ui.view"
+    >
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.delivery.carrier.label</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//block[@name='shipping_setting_container']" position="inside">
+                <setting
+                    id="delivery_set_default_package"
+                    help="Automatically assign a single package before shipping"
+                    title="When sending a picking to the carrier, this option ensures all items are grouped into one package if none exist. This helps shipping connectors that require at least one package for label generation or tracking. If no packages are assigned, the system will group all items into a single package before shipping."
+                >
+                    <field name="delivery_set_default_package" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This PR adds a configuration option to not set the default packages when sending a picking to the carrier

The functionality has been removed in v16: https://github.com/OCA/delivery-carrier/pull/853/files

Related with the https://github.com/OCA/delivery-carrier/issues/1009 Issue

T-8186