### PR TITLE
[18.0][IMP] delivery_state: Include tracking update/connection errors in channel notifications

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -72,7 +72,13 @@ class StockPicking(models.Model):
         for picking in self.filtered("carrier_id"):
             method = f"{picking.delivery_type}_tracking_state_update"
             if hasattr(picking.carrier_id, method):
-                getattr(picking.carrier_id, method)(picking)
+                try:
+                    with self.env.cr.savepoint():
+                        getattr(picking.carrier_id, method)(picking)
+                except Exception as e:
+                    if not self.env.context.get("cron_id"):
+                        raise
+                    picking.pod_error = str(e)
         # Filter pickings with errors and notify
         pickings_with_errors = self.filtered("pod_error")
         if pickings_with_errors:


### PR DESCRIPTION

In PR https://github.com/OCA/delivery-carrier/pull/1124 , logic was added to store errors and notify them through the admin channel. However, each module still needs to implement this logic individually.

For UPS, this is handled in https://github.com/OCA/delivery-carrier/pull/1109/changes/2f74178d71637dcc7ec898d0425fc7b81f654459 and for GLS in https://github.com/OCA/l10n-spain/pull/4782/changes/5a940b49a056229079e0362eb7f14af75b917741

However, for other modules, this is still pending. Additionally, in GLS and UPS, errors are only captured when the API returns an error, but other cases are not covered, for example, when the API is down or there are connection issues, since the connection is made outside of a `try/except` block.
https://github.com/OCA/delivery-carrier/blob/ea63f8ec1e677f7d212e52e2ff0d613d5daca36f/delivery_ups_oca/models/ups_request.py#L370-L381

This change aims to cover more cases, but only when the update is executed by a cron job. If the user updates the state manually from the picking button, the exception is raised.

TT59692
@Tecnativa @pedrobaeza @sergio-teruel could you please review this?