### PR TITLE
[IMP] stock_picking_delivery_link: Set the delivery on delivery picking too

### DIFF
--- a/stock_picking_delivery_link/models/stock_picking.py
+++ b/stock_picking_delivery_link/models/stock_picking.py
@@ -35,6 +35,9 @@ class StockPicking(models.Model):
 
     def _get_ship_from_chain(self, done=False):
         """Returns the shipment related to the current operation."""
+        self.ensure_one()
+        if self.picking_type_id.code == "outgoing":
+            return self
         move_dest = get_first_move_dest(self.move_ids, done=done)
         while move_dest:
             picking = move_dest.picking_id

--- a/stock_picking_delivery_link/tests/test_delivery_link.py
+++ b/stock_picking_delivery_link/tests/test_delivery_link.py
@@ -77,6 +77,8 @@ class TestStockPickingDeliveryLink(StockPickingDeliveryLinkCommonCase):
         self.assertEqual(ship, move3.picking_id)
         self.assertEqual(ship.carrier_id, carrier)
 
+        self.assertEqual(ship.ship_picking_id, ship)
+
     def test_ship_data_from_pack(self):
         move1 = self._create_move(
             self.product,


### PR DESCRIPTION

As in situations you don't know you are on a ship picking, you want to retrieve the ship picking, put the `ship_picking_id` on itself too.