### PR TITLE
[18.0] Fix postlogistics delivery fix date computation

### DIFF
--- a/delivery_postlogistics/models/stock_move.py
+++ b/delivery_postlogistics/models/stock_move.py
@@ -9,11 +9,15 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super()._get_new_picking_values()
-        if order_commitment_date := (
-            self.sale_line_id and self.sale_line_id.order_id.commitment_date
-        ):
+
+        order_commitment_dates = [
+            date
+            for date in self.sale_line_id.order_id.mapped("commitment_date")
+            if date
+        ]
+        if order_commitment_dates:
             user_time = fields.Datetime.context_timestamp(
-                self, order_commitment_date
+                self, max(order_commitment_dates)
             ).date()
             vals["delivery_fixed_date"] = user_time
         return vals


### PR DESCRIPTION
If there is multiple commitment dates when creating a picking. Use the date the furthest in the future.

Original commit: https://github.com/OCA/delivery-carrier/commit/46c3dec5ecbd587b68e5e1da9495505feecc2293