### PR TITLE
[18.0][IMP] delivery_ups_oca: Sanitize phone/mobile before send data to carrier

### DIFF
--- a/delivery_ups_oca/models/delivery_carrier.py
+++ b/delivery_ups_oca/models/delivery_carrier.py
@@ -3,8 +3,9 @@
 # Copyright 2023 ForgeFlow, S.L. - Jordi Ballester
 # Copyright 2024 Sygel - Manuel Regidor
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import re
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 from .ups_request import UpsRequest
 
@@ -209,3 +210,24 @@ class DeliveryCarrier(models.Model):
         self.ensure_one()
         ups_request = UpsRequest(self)
         ups_request._get_new_token()
+
+    @api.model
+    def sanitize_phone_ups(self, phone_number):
+        """Sanitize a phone number for UPS usage."""
+        if not phone_number:
+            return phone_number
+        sanitize_fn = getattr(self, "_phone_format", None)
+        if sanitize_fn:
+            phone_sanitized = sanitize_fn(number=phone_number)
+            if phone_sanitized:
+                return phone_sanitized
+        if phone_number:
+            phone_number = re.sub(r"[^\d+]", "", phone_number)
+            # Clean plus character is there is any in the number in othe positions.
+            # We only want the first plus
+            phone_number = (
+                "+" + phone_number.replace("+", "")
+                if "+" in phone_number
+                else phone_number
+            )
+        return phone_number

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -139,7 +139,9 @@ class UpsRequest:
             Name=(partner.parent_id or partner).name,
             AttentionName=partner.name,
             TaxIdentificationNumber=partner.vat,
-            Phone=dict(Number=partner.phone or partner.mobile),
+            Phone=dict(
+                Number=self.carrier.sanitize_phone_ups(partner.phone or partner.mobile)
+            ),
             EMailAddress=partner.email,
             Address=dict(
                 AddressLine=[partner.street, partner.street2 or ""],


### PR DESCRIPTION
If the phone number is stored as +34 122 12 12 12, it is sent to the carrier in this format, which may cause an error due to the number being too long.
The formatting from the phone_validation module (without adding a direct dependency) is used in E164 format.

cc @Tecnativa

ping @carlosdauden @carlos-lopez-tecnativa 