### PR TITLE
[14.0][IMP][BP] delivery_state: POD Fields, no Copy of some Fields and Tracking Update Savepoint

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -16,6 +16,8 @@ class StockPicking(models.Model):
         string="Delivery Date",
         readonly=True,
     )
+    # Technical field to store raw tracking data from the carrier API
+    tracking_json = fields.Json(readonly=True, copy=False)
     tracking_state = fields.Char(
         string="Tracking state",
         readonly=True,

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -40,6 +40,16 @@ class StockPicking(models.Model):
         tracking=True,
         readonly=True,
     )
+    pod_file = fields.Binary(
+        string="Proof of Delivery File",
+        readonly=True,
+        copy=False,
+    )
+    pod_filename = fields.Char(
+        string="Proof of Delivery Filename",
+        readonly=True,
+        copy=False,
+    )
 
     def tracking_state_update(self):
         """Call to the service provider API which should have the method

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -17,7 +17,7 @@ class StockPicking(models.Model):
         readonly=True,
     )
     # Technical field to store raw tracking data from the carrier API
-    tracking_json = fields.Json(readonly=True, copy=False)
+    tracking_json = fields.Char(readonly=True, copy=False)
     tracking_state = fields.Char(
         string="Tracking state",
         readonly=True,

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -2,7 +2,9 @@
 # Copyright 2020 FactorLibre
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from markupsafe import Markup
+
+from odoo import SUPERUSER_ID, api, fields, models
 
 
 class StockPicking(models.Model):
@@ -57,6 +59,11 @@ class StockPicking(models.Model):
         readonly=True,
         copy=False,
     )
+    pod_error = fields.Char(
+        string="Proof of Delivery Error",
+        readonly=True,
+        copy=False,
+    )
 
     def tracking_state_update(self):
         """Call to the service provider API which should have the method
@@ -67,6 +74,10 @@ class StockPicking(models.Model):
             method = "%s_tracking_state_update" % picking.delivery_type
             if hasattr(picking.carrier_id, method):
                 getattr(picking.carrier_id, method)(picking)
+        # Filter pickings with errors and notify
+        pickings_with_errors = self.filtered("pod_error")
+        if pickings_with_errors:
+            pickings_with_errors._send_message_pod_error()
 
     @api.model
     def _update_delivery_state(self):
@@ -86,3 +97,26 @@ class StockPicking(models.Model):
             ]
         )
         pickings.tracking_state_update()
+
+    def _send_message_pod_error(self):
+        channel_admin = self.env.ref("mail.channel_admin", raise_if_not_found=False)
+        if not channel_admin:
+            return
+        pickings_by_carrier = self.grouped("carrier_id")
+        for _carrier, pickings in pickings_by_carrier.items():
+            message = pickings._build_message_pod_error()
+            channel_admin.with_user(SUPERUSER_ID).message_post(body=Markup(message))
+
+    def _build_message_pod_error(self):
+        message = self.env._(
+            "<b>Errors while fetching POD for carrier %s:</b><br/>"
+            "Please review the details below "
+            "and take the necessary actions to resolve these issues.:<br/>",
+            self.carrier_id.name,
+        )
+        message += "<ul>"
+        for picking in self:
+            picking_url = picking._get_html_link()
+            message += f"<li>Picking {picking_url}: {picking.pod_error}</li>"
+        message += "</ul>"
+        return message

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -73,7 +73,13 @@ class StockPicking(models.Model):
         for picking in self.filtered("carrier_id"):
             method = "%s_tracking_state_update" % picking.delivery_type
             if hasattr(picking.carrier_id, method):
-                getattr(picking.carrier_id, method)(picking)
+                try:
+                    with self.env.cr.savepoint():
+                        getattr(picking.carrier_id, method)(picking)
+                except Exception as e:
+                    if not self.env.context.get("cron_id"):
+                        raise
+                    picking.pod_error = str(e)
         # Filter pickings with errors and notify
         pickings_with_errors = self.filtered("pod_error")
         if pickings_with_errors:

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -77,7 +77,7 @@ class StockPicking(models.Model):
                     with self.env.cr.savepoint():
                         getattr(picking.carrier_id, method)(picking)
                 except Exception as e:
-                    if not self.env.context.get("cron_id"):
+                    if not self.env.context.get("lastcall"):
                         raise
                     picking.pod_error = str(e)
         # Filter pickings with errors and notify

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from markupsafe import Markup
 
-from odoo import SUPERUSER_ID, api, fields, models
+from odoo import _, api, fields, models
 
 
 class StockPicking(models.Model):
