### PR TITLE
[15.0][IMP] delivery_purchase: Take into account the delivered quantity to calculate the shipping cost

### DIFF
--- a/delivery_purchase/README.rst
+++ b/delivery_purchase/README.rst
@@ -39,6 +39,13 @@ applying the delivery method to purchases.
 .. contents::
    :local:
 
+Configuration
+=============
+
+If you want to recompute the delivery cost on picking validation based
+on received quantity, you need to check the option
+"Recompute Delivery Price When Validate Picking"
+
 Usage
 =====
 
@@ -86,6 +93,7 @@ Contributors
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Vicent Cubells
+  * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/delivery_purchase/__init__.py
+++ b/delivery_purchase/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import models
+from . import wizards

--- a/delivery_purchase/__manifest__.py
+++ b/delivery_purchase/__manifest__.py
@@ -12,5 +12,9 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["purchase", "delivery"],
-    "data": ["views/purchase_order_view.xml", "views/stock_picking_view.xml"],
+    "data": [
+        "views/purchase_order_view.xml",
+        "views/stock_picking_view.xml",
+        "wizards/res_config_settings_views.xml",
+    ],
 }

--- a/delivery_purchase/i18n/delivery_purchase.pot
+++ b/delivery_purchase/i18n/delivery_purchase.pot
@@ -6,12 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-24 06:39+0000\n"
+"PO-Revision-Date: 2025-06-24 06:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: delivery_purchase
+#: model:ir.model,name:delivery_purchase.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
 
 #. module: delivery_purchase
 #: model:ir.model.fields,field_description:delivery_purchase.field_purchase_order__carrier_id
@@ -62,11 +69,28 @@ msgid "Purchase Order Line"
 msgstr ""
 
 #. module: delivery_purchase
+#: model:ir.model.fields,field_description:delivery_purchase.field_res_config_settings__recompute_delivery_price_on_picking
+msgid "Recompute Delivery Price When Validate Picking"
+msgstr ""
+
+#. module: delivery_purchase
+#: model_terms:ir.ui.view,arch_db:delivery_purchase.res_config_settings_view_form
+msgid ""
+"Recompute shipping costs when validating the picking with the quantity "
+"received."
+msgstr ""
+
+#. module: delivery_purchase
 #: code:addons/delivery_purchase/models/stock_picking.py:0
 #, python-format
 msgid ""
 "Shipment sent to carrier %(carrier_name)s for shipping with tracking number "
 "%(tracking_ref)s<br/>Cost: %(carrier_price)s %(currency_name)s"
+msgstr ""
+
+#. module: delivery_purchase
+#: model_terms:ir.ui.view,arch_db:delivery_purchase.res_config_settings_view_form
+msgid "Shipping"
 msgstr ""
 
 #. module: delivery_purchase

--- a/delivery_purchase/i18n/es.po
+++ b/delivery_purchase/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-19 08:32+0000\n"
-"PO-Revision-Date: 2024-07-19 10:33+0200\n"
+"POT-Creation-Date: 2025-06-24 06:39+0000\n"
+"PO-Revision-Date: 2025-06-24 08:43+0200\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -15,7 +15,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. module: delivery_purchase
+#: model:ir.model,name:delivery_purchase.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ajustes de configuración"
 
 #. module: delivery_purchase
 #: model:ir.model.fields,field_description:delivery_purchase.field_purchase_order__carrier_id
@@ -67,6 +72,19 @@ msgid "Purchase Order Line"
 msgstr "Línea de pedido de compra"
 
 #. module: delivery_purchase
+#: model:ir.model.fields,field_description:delivery_purchase.field_res_config_settings__recompute_delivery_price_on_picking
+msgid "Recompute Delivery Price When Validate Picking"
+msgstr "Recomputar precio de entrega al validar albarán"
+
+#. module: delivery_purchase
+#: model_terms:ir.ui.view,arch_db:delivery_purchase.res_config_settings_view_form
+msgid ""
+"Recompute shipping costs when validating the picking with the quantity "
+"received."
+msgstr ""
+"Recomputar costes de envío al validar el albarán con la cantidad recibida."
+
+#. module: delivery_purchase
 #: code:addons/delivery_purchase/models/stock_picking.py:0
 #, python-format
 msgid ""
