### PR TITLE
[14.0][FIX] delivery_schenker: Use BID for Tracking State Update

### DIFF
--- a/delivery_schenker/models/delivery_carrier.py
+++ b/delivery_schenker/models/delivery_carrier.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Tecnativa - David Vidal
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# Copyright 2026 Raumschmiede GmbH
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from lxml import etree
 
@@ -622,7 +623,7 @@ class DeliveryCarrier(models.Model):
         self.ensure_one()
         return {
             "reference": picking.carrier_tracking_ref,
-            "reference_type": "cu",
+            "reference_type": "BID",
             "booking_type": self.schenker_booking_type,
         }
 

--- a/delivery_schenker/models/schenker_request.py
+++ b/delivery_schenker/models/schenker_request.py
@@ -183,7 +183,7 @@ class SchenkerRequest:
         return {"AccessKey": self.access_key, "in": {}}
 
     def _get_tracking_states(
-        self, reference=False, reference_type="cu", booking_type="land"
+        self, reference=False, reference_type="BID", booking_type="land"
     ):
         if not reference:
             return {}


### PR DESCRIPTION
The fetched tracking number is the Schenker booking ID. BID is the corresponding code in the tracking API.

With code cu the API returns nothing since March 2024. With BID it returns data for recent pickings in our Odoo.


Documentation: 
<img width="942" height="480" alt="image" src="https://github.com/user-attachments/assets/d6e7e728-6f2e-412b-8b80-61f4957e5318" />


Can't really tell the difference, the documentation has no more description for it.

 
**EDIT**
I asked Schenker via mail. Got an answer. They say BID is better. cu could be used differently depending on country and product and can change over time