### PR TITLE
[18.0][FIX] Fix encoding

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -44,7 +44,7 @@ def sanitize_string(value, mapping=None):
     value = value or ""
     for char, repl in mapping.items():
         value = value.replace(char, repl)
-    return value
+    return value.encode("iso-8859-1")
 
 
 class PostlogisticsWebService:


### PR DESCRIPTION
It seems that postlogistics is waiting for ISO-8859-1 charcaters instead of UTF-8.

Honestly it's strange to me that we have to communicate with this API in this encoding. But can't find any instruction about that on the [API DOC](https://developer.post.ch/en/digital-commerce-api).

We should maybe try to send requests with: 
```python
response = requests.post(
                url=generate_label_url,
                headers={
                    "Authorization": f"Bearer {access_token}",
                    "accept": "application/json",
                    "content-type": "application/json;charset=UTF-8",
                },
                data=json.dumps(data),
                timeout=60,
            )
``` 

or 
```python
response = requests.post(
                url=generate_label_url,
                headers={
                    "Authorization": f"Bearer {access_token}",
                    "accept": "application/json",
                    "content-type": "application/json",
                },
                json=json.dumps(data),
                timeout=60,
            )
``` 