### PR TITLE
[FIX][18.0] `delivery_postlogistics`: Remove `default_type` from context keys when generating labels

### DIFF
--- a/delivery_postlogistics/models/stock_picking.py
+++ b/delivery_postlogistics/models/stock_picking.py
@@ -78,14 +78,13 @@ Please use _get_quant_packages_from_picking instead."
             return super().attach_shipping_label(label)
         self.ensure_one()
         data = self.get_shipping_label_values(label)
-        context_attachment = self.env.context.copy()
-        # remove default_type setted for stock_picking
+        # remove `default_type` set for stock_picking
         # as it would try to define default value of attachement
-        if "default_type" in context_attachment:
-            del context_attachment["default_type"]
-        return (
-            self.env["shipping.label"].with_context(**context_attachment).create(data)
-        )
+        if self.env.context.get("default_type"):
+            new_ctx = self.env.context.copy()
+            new_ctx.pop("default_type")
+            self = self.with_context(new_ctx)  # pylint: disable=context-overridden
+        return self.env["shipping.label"].create(data)
 
     def postlogistics_cod_amount(self):
         """Return the PostLogistics Cash on Delivery amount of a picking


### PR DESCRIPTION
Introduced with https://github.com/OCA/delivery-carrier/pull/619/commits/f82c75a9dc22bd29897e67bcb5824f6d8c47fdd9#diff-7d5856a39a59766b6cd8d580e267bd8b19f48ff5ceccb17d7243e90632feef21, probably because of pre-commit suggestions. If `default_type` is in the context for the `stock.picking` records, we need to remove it before generating the label, and thus the attachment, otherwise Odoo tries to set `default_type` from the picking as default `type` value for the attachment field, leading to a traceback.

Before the v16, it was done by copying the template, removing ``default`` get from the copy, and erasing the current context with the copy.
As pre-commit advices now to avoid erasing the whole context, in the v16 migration, the code has been change to update (rather than erase) the context with the copy, and thus the removal of the context key had no effect anymore.
Here we come back to a code similar to what was not in v15 and before.