### PR TITLE
[15.0][FIX] delivery_multi_destination: Properly filter in the name_search() method

### DIFF
--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -49,8 +49,9 @@ class DeliveryCarrier(models.Model):
     @api.model
     def name_search(self, name="", args=None, operator="ilike", limit=100):
         """Don't show by default children carriers."""
-        domain = [("parent_id", "=", False)]
-        return self.search(domain, limit=limit).name_get()
+        args = args or []
+        args += [("parent_id", "=", False)]
+        return super().name_search(name=name, args=args, operator=operator, limit=limit)
 
     def available_carriers(self, partner):
         """If the carrier is multi, we test the availability on children."""


### PR DESCRIPTION
Properly filter in the `name_search()` method

This has already been fixed in v17 in https://github.com/OCA/delivery-carrier/commit/8742187f15bd6172c45584998df1220d82c539c9#diff-dd64fba8220eea4cce28840b79f2d93e493a0b99c3b276a01d47f8f0f8cb7a3b

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT58173