### PR TITLE
[14.0][IMP] delivery_state: Exclude Pickings without Delivery State

### DIFF
--- a/delivery_state/models/delivery_carrier.py
+++ b/delivery_state/models/delivery_carrier.py
@@ -4,6 +4,12 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
+from ..models.stock_picking import (
+    DELIVERY_STATE_CANCELED,
+    DELIVERY_STATE_NO_UPDATE,
+    DELIVERY_STATE_SHIPPING_RECORDED,
+)
+
 
 class DeliveryCarrier(models.Model):
     _inherit = "delivery.carrier"
@@ -19,9 +25,9 @@ class DeliveryCarrier(models.Model):
         pickings.write(
             {
                 "date_shipped": fields.Date.today(),
-                "delivery_state": "shipping_recorded_in_carrier"
+                "delivery_state": DELIVERY_STATE_SHIPPING_RECORDED
                 if self.track_carrier_state
-                else "no_update",
+                else DELIVERY_STATE_NO_UPDATE,
             }
         )
         return res
@@ -30,7 +36,7 @@ class DeliveryCarrier(models.Model):
         super().cancel_shipment(pickings)
         pickings.write(
             {
-                "delivery_state": "canceled_shipment",
+                "delivery_state": DELIVERY_STATE_CANCELED,
                 "date_delivered": False,
                 "date_shipped": False,
             }

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -76,6 +76,14 @@ class StockPicking(models.Model):
         copy=False,
     )
 