@@ -99,24 +99,17 @@ class StockPicking(models.Model):
         pickings.tracking_state_update()
 
     def _send_message_pod_error(self):
-        channel_admin = self.env.ref("mail.channel_admin", raise_if_not_found=False)
-        if not channel_admin:
-            return
-        pickings_by_carrier = self.grouped("carrier_id")
-        for _carrier, pickings in pickings_by_carrier.items():
-            message = pickings._build_message_pod_error()
-            channel_admin.with_user(SUPERUSER_ID).message_post(body=Markup(message))
+        for picking in self:
+            message = picking._build_message_pod_error()
+            picking.message_post(body=Markup(message))
 
     def _build_message_pod_error(self):
-        message = self.env._(
+        self.ensure_one()
+
+        return _(
             "<b>Errors while fetching POD for carrier %s:</b><br/>"
             "Please review the details below "
-            "and take the necessary actions to resolve these issues.:<br/>",
+            "and take the necessary actions to resolve these issues.: %s<br/>",
             self.carrier_id.name,
+            self.pod_error,
         )
-        message += "<ul>"
-        for picking in self:
-            picking_url = picking._get_html_link()
-            message += f"<li>Picking {picking_url}: {picking.pod_error}</li>"
-        message += "</ul>"
-        return message

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -11,10 +11,12 @@ class StockPicking(models.Model):
     date_shipped = fields.Date(
         string="Shipment Date",
         readonly=True,
+        copy=False,
     )
     date_delivered = fields.Datetime(
         string="Delivery Date",
         readonly=True,
+        copy=False,
     )
     # Technical field to store raw tracking data from the carrier API
     tracking_json = fields.Char(readonly=True, copy=False)
@@ -23,10 +25,12 @@ class StockPicking(models.Model):
         readonly=True,
         index=True,
         tracking=True,
+        copy=False,
     )
     tracking_state_history = fields.Text(
         string="Tracking state history",
         readonly=True,
+        copy=False,
     )
     delivery_state = fields.Selection(
         selection=[
@@ -41,6 +45,7 @@ class StockPicking(models.Model):
         string="Carrier State",
         tracking=True,
         readonly=True,
+        copy=False,
     )
     pod_file = fields.Binary(
         string="Proof of Delivery File",

--- a/delivery_state/views/stock_picking_views.xml
+++ b/delivery_state/views/stock_picking_views.xml
@@ -19,6 +19,8 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                     <field name="date_delivered" />
                     <field name="delivery_state" />
                     <field name="tracking_state" class="oe_inline" />
+                    <field name="pod_file" filename="pod_filename" />
+                    <field name="pod_filename" invisible="1" />
                     <button
                         name="tracking_state_update"
                         string="Update tracking state"

--- a/delivery_state/views/stock_picking_views.xml
+++ b/delivery_state/views/stock_picking_views.xml
@@ -21,6 +21,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                     <field name="tracking_state" class="oe_inline" />
                     <field name="pod_file" filename="pod_filename" />
                     <field name="pod_filename" invisible="1" />
+                    <field name="pod_error" invisible="not pod_error" />
                     <button
                         name="tracking_state_update"
                         string="Update tracking state"

--- a/delivery_state/views/stock_picking_views.xml
+++ b/delivery_state/views/stock_picking_views.xml
@@ -21,7 +21,10 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                     <field name="tracking_state" class="oe_inline" />
                     <field name="pod_file" filename="pod_filename" />
                     <field name="pod_filename" invisible="1" />
-                    <field name="pod_error" invisible="not pod_error" />
+                    <field
+                        name="pod_error"
+                        attrs="{'invisible': [('pod_error', '=', False)]}"
+                    />
                     <button
                         name="tracking_state_update"
                         string="Update tracking state"


### PR DESCRIPTION
Various backports of commits from version 18.0

Relates to PR https://github.com/OCA/delivery-carrier/pull/1148. Because of the wrong tracking number on the OUT the Schenker API raises an error which results in that the tracking state can not be fetched for any other picking. With the savepoint this is fixed.

The other commits relate to the savepoint commit, that's why I backported them, too.

The commit that adds `pod_error` also adds the message post for the admin channel. The channel does not exist in version 14.0. I changed to code so that it works with 14.0. Should I keep this part? As long as no channel exists, this part will not do anything. Or should I add one as XML record in `delivery_state`?

- `tracking_json` was added as `fields.Json`. This does not exist in 14.0, I changed it to `fields.Char`
- `not pod_error` does not work for `invisible` in the view. I changed it to `attrs`
- In the last commit that adds the savepoint I had to change the check whether a cron is calling this. `cron_id` is not set in 14.0, only `lastcall`