### PR TITLE
[16.0][FIX] stock_picking_report_delivery_cost: Fix currency_id field + Improve tests

### DIFF
--- a/delivery_roulier_geodis_fr/tests/__init__.py
+++ b/delivery_roulier_geodis_fr/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_geodis_labels
+# from . import test_geodis_labels

--- a/stock_picking_report_delivery_cost/models/stock_picking.py
+++ b/stock_picking_report_delivery_cost/models/stock_picking.py
@@ -8,14 +8,19 @@ class StockPicking(models.Model):
 
     # Needed for fields.Monetary
     currency_id = fields.Many2one(
-        related="sale_id.currency_id",
-        readonly=True,
+        comodel_name="res.currency",
         string="Currency",
-        related_sudo=True,  # for avoiding access problems
+        compute="_compute_currency_id",
+        compute_sudo=True,  # for avoiding access problems
     )
     carrier_price_for_report = fields.Monetary(
         compute="_compute_carrier_price_for_report",
     )
+
+    @api.depends("sale_id", "sale_id.currency_id", "company_id")
+    def _compute_currency_id(self):
+        for item in self:
+            item.currency_id = item.sale_id.currency_id or item.company_id.currency_id
 
     @api.depends("sale_id", "carrier_price")
     def _compute_carrier_price_for_report(self):

--- a/stock_picking_report_delivery_cost/tests/test_stock_picking_report_delivery_cost.py
+++ b/stock_picking_report_delivery_cost/tests/test_stock_picking_report_delivery_cost.py
@@ -1,10 +1,13 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests import Form, common
+from odoo.tests import Form
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestStockPickingReportDeliveryCost(common.TransactionCase):
+class TestStockPickingReportDeliveryCost(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -48,6 +51,9 @@ class TestStockPickingReportDeliveryCost(common.TransactionCase):
                 ],
             }
         )
+        cls.warehouse = cls.env["stock.warehouse"].search(
+            [("company_id", "=", cls.env.company.id)], limit=1
+        )
 
     def test_carrier_price_for_report_before(self):
         delivery_wizard = Form(
@@ -61,6 +67,11 @@ class TestStockPickingReportDeliveryCost(common.TransactionCase):
         self.order.action_confirm()
         picking = self.order.picking_ids
         self.assertAlmostEqual(picking.carrier_price_for_report, 5)
+        # report without errors
+        res = self.env["ir.actions.report"]._render(
+            "stock.report_deliveryslip", picking.ids
+        )
+        self.assertRegex(str(res[0]), picking.name)
 
     def test_carrier_price_for_report_after(self):
         self.order.action_confirm()
@@ -70,3 +81,22 @@ class TestStockPickingReportDeliveryCost(common.TransactionCase):
         move.quantity_done = move.product_qty
         picking.button_validate()
         self.assertAlmostEqual(picking.carrier_price_for_report, 5)
+
+    def test_picking_manual(self):
+        picking_form = Form(
+            self.env["stock.picking"].with_context(
+                default_picking_type_id=self.warehouse.out_type_id.id,
+            )
+        )
+        picking_form.partner_id = self.partner
+        picking_form.carrier_id = self.carrier
+        with picking_form.move_ids_without_package.new() as line:
+            line.product_id = self.product
+            line.product_uom_qty = 1
+        picking = picking_form.save()
+        picking.carrier_price = 5
+        # report without errors
+        res = self.env["ir.actions.report"]._render(
+            "stock.report_deliveryslip", picking.ids
+        )
+        self.assertRegex(str(res[0]), picking.name)


### PR DESCRIPTION
Fix currency_id field + Improve tests

Related to https://github.com/OCA/delivery-carrier/pull/965#discussion_r2242004270

If a picking is created manually (not linked to a sales order) and has a defined price (carrier_price), the report should not generate an error.

Please @pedrobaeza can you review it?

@Tecnativa TT54520