+    def _get_delivery_states_in_progress(self):
+        return [
+            DELIVERY_STATE_SHIPPING_RECORDED,
+            DELIVERY_STATE_IN_TRANSIT,
+            DELIVERY_STATE_INCIDENCE,
+            DELIVERY_STATE_WH_DELIVERED,
+        ]
+
     def tracking_state_update(self):
         """Call to the service provider API which should have the method
         defined in the model as:
@@ -132,12 +140,8 @@ class StockPicking(models.Model):
                 ("state", "=", "done"),
                 (
                     "delivery_state",
-                    "not in",
-                    [
-                        DELIVERY_STATE_CUS_DELIVERED,
-                        DELIVERY_STATE_CANCELED,
-                        DELIVERY_STATE_NO_UPDATE,
-                    ],
+                    "in",
+                    self._get_delivery_states_in_progress(),
                 ),
                 # These won't ever autoupdate, so we don't want to evaluate them
                 ("delivery_type", "not in", [False, "fixed", "base_on_rule"]),

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -9,6 +9,14 @@ from markupsafe import Markup
 
 from odoo import _, api, fields, models
 
+DELIVERY_STATE_SHIPPING_RECORDED = "shipping_recorded_in_carrier"
+DELIVERY_STATE_IN_TRANSIT = "in_transit"
+DELIVERY_STATE_CANCELED = "canceled_shipment"
+DELIVERY_STATE_INCIDENCE = "incidence"
+DELIVERY_STATE_CUS_DELIVERED = "customer_delivered"
+DELIVERY_STATE_WH_DELIVERED = "warehouse_delivered"
+DELIVERY_STATE_NO_UPDATE = "no_update"
+
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
@@ -39,13 +47,13 @@ class StockPicking(models.Model):
     )
     delivery_state = fields.Selection(
         selection=[
-            ("shipping_recorded_in_carrier", "Shipping recorded in carrier"),
-            ("in_transit", "In transit"),
-            ("canceled_shipment", "Canceled shipment"),
-            ("incidence", "Incidence"),
-            ("customer_delivered", "Customer delivered"),
-            ("warehouse_delivered", "Warehouse delivered"),
-            ("no_update", "No more updates from carrier"),
+            (DELIVERY_STATE_SHIPPING_RECORDED, "Shipping recorded in carrier"),
+            (DELIVERY_STATE_IN_TRANSIT, "In transit"),
+            (DELIVERY_STATE_CANCELED, "Canceled shipment"),
+            (DELIVERY_STATE_INCIDENCE, "Incidence"),
+            (DELIVERY_STATE_CUS_DELIVERED, "Customer delivered"),
+            (DELIVERY_STATE_WH_DELIVERED, "Warehouse delivered"),
+            (DELIVERY_STATE_NO_UPDATE, "No more updates from carrier"),
         ],
         string="Carrier State",
         tracking=True,
@@ -89,7 +97,11 @@ class StockPicking(models.Model):
             days = carrier.days_fetch_tracking_state_update
             if (
                 picking.delivery_state
-                in ["customer_delivered", "canceled_shipment", "no_update"]
+                in [
+                    DELIVERY_STATE_CUS_DELIVERED,
+                    DELIVERY_STATE_CANCELED,
+                    DELIVERY_STATE_NO_UPDATE,
+                ]
                 or days <= 0
             ):
                 continue
@@ -103,7 +115,7 @@ class StockPicking(models.Model):
                 date_tracking_started = picking.date_done
 
             if date_tracking_started <= datetime.now() - timedelta(days=days):
-                picking.delivery_state = "no_update"
+                picking.delivery_state = DELIVERY_STATE_NO_UPDATE
 
         # Filter pickings with errors and notify
         pickings_with_errors = self.filtered("pod_error")
@@ -121,7 +133,11 @@ class StockPicking(models.Model):
                 (
                     "delivery_state",
                     "not in",
-                    ["customer_delivered", "canceled_shipment", "no_update"],
+                    [
+                        DELIVERY_STATE_CUS_DELIVERED,
+                        DELIVERY_STATE_CANCELED,
+                        DELIVERY_STATE_NO_UPDATE,
+                    ],
                 ),
                 # These won't ever autoupdate, so we don't want to evaluate them
                 ("delivery_type", "not in", [False, "fixed", "base_on_rule"]),

--- a/delivery_state/tests/test_delivery_state.py
+++ b/delivery_state/tests/test_delivery_state.py
@@ -10,6 +10,14 @@ from odoo.tests import Form
 from odoo.tests.common import SavepointCase
 from odoo.tools import float_compare
 
+from ..models.stock_picking import (
+    DELIVERY_STATE_CANCELED,
+    DELIVERY_STATE_CUS_DELIVERED,
+    DELIVERY_STATE_INCIDENCE,
+    DELIVERY_STATE_NO_UPDATE,
+    DELIVERY_STATE_SHIPPING_RECORDED,
+)
+
 
 class TestDeliveryState(SavepointCase):
     @classmethod
@@ -106,7 +114,7 @@ class TestDeliveryState(SavepointCase):
         picking.action_confirm()
         picking.action_assign()
         picking.send_to_shipper()
-        self.assertEqual(picking.delivery_state, "shipping_recorded_in_carrier")
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_SHIPPING_RECORDED)
         self.assertTrue(picking.date_shipped)
         self.assertFalse(picking.tracking_state_history)
         picking.tracking_state_update()
@@ -117,7 +125,7 @@ class TestDeliveryState(SavepointCase):
             "fixed_cancel_shipment", lambda *args: True
         )
         picking.cancel_shipment()
-        self.assertEqual(picking.delivery_state, "canceled_shipment")
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_CANCELED)
         self.assertFalse(picking.date_shipped)
         self.assertFalse(picking.date_delivered)
 
@@ -138,7 +146,7 @@ class TestDeliveryState(SavepointCase):
         picking.action_confirm()
         picking.action_assign()
         picking.send_to_shipper()
-        self.assertEqual(picking.delivery_state, "no_update")
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_NO_UPDATE)
 
     def test_delivery_confirmation_send(self):
         """Check that the shipping notification is sent to the right partner"""
@@ -169,23 +177,23 @@ class TestDeliveryState(SavepointCase):
             picking._action_done()
         picking.tracking_state_update()
         # No days are set on the carrier, so delivery_state must be the same as before
-        self.assertEqual(picking.delivery_state, "shipping_recorded_in_carrier")
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_SHIPPING_RECORDED)
 
         self.carrier_test.days_fetch_tracking_state_update = 5
         # date_shipped is not within the time range, delivery_state must be set
         picking.tracking_state_update()
-        self.assertEqual(picking.delivery_state, "no_update")
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_NO_UPDATE)
 
-        data = {"delivery_state": "incidence"}
+        data = {"delivery_state": DELIVERY_STATE_INCIDENCE}
         with freeze_time("2026-03-30"):
             picking.with_context(track_data=data).tracking_state_update()
         # Doesn't matter whether the API returned a new delivery state as long as it is
         # not a final state. State must be set to no_update
-        self.assertEqual(picking.delivery_state, "no_update")
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_NO_UPDATE)
 
-        data = {"delivery_state": "customer_delivered"}
+        data = {"delivery_state": DELIVERY_STATE_CUS_DELIVERED}
         with freeze_time("2026-03-30"):
             picking.with_context(track_data=data).tracking_state_update()
 
         # API returned a final state, delivery_state must not be overwritten
-        self.assertEqual(picking.delivery_state, "customer_delivered")
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_CUS_DELIVERED)

--- a/delivery_state/tests/test_delivery_state.py
+++ b/delivery_state/tests/test_delivery_state.py
@@ -2,6 +2,8 @@
 # Copyright 2020 FactorLibre
 # Copyright 2026 Raumschmiede GmbH
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import mock
 from freezegun import freeze_time
 from odoo_test_helper import FakeModelLoader
 
@@ -56,6 +58,8 @@ class TestDeliveryState(SavepointCase):
         cls.product = cls.env["product.product"].create(
             {"name": "Test product", "type": "product"}
         )
+        cls._set_stock(cls.product, 100)
+
         cls.partner = cls.env["res.partner"].create({"name": "Mr. Odoo"})
         cls.partner_shipping = cls.env["res.partner"].create(
             {"name": "Mr. Odoo (shipping)"}
@@ -91,6 +95,14 @@ class TestDeliveryState(SavepointCase):
     def tearDownClass(cls):
         cls.loader.restore_registry()
         super().tearDownClass()
+
+    @classmethod
+    def _set_stock(cls, product, qty):
+        return cls.env["stock.quant"]._update_available_quantity(
+            product,
+            cls.env.ref("stock.stock_location_stock"),
+            qty,
+        )
 
     def test_delivery_state(self):
         delivery_wizard = Form(
@@ -197,3 +209,45 @@ class TestDeliveryState(SavepointCase):
 
         # API returned a final state, delivery_state must not be overwritten
         self.assertEqual(picking.delivery_state, DELIVERY_STATE_CUS_DELIVERED)
+
+    def test_cron_pickings(self):
+        self.env.ref("stock.warehouse0").delivery_steps = "pick_pack_ship"
+        self.sale.action_confirm()
+
+        # Set PICK to done
+        pick = self.sale.picking_ids.filtered(lambda p: p.state == "assigned")
+        for ml in pick.move_line_ids:
+            ml.qty_done = ml.product_uom_qty
+        pick.button_validate()
+        pick.carrier_id = self.carrier_test
+
+        # Set PACK to done. Call carrier API with this picking
+        pack = self.sale.picking_ids.filtered(lambda p: p.state == "assigned")
+        for ml in pack.move_line_ids:
+            ml.qty_done = ml.product_uom_qty
+        pack.carrier_id = self.carrier_test
+        pack.button_validate()
+        self.assertTrue(pack)
+
+        # SET OUT to done
+        ship = self.sale.picking_ids.filtered(lambda p: p.state == "assigned")
+        for ml in ship.move_line_ids:
+            ml.qty_done = ml.product_uom_qty
+        ship.button_validate()
+        # NOTE: On version >= 18.0 use the carrier on the picking and the PACK rule
+        # should propagate the carrier to the OUT
+        ship.carrier_id = self.carrier_test
+
+        with mock.patch.object(
+            type(self.env["stock.picking"]),
+            "tracking_state_update",
+            autospec=True,
+        ) as mocked:
+            self.env.ref(
+                "delivery_state.ir_cron_delivery_state"
+            ).method_direct_trigger()
+
+            # As only the PACK picking was sent to the carrier API only for this
+            # the tracking state must be updated even if the other pickings have
+            # a carrier set
+            mocked.assert_called_once_with(pack)


### PR DESCRIPTION
In our system we have `delivery_send_to_shipper_at_operation` and `deliver_schenker` installed. We create the Schenker labels on the PACK step. When the PACK picking creates a backorder and we send the backorder to the schenker API, its tracking number is added to the OUT picking next to tracking number of the first PACK picking. Then we set the OUT picking to done.

The cron of `delivery_state` finds all 3 pickings and tries to fetch the state. For the 2 PACK pickings it is fine, but the API call for the OUT picking fails. This is the log:

<img width="1220" height="375" alt="image" src="https://github.com/user-attachments/assets/1fe0a94a-ac42-4c2f-9337-2fe309994d53" />

The API does not like 2 tracking numbers.


The cron should only fetch the tracking state for pickings that were sent to the carrier API.
My fix ensures that `delivery_state` is compatible with `delivery_send_to_shipper_at_operation`. [Here](https://github.com/OCA/delivery-carrier/blob/fed707047d70833de0802c7ae03aaa8a092c04f0/delivery_send_to_shipper_at_operation/models/stock_picking.py#L87) the module skips the super call that would call later the `send_shipping` of `delivery_state` that would set `date_shipped` on the OUTs:
<img width="707" height="230" alt="image" src="https://github.com/user-attachments/assets/0574bc0a-265e-43cc-84a6-5c396d5cd4af" />


That's why checking `date_shipped` is enough to make it compatible.
**EDIT**
Or to check for other delivery states