### PR TITLE
[16.0][FIX] delivery_purchase: Dropshipping compatibility (purchase order)

### DIFF
--- a/delivery_purchase/models/delivery_carrier.py
+++ b/delivery_purchase/models/delivery_carrier.py
@@ -55,7 +55,8 @@ class DeliveryCarrier(models.Model):
             )
 
     def purchase_fixed_rate_shipment(self, order):
-        carrier = self._match_address(order.partner_id)
+        partner = order.dest_address_id or order.partner_id
+        carrier = self._match_address(partner)
         if not carrier:
             return {
                 "success": False,
@@ -79,7 +80,8 @@ class DeliveryCarrier(models.Model):
         }
 
     def purchase_base_on_rule_rate_shipment(self, order):
-        carrier = self._match_address(order.partner_id)
+        partner = order.dest_address_id or order.partner_id
+        carrier = self._match_address(partner)
         if not carrier:
             return {
                 "success": False,


### PR DESCRIPTION
Dropshipping compatibility (purchase order)

Use case example:
- Create a sales order and use the Dropshipping route
- Set the delivery address as France, for example
- Create a rule-based carrier only available for France
- Confirm the sales order
- Set the previously created carrier on the purchase order
- The carrier must be applied correctly, using the delivery address (France) as a reference

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT58174