### PR TITLE
[16.0][FIX] delivery_multi_destination: using _match_address is wrong

### DIFF
--- a/delivery_multi_destination/models/delivery_carrier.py
+++ b/delivery_multi_destination/models/delivery_carrier.py
@@ -103,6 +103,17 @@ class DeliveryCarrier(models.Model):
                 available |= carrier
         return available
 
+    def _match_address(self, partner):
+        """If the delivery carrier is a multi, we need to check
+        their childs"""
+        carrier = self.with_context(show_children_carriers=True)
+        if carrier.destination_type == "multi":
+            for child in carrier.child_ids:
+                if child._match_address(partner):
+                    return True
+            return False
+        return super()._match_address(partner)
+
     def base_on_destination_rate_shipment(self, order):
         carrier = self.with_context(show_children_carriers=True)
         for subcarrier in carrier.child_ids:


### PR DESCRIPTION
_match_address is a root function used to filter delivery carrier given the partner address. Calling it on a 'multi' delivery carrier leads to wrong results. With a 'multi' delivery carrier, it’s their childs that need to be checked.

For example it is used in this trace:
- https://github.com/odoo/odoo/blob/16.0/addons/website_sale_delivery/controllers/main.py#L306C39-L306C60
- https://github.com/odoo/odoo/blob/16.0/addons/website_sale_delivery/models/sale_order.py#L72
- https://github.com/odoo/odoo/blob/16.0/addons/delivery/models/delivery_carrier.py#L118-L127