@@ -75,6 +93,11 @@ msgid ""
 msgstr ""
 "Envío enviado al transportista %(carrier_name)s para envío con número de "
 "seguimiento %(tracking_ref)s<br/>Coste: %(carrier_price)s %(currency_name)s"
+
+#. module: delivery_purchase
+#: model_terms:ir.ui.view,arch_db:delivery_purchase.res_config_settings_view_form
+msgid "Shipping"
+msgstr "Envío"
 
 #. module: delivery_purchase
 #: model:ir.model,name:delivery_purchase.model_delivery_carrier

--- a/delivery_purchase/models/delivery_carrier.py
+++ b/delivery_purchase/models/delivery_carrier.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.misc import str2bool
 
 
 class DeliveryCarrier(models.Model):
@@ -121,6 +122,11 @@ class DeliveryCarrier(models.Model):
         return res
 
     def purchase_base_on_rule_send_shipping(self, pickings):
+        use_picking = str2bool(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("delivery_purchase.use_delivered_qty_to_set_cost", "False")
+        )
         res = []
         for p in pickings:
             carrier = self._match_address(p.partner_id)
@@ -128,8 +134,10 @@ class DeliveryCarrier(models.Model):
                 raise ValidationError(_("There is no matching delivery rule."))
             res = res + [
                 {
-                    "exact_price": p.carrier_id._purchase_get_price_available(
-                        p.purchase_id
+                    "exact_price": (
+                        p.carrier_id._purchase_get_price_available(p.purchase_id)
+                        if not use_picking
+                        else p.carrier_id._picking_get_price_available(p)
                     )
                     if p.purchase_id
                     else 0.0,
@@ -138,16 +146,13 @@ class DeliveryCarrier(models.Model):
             ]
         return res
 
-    def _purchase_get_price_available(self, order):
-        self.ensure_one()
-        self = self.sudo()
-        order = order.sudo()
+    def _get_delivery_data(self, order, lines, qty_field):
         weight = volume = quantity = 0
-        for line in order.order_line.filtered(
+        for line in lines.filtered(
             lambda l: l.state != "cancel" and bool(l.product_id)
         ):
             qty = line.product_uom._compute_quantity(
-                line.product_uom_qty, line.product_id.uom_id
+                line[qty_field], line.product_id.uom_id
             )
             weight += (line.product_id.weight or 0.0) * qty
             volume += (line.product_id.volume or 0.0) * qty
@@ -158,5 +163,23 @@ class DeliveryCarrier(models.Model):
             order.company_id.currency_id,
             order.company_id,
             order.date_order or fields.Date.today(),
+        )
+        return weight, volume, quantity, total
+
+    def _purchase_get_price_available(self, order):
+        self.ensure_one()
+        self = self.sudo()
+        order = order.sudo()
+        weight, volume, quantity, total = self._get_delivery_data(
+            order, order.order_line, "product_uom_qty"
+        )
+        return self._get_price_from_picking(total, weight, volume, quantity)
+
+    def _picking_get_price_available(self, picking):
+        self.ensure_one()
+        self = self.sudo()
+        picking = picking.sudo()
+        weight, volume, quantity, total = self._get_delivery_data(
+            picking.purchase_id, picking.move_lines, "quantity_done"
         )
         return self._get_price_from_picking(total, weight, volume, quantity)

--- a/delivery_purchase/readme/CONFIGURE.rst
+++ b/delivery_purchase/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+If you want to recompute the delivery cost on picking validation based
+on received quantity, you need to check the option
+"Recompute Delivery Price When Validate Picking"

--- a/delivery_purchase/readme/CONTRIBUTORS.rst
+++ b/delivery_purchase/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Vicent Cubells
+  * Carlos Roca

--- a/delivery_purchase/static/description/index.html
+++ b/delivery_purchase/static/description/index.html
@@ -377,18 +377,25 @@ applying the delivery method to purchases.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>If you want to recompute the delivery cost on picking validation based
+on received quantity, you need to check the option
+“Recompute Delivery Price When Validate Picking”</p>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to <em>Purchase &gt; Orders &gt; Purchase Orders</em> and create a new Purchase Order.</li>
@@ -409,7 +416,7 @@ automatically when the ‘Receipt’ is validated.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/delivery-carrier/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -417,26 +424,27 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Ernesto Tejeda</li>
 <li>Pedro M. Baeza</li>
 <li>Vicent Cubells</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/delivery_purchase/tests/test_delivery_purchase.py
+++ b/delivery_purchase/tests/test_delivery_purchase.py
@@ -168,3 +168,29 @@ class TestDeliveryPurchase(TestDeliveryPurchaseBase):
         delivery_line = self.purchase.order_line.filtered(lambda x: x.is_delivery)
         self.assertEqual(delivery_line.delivery_picking_orig_id, picking)
         self.assertEqual(self.purchase.delivery_price, 10)
+
+    def test_picking_with_backorders(self):
+        self.env["ir.config_parameter"].set_param(
+            "delivery_purchase.use_delivered_qty_to_set_cost", "True"
+        )
+        self.product.weight = 1
+        purchase_form = Form(self.env["purchase.order"])
+        purchase_form.partner_id = self.partner
+        purchase_form.carrier_id = self.carrier_rules
+        with purchase_form.order_line.new() as purchase_line_form:
+            purchase_line_form.product_id = self.product
+            purchase_line_form.product_qty = 10
+            purchase_line_form.price_unit = 1
+        purchase = purchase_form.save()
+        self.assertEqual(purchase.delivery_price, 30)
+        purchase.button_confirm()
+        picking = purchase.picking_ids
+        picking.move_lines.quantity_done = 4
+        picking.with_context(cancel_backorder=False)._action_done()
+        self.assertEqual(picking.carrier_price, 10)
+        other_picking = purchase.picking_ids - picking
+        other_picking.move_lines.filtered(
+            lambda ml: ml.product_id == self.product
+        ).quantity_done = 6
+        self._action_picking_validate(other_picking)
+        self.assertEqual(other_picking.carrier_price, 30)

--- a/delivery_purchase/wizards/__init__.py
+++ b/delivery_purchase/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import res_config_settings

--- a/delivery_purchase/wizards/res_config_settings.py
+++ b/delivery_purchase/wizards/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    recompute_delivery_price_on_picking = fields.Boolean(
+        string="Recompute Delivery Price When Validate Picking",
+        config_parameter="delivery_purchase.use_delivered_qty_to_set_cost",
+    )

--- a/delivery_purchase/wizards/res_config_settings_views.xml
+++ b/delivery_purchase/wizards/res_config_settings_views.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field
+            name="inherit_id"
+            ref="purchase.res_config_settings_view_form_purchase"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='matrix_setting_container']" position="after">
+                 <h2>Shipping</h2>
+                 <div
+                    class="row mt16 o_settings_container"
+                    name="shipping_setting_container"
+                >
+                     <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        id="recompute_delivery_cost"
+                    >
+                        <div class="o_setting_left_pane">
+                            <field name="recompute_delivery_price_on_picking" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="recompute_delivery_price_on_picking" />
+                            <div class="text-muted">
+                                Recompute shipping costs when validating the picking with the quantity received.
+                            </div>
+                        </div>
+                     </div>
+                 </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Before these changes, the shipping cost set on the delivery note always took into account the quantity from the purchase order.

After making these changes, the behavior can be modified so that if the system parameter "delivery_purchase.use_delivered_qty_to_set_cost" is set to True, the received quantity will be taken into account when receiving partial quantities on the delivery note.

cc @Tecnativa TT56831

ping @pedrobaeza @victoralmau 