### PR TITLE
[16.0][FIX] delivery_roulier_laposte_fr:  crash in _laposte_fr_get_parcel when done quantity is 0

### DIFF
--- a/delivery_roulier_laposte_fr/models/stock_quant_package.py
+++ b/delivery_roulier_laposte_fr/models/stock_quant_package.py
@@ -28,7 +28,7 @@ class StockQuantPackage(models.Model):
         def calc_package_price():
             return sum(
                 [
-                    op.product_id.lst_price * op.qty_done or op.product_qty
+                    op.product_id.lst_price * op.qty_done
                     for op in self.get_operations()
                 ]
             )


### PR DESCRIPTION
The product_qty field does not exist on stock.move.line in 16.0 so we removed the corresponding code.