### PR TITLE
[17.0][FIX] partner_delivery_zone: deliver_zony_id in sale order readonly for confirmed sales

### DIFF
--- a/partner_delivery_zone/views/sale_order_view.xml
+++ b/partner_delivery_zone/views/sale_order_view.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='payment_term_id']" position="after">
-                <field name="delivery_zone_id" readonly="state in ['sale', 'cancel']" />
+                <field name="delivery_zone_id" readonly="state == 'cancel' or locked" />
             </xpath>
         </field>
     </record>
@@ -17,9 +17,10 @@
         <field name="inherit_id" ref="sale.view_quotation_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="before">
+                <field name="locked" invisible="1" />
                 <field
                     name="delivery_zone_id"
-                    readonly="state in ['sale', 'cancel']"
+                    readonly="state == 'cancel' or locked"
                     optional="hidden"
                 />
             </xpath>


### PR DESCRIPTION
Since migration to 17 the field delivery_zone_id was locked for confirmed sales, this was a change behaviour from previous version.
This PR restore it.

@Tecnativa 

ping @carlosdauden @juancarlosonate-tecnativa 