### PR TITLE
[14.0][FIX] delivery_schenker: Use parent partner name as fallback

### DIFF
--- a/delivery_schenker/models/delivery_carrier.py
+++ b/delivery_schenker/models/delivery_carrier.py
@@ -266,7 +266,7 @@ class DeliveryCarrier(models.Model):
         """
         vals = {
             "type": address_type,
-            "name1": partner.name,
+            "name1": partner.name or partner.parent_name,
             "locationType": location_type,  # POSTAL or PHYSICAL
             "personType": person_type,  # PERSON OR COMPANY
             "street": partner.street,

--- a/delivery_schenker/tests/test_delivery_schenker.py
+++ b/delivery_schenker/tests/test_delivery_schenker.py
@@ -42,3 +42,15 @@ class TestDeliverySchenker(TestDeliverySchenkerCommon):
             "cargoDesc"
         ] = " / ".join([picking.name, picking.move_line_ids.result_package_id.name])
         self.assertDictEqual(expected, data)
+
+    def test_fallback_parent_partner_name(self):
+        parent_partner_name = "Parent partner name"
+        parent_partner = self.partner.create({"name": parent_partner_name})
+        self.partner.parent_id = parent_partner
+        self.partner.type = "delivery"
+        self.partner.name = False
+        expected = self._prepare_schenker_shipping(self.picking)
+        expected["address"][1]["name1"] = parent_partner.name
+        expected["incotermLocation"] = self.partner.display_name[:35]
+        vals = self.carrier._prepare_schenker_shipping(self.picking)
+        self.assertDictEqual(vals, expected)


### PR DESCRIPTION
This supersedes https://github.com/OCA/delivery-carrier/pull/805

cc @jbaudoux @RuudFreshfilter @thomaspaulb @NL66278 