### PR TITLE
[18.0][FIX] delivery_price_method: Skip base functionality

### DIFF
--- a/delivery_price_method/models/delivery_carrier.py
+++ b/delivery_price_method/models/delivery_carrier.py
@@ -42,3 +42,12 @@ class DeliveryCarrier(models.Model):
                 del rate["tracking_number"]  # remove offending key
                 res[index].update(rate)
         return res
+
+    def _get_price_from_picking(self, total, weight, volume, quantity, wv=0.0):
+        if (
+            self.price_method == "base_on_rule"
+            and self.free_over
+            and total >= self.amount
+        ):
+            return 0.0
+        return super()._get_price_from_picking(total, weight, volume, quantity, wv)

--- a/delivery_price_method/models/delivery_carrier.py
+++ b/delivery_price_method/models/delivery_carrier.py
@@ -21,7 +21,12 @@ class DeliveryCarrier(models.Model):
         # Trick the method for using all the upstream code for the
         # price computation in case of using fixed or base_on_rule.
         previous_method = False
-        if self.price_method in ("fixed", "base_on_rule"):
+        if self.price_method in ("fixed", "base_on_rule") and (
+            not self.free_over
+            or not self.amount
+            or self._compute_currency(order, order.amount_total, "pricelist_to_company")
+            < self.amount
+        ):
             previous_method = self.delivery_type
             self.sudo().delivery_type = self.price_method
         res = super().rate_shipment(order)

--- a/delivery_price_method/tests/common.py
+++ b/delivery_price_method/tests/common.py
@@ -29,6 +29,15 @@ class TestDeliveryPriceMethodCommon(BaseCommon):
                 "fixed_price": 99.99,
             }
         )
+        self.carrier_free = self.env["delivery.carrier"].create(
+            {
+                "name": "Free carrier",
+                "price_method": "base_on_rule",
+                "product_id": product_shipping_cost.id,
+                "free_over": True,
+                "amount": 0,
+            }
+        )
         self.pricelist = self.env["product.pricelist"].create(
             {
                 "name": "Test pricelist",
@@ -57,6 +66,16 @@ class TestDeliveryPriceMethodCommon(BaseCommon):
                 ],
             }
         )
+        self.sale_2 = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "pricelist_id": self.pricelist.id,
+                "carrier_id": self.carrier_free.id,
+                "order_line": [
+                    (0, 0, {"product_id": self.product.id, "product_uom_qty": 1})
+                ],
+            }
+        )
 
     def _add_delivery(self):
         sale = self.sale
@@ -67,3 +86,11 @@ class TestDeliveryPriceMethodCommon(BaseCommon):
         )
         choose_delivery_carrier = delivery_wizard.save()
         choose_delivery_carrier.button_confirm()
+        sale_2 = self.sale_2
+        delivery_wizard_2 = Form(
+            self.env["choose.delivery.carrier"].with_context(
+                default_order_id=sale_2.id, default_carrier_id=self.carrier_free
+            )
+        )
+        choose_delivery_carrier_2 = delivery_wizard_2.save()
+        choose_delivery_carrier_2.button_confirm()

--- a/delivery_price_method/tests/test_delivery_price_method.py
+++ b/delivery_price_method/tests/test_delivery_price_method.py
@@ -64,3 +64,38 @@ class TestDeliveryPriceMethod(TestDeliveryPriceMethodCommon):
         delivery_lines = sale.order_line.filtered(lambda r: r.is_delivery)
         delivery_price = sum(delivery_lines.mapped("price_unit"))
         self.assertEqual(delivery_price, 11.11)
+
+    def test_03_delivery_price_method_free_over(self):
+        free_price = self.carrier_free._get_price_from_picking(
+            total=50, weight=20, volume=10, quantity=10, wv=0.0
+        )
+        self.assertEqual(free_price, 0.0)
+        prices = self.carrier_free.rate_shipment(self.sale_2)
+        self.assertEqual(prices["price"], 0.0)
+        self.assertEqual(prices["carrier_price"], 0.0)
+        self.carrier_free.write(
+            {
+                "price_method": "base_on_rule",
+                "amount": 100,
+                "free_over": False,
+                "price_rule_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "variable": "quantity",
+                            "operator": "==",
+                            "max_value": 1,
+                            "list_base_price": 11.11,
+                        },
+                    )
+                ],
+            }
+        )
+        base_price = self.carrier_free._get_price_from_picking(
+            total=70.0, weight=0.01, volume=0.0, quantity=1.0, wv=0.0
+        )
+        prices = self.carrier_free.rate_shipment(self.sale_2)
+        self.assertEqual(prices["price"], 11.11)
+        self.assertEqual(prices["carrier_price"], 11.11)
+        self.assertEqual(base_price, 11.11)


### PR DESCRIPTION
- The change has been made because it skipped the base functionality to check if the shipment has to be free or not if it exceeded the price set in the field `free_over` I leave the exact line of the Odoo code, as it is forcing the `delivery_type` to be the same as this in the `price_method` then does not make the `if` when it should be done.
[Odoo code](https://github.com/odoo/odoo/blob/18.0/addons/delivery/models/delivery_carrier.py#L282)
