### PR TITLE
[17.0][OU-FIX] delivery_auto_refresh: Field already exists

### DIFF
--- a/delivery_auto_refresh/migrations/17.0.1.0.0/pre-migration.py
+++ b/delivery_auto_refresh/migrations/17.0.1.0.0/pre-migration.py
@@ -6,14 +6,8 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_fields(
-        env,
-        [
-            (
-                "res.company",
-                "res_company",
-                "sale_auto_assign_carrier_on_create",
-                "carrier_on_create",
-            ),
-        ],
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE res_company SET carrier_on_create = True
+        WHERE sale_auto_assign_carrier_on_create""",
     )


### PR DESCRIPTION
As `sale_order_carrier_auto_assign` is installed as pre-requisite, the column `carrier_on_create` already exists at this stage, so we can't rename the field. Let's assign it through a query instead, as it's very unlikely that the field was in any filter, domain or similar.

@Tecnativa 