### PR TITLE
[18.0][FIX]`delivery_postlogistics`: Replace ``pack.env`` by ``self.env`` because ``pack`` parameter can be ``None``

### DIFF
--- a/delivery_postlogistics/models/stock_picking.py
+++ b/delivery_postlogistics/models/stock_picking.py
@@ -297,7 +297,7 @@ Please use _get_quant_packages_from_picking instead."
 
         if not package_codes:
             raise UserError(
-                pack.env._(
+                self.env._(
                     "No PostLogistics packaging services found "
                     "in package type {package_type_name}, for picking {picking_name}."
                 ).format(package_type_name=package_type.name, picking_name=self.name)


### PR DESCRIPTION
In ``stock.picking::postlogistics_label_prepare_attributes`` method, parameter ``pack`` is optionnal. If it is not set, ``pack.env._(`` triggers a traceback. Here we replace it by ``self.env._(``, for it to work in any case