### PR TITLE
[18.0][IMP] delivery_state: Add fields to store the POD

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -39,6 +39,16 @@ class StockPicking(models.Model):
         tracking=True,
         readonly=True,
     )
+    pod_file = fields.Binary(
+        string="Proof of Delivery File",
+        readonly=True,
+        copy=False,
+    )
+    pod_filename = fields.Char(
+        string="Proof of Delivery Filename",
+        readonly=True,
+        copy=False,
+    )
 
     def tracking_state_update(self):
         """Call to the service provider API which should have the method

--- a/delivery_state/views/stock_picking_views.xml
+++ b/delivery_state/views/stock_picking_views.xml
@@ -22,6 +22,8 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                     <field name="date_delivered" />
                     <field name="delivery_state" />
                     <field name="tracking_state" class="oe_inline" />
+                    <field name="pod_file" filename="pod_filename" />
+                    <field name="pod_filename" invisible="1" />
                     <button
                         name="tracking_state_update"
                         string="Update tracking state"


### PR DESCRIPTION
Each delivery module must implement the logic to retrieve and save the POD (Proof of Delivery).

TT59692
@Tecnativa @sergio-teruel @pedrobaeza could you please review this?

