### PR TITLE
Fix crash when opening contact due to undefined delivery_zone_id

### DIFF
--- a/partner_delivery_zone/views/res_partner_view.xml
+++ b/partner_delivery_zone/views/res_partner_view.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2018 Tecnativa - Sergio Teruel
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <record id="view_partner_form" model="ir.ui.view">
+        <record id="view_partner_form" model="ir.ui.view">
         <field name="model">res.partner</field>
         <field name="name">partner delivery zone</field>
         <field name="inherit_id" ref="base.view_partner_form" />
@@ -15,6 +15,11 @@
                 position="after"
             >
                 <field name="delivery_zone_id" invisible="type != 'delivery'" />
+            </xpath>
+            <xpath expr="//field[@name='child_ids']" position="attributes">
+                <attribute name="context">
+                    {'default_delivery_zone_id': delivery_zone_id.id if delivery_zone_id else False}
+                </attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This pull request introduces a small but useful change to the `res_partner_view.xml` file. It updates the context for the `child_ids` field to automatically set the default `delivery_zone_id` when creating child records, improving user experience by pre-filling this value when appropriate.

Fix by explicitly setting the child_ids context with
delivery_zone_id.id so the Many2one field is resolved safely.

Fixes #1047

- User Experience Improvement:
  * [`partner_delivery_zone/views/res_partner_view.xml`](diffhunk://#diff-44d759264f7c83e66969cf20480740ddfce05156cf779f721d079593cec5508aR19-R23): Adds a `context` attribute to the `child_ids` field so that new child records will inherit the `delivery_zone_id` from the parent if available.