### PR TITLE
[16.0][IMP] Update visibility conditions for laposte fields

### DIFF
--- a/delivery_roulier_laposte_fr/views/stock_picking.xml
+++ b/delivery_roulier_laposte_fr/views/stock_picking.xml
@@ -14,14 +14,14 @@
                     attrs="{
                         'invisible': ['|',
                                       ('display_insurance', '=', False),
-                                      ('delivery_type', '!=', 'laposte')]}"
+                                      ('delivery_type', '!=', 'laposte_fr')]}"
                 />
                     <field
                     name="laposte_insurance"
                     attrs="{
                         'invisible': ['|',
                                       ('display_insurance', '=', False),
-                                      ('delivery_type', '!=', 'laposte')]}"
+                                      ('delivery_type', '!=', 'laposte_fr')]}"
                 />
             </xpath>
                         <!-- 'readonly': [('state','=','done')], -->


### PR DESCRIPTION
The delivery type value used in the visibility condition of
the 'display_insurance' and 'laposte_insurance' fields was incorrect
('laposte' instead of 'laposte_fr'). This was fixed in this PR.