### PR TITLE
[17.0][FIX] delivery_correos_express: don't crash if tracking number not found.

### DIFF
--- a/delivery_correos_express/models/delivery_carrier.py
+++ b/delivery_correos_express/models/delivery_carrier.py
@@ -5,6 +5,7 @@ import base64
 from unidecode import unidecode
 
 from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 from .correos_express_request import (
     CORREOS_EXPRESS_LABEL_TYPE,
@@ -205,9 +206,16 @@ class DeliveryCarrier(models.Model):
         if not picking.carrier_tracking_ref:
             return
         correos_express_request = CorreosExpressRequest(self)
-        result = correos_express_request.track_shipment(
-            self._prepare_correos_express_tracking(picking)
-        )
+        try:
+            result = correos_express_request.track_shipment(
+                self._prepare_correos_express_tracking(picking)
+            )
+        except UserError as e:
+            if "NO ENCONTRADO" in str(e):
+                picking.delivery_state = "no_update"
+                picking.tracking_state = "Shipment not found"
+                return
+            raise
         if not result:
             return
         tracking_events = result.get("estadoEnvios", [])


### PR DESCRIPTION
The tracking request can fail if the server doesn't know about the tracking number.
This can happen if the tracking number is very old, or if it's incorrect. When this
happens an exception would be raised, which would cause the cron to stop and not update
other pickings.

This handles the error without raising. It changes the state to `no_update` to ensure
future cron runs don't try to update this picking again.
