### PR TITLE
[17.0][FIX] delivery_cbl: add super() call in get_manifest_file of manifest_wizard

### DIFF
--- a/delivery_cbl/wizard/manifest_wizard.py
+++ b/delivery_cbl/wizard/manifest_wizard.py
@@ -25,6 +25,8 @@ class ManifestWizard(models.TransientModel):
 
     def get_manifest_file(self):
         self.ensure_one()
+        if self.carrier_id.delivery_type != "cbl":
+            return super().get_manifest_file()
         pickings = self._get_cbl_picking()
         if not pickings:
             raise ValidationError(_("There are no pickings to proceed"))


### PR DESCRIPTION
The get_manifest_file() function of the manifest_wizard model can be inherited in multiple models to add a custom manifest file depending on the carrier type, just like we do in this module.

A super() call should be added in this inheritance to ensure module interoperability.

The _get_cbl_picking() function only returns CBL picking, so there is no problem restricting the delivery type.