### PR TITLE
[14.0] [FIX] delivery_purchase_label: keep sale_id on group

### DIFF
--- a/delivery_purchase_label/models/purchase_order.py
+++ b/delivery_purchase_label/models/purchase_order.py
@@ -127,9 +127,11 @@ class PurchaseOrder(models.Model):
         moves.location_dest_id = picking.location_dest_id
         # Remove the link on the sale and purchase
         # To not impact the delivered quantity on them
-        picking.sale_id = False
-        moves.sale_line_id = False
-        moves.purchase_line_id = False
+        moves.write({
+            "group_id": False,
+            "moves.sale_line_id": False,
+            "purchase_line_id": False,
+        })
         picking.action_assign()
         for move in picking.move_lines:
             move.quantity_done = move.product_uom_qty

--- a/delivery_purchase_label/models/purchase_order.py
+++ b/delivery_purchase_label/models/purchase_order.py
@@ -127,11 +127,13 @@ class PurchaseOrder(models.Model):
         moves.location_dest_id = picking.location_dest_id
         # Remove the link on the sale and purchase
         # To not impact the delivered quantity on them
-        moves.write({
-            "group_id": False,
-            "moves.sale_line_id": False,
-            "purchase_line_id": False,
-        })
+        moves.write(
+            {
+                "group_id": False,
+                "sale_line_id": False,
+                "purchase_line_id": False,
+            }
+        )
         picking.action_assign()
         for move in picking.move_lines:
             move.quantity_done = move.product_uom_qty


### PR DESCRIPTION
sale_id is related field, update on purchase picking updates it for all deliveries in the procurement.group