### PR TITLE
[18.0][IMP] delivery_state: Add field to store raw tracking response

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -17,6 +17,8 @@ class StockPicking(models.Model):
         string="Delivery Date",
         readonly=True,
     )
+    # Technical field to store raw tracking data from the carrier API
+    tracking_json = fields.Json(readonly=True, copy=False)
     tracking_state = fields.Char(
         readonly=True,
         index=True,

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -12,10 +12,12 @@ class StockPicking(models.Model):
     date_shipped = fields.Date(
         string="Shipment Date",
         readonly=True,
+        copy=False,
     )
     date_delivered = fields.Datetime(
         string="Delivery Date",
         readonly=True,
+        copy=False,
     )
     # Technical field to store raw tracking data from the carrier API
     tracking_json = fields.Json(readonly=True, copy=False)
@@ -23,9 +25,11 @@ class StockPicking(models.Model):
         readonly=True,
         index=True,
         tracking=True,
+        copy=False,
     )
     tracking_state_history = fields.Text(
         readonly=True,
+        copy=False,
     )
     delivery_state = fields.Selection(
         selection=[
@@ -40,6 +44,7 @@ class StockPicking(models.Model):
         string="Carrier State",
         tracking=True,
         readonly=True,
+        copy=False,
     )
     pod_file = fields.Binary(
         string="Proof of Delivery File",


### PR DESCRIPTION
The purpose of this field is to store tracking information in raw format, because some carriers stop responding through the API after a certain period of time. In cases where the information is required later (for example, audits or documentation requests), this field can be used to retrieve tracking data that may no longer be available via the API.

Note: Each delivery module must implement the logic to retrieve and store this information.

TT59692
@Tecnativa @sergio-teruel @pedrobaeza could you please review this?