### PR TITLE
[18.0] [IMP] delivery_ups_oca: Save the POD, Signature and tracking_state

### DIFF
--- a/delivery_ups_oca/models/delivery_carrier.py
+++ b/delivery_ups_oca/models/delivery_carrier.py
@@ -236,6 +236,7 @@ class DeliveryCarrier(models.Model):
             picking_vals = {
                 "delivery_state": response["delivery_state"],
                 "tracking_state_history": response["tracking_state_history"],
+                "tracking_state": response.get("tracking_state"),
             }
             if response.get("pod"):
                 picking_vals.update(

--- a/delivery_ups_oca/models/delivery_carrier.py
+++ b/delivery_ups_oca/models/delivery_carrier.py
@@ -233,8 +233,19 @@ class DeliveryCarrier(models.Model):
         ):
             ups_request = UpsRequest(self)
             response = ups_request.tracking_state_update(picking)
-            picking.delivery_state = response["delivery_state"]
-            picking.tracking_state_history = response["tracking_state_history"]
+            picking_vals = {
+                "delivery_state": response["delivery_state"],
+                "tracking_state_history": response["tracking_state_history"],
+            }
+            if response.get("pod"):
+                picking_vals.update(
+                    {
+                        "pod_filename": f"ups_pod_{picking.carrier_tracking_ref}.html",
+                        "pod_file": response["pod"],
+                        "pod_error": False,
+                    }
+                )
+            picking.write(picking_vals)
 
     def ups_update_token(self):
         self.ensure_one()

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -5,6 +5,7 @@
 
 import datetime
 import logging
+from urllib.parse import urlencode
 
 import requests
 
@@ -390,8 +391,10 @@ class UpsRequest:
             "P": "customer_delivered",
             "M": "in_transit",
         }
+        params = {"returnSignature": "true", "returnPOD": "true"}
+        query_string = urlencode(params)
         status = self._process_reply(
-            url=f"{self.url}/api/track/v1/details/{picking.carrier_tracking_ref}?returnPOD=true",
+            url=f"{self.url}/api/track/v1/details/{picking.carrier_tracking_ref}?{query_string}",
             method="get",
             headers_extra={
                 "transId": f"{datetime.datetime.now().timestamp()}",

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -391,7 +391,7 @@ class UpsRequest:
             "M": "in_transit",
         }
         status = self._process_reply(
-            url=f"{self.url}/api/track/v1/details/{picking.carrier_tracking_ref}",
+            url=f"{self.url}/api/track/v1/details/{picking.carrier_tracking_ref}?returnPOD=true",
             method="get",
             headers_extra={
                 "transId": f"{datetime.datetime.now().timestamp()}",
@@ -399,10 +399,14 @@ class UpsRequest:
             },
         )
         self._raise_for_status(status, False)
+        shipment = status["trackResponse"]["shipment"][0]
+        package = shipment["package"][0]
         states_list = []
         delivery_state = "incident"
+        pod = (
+            package.get("deliveryInformation", {}).get("pod", {}).get("content", False)
+        )
         try:
-            shipment = status["trackResponse"]["shipment"][0]
             if not shipment.get("warnings"):
                 for activity in shipment["package"][0]["activity"]:
                     states_list.append(
@@ -439,4 +443,5 @@ class UpsRequest:
         return {
             "delivery_state": delivery_state,
             "tracking_state_history": "\n".join(states_list),
+            "pod": pod,
         }

--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -401,8 +401,10 @@ class UpsRequest:
         self._raise_for_status(status, False)
         shipment = status["trackResponse"]["shipment"][0]
         package = shipment["package"][0]
+        current_status = package.get("currentStatus") or {}
         states_list = []
         delivery_state = "incident"
+        tracking_state = f"[{current_status['code']}] {current_status['description']}"
         pod = (
             package.get("deliveryInformation", {}).get("pod", {}).get("content", False)
         )
@@ -443,5 +445,6 @@ class UpsRequest:
         return {
             "delivery_state": delivery_state,
             "tracking_state_history": "\n".join(states_list),
+            "tracking_state": tracking_state,
             "pod": pod,
         }

--- a/delivery_ups_oca/tests/test_delivery_ups.py
+++ b/delivery_ups_oca/tests/test_delivery_ups.py
@@ -216,6 +216,7 @@ class TestDeliveryUps(TestDeliveryUpsBase):
                     return_value={
                         "delivery_state": "in_transit",
                         "tracking_state_history": "history",
+                        "tracking_state": "[300] In Transit",
                     },
                 ):
                     self.picking.tracking_state_update()
@@ -535,6 +536,7 @@ class TestDeliveryUps(TestDeliveryUpsBase):
             return_value={
                 "delivery_state": "in_transit",
                 "tracking_state_history": "Test history",
+                "tracking_state": "[300] In Transit",
             },
         ):
             self.carrier.ups_tracking_state_update(self.picking)


### PR DESCRIPTION
By passing the parameter `returnPOD=true`, the API can return the POD in HTML format.
By passing the parameter returnSignature=true, the API can return the Signature in PNG format.


TT59692
@Tecnativa @pedrobaeza @sergio-teruel could you please review this?