### PR TITLE
[18.0][FIX] delivery_ups_oca: truncate Name/AttentionName to 35 chars

### DIFF
--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -136,8 +136,8 @@ class UpsRequest:
         """Return a dict describing a partner for the shipping request"""
         return dict(
             **kwargs,
-            Name=(partner.parent_id or partner).name,
-            AttentionName=partner.name,
+            Name=((partner.parent_id or partner).name or "")[:35],
+            AttentionName=(partner.name or "")[:35],
             TaxIdentificationNumber=partner.vat,
             Phone=dict(Number=partner.phone or partner.mobile),
             EMailAddress=partner.email,


### PR DESCRIPTION
UPS API rejects requests when Name or AttentionName exceed 35 characters.

Verified on UPS CIE (`wwwcie.ups.com/api/shipments/v1/ship`):

- `ShipTo.Name` with 36 chars : `120200: Missing or invalid ship to name`
- `ShipTo.AttentionName` with 36 chars : `120201: Missing or invalid ship to attention name`

Both fields work fine at 35 chars.

@tecnativa @carlos-lopez-tecnativa 