### PR TITLE
[16.0][FIX] delivery_purchase: Dropshipping compatibility

### DIFF
--- a/delivery_purchase/models/delivery_carrier.py
+++ b/delivery_purchase/models/delivery_carrier.py
@@ -123,7 +123,8 @@ class DeliveryCarrier(models.Model):
     def purchase_base_on_rule_send_shipping(self, pickings):
         res = []
         for p in pickings:
-            carrier = self._match_address(p.partner_id)
+            partner = p.purchase_id.dest_address_id or p.partner_id
+            carrier = self._match_address(partner)
             if not carrier:
                 raise ValidationError(_("There is no matching delivery rule."))
             res = res + [


### PR DESCRIPTION
Dropshipping compatibility

Use case example:
- Create a sales order and use the Dropshipping route
- Set the delivery address as France, for example
- Create a rule-based carrier only available for France
- Confirm the sales order
- Confirm the purchase order
- Set the previously created carrier on the delivery note
- The carrier must be applied correctly, using the delivery address (France) as a reference

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT58174