### PR TITLE
[19.0][FIX] delivery_carrier_picking_valid_dangerous_goods:  support …

### DIFF
--- a/delivery_carrier_picking_valid_dangerous_goods/models/delivery_carrier.py
+++ b/delivery_carrier_picking_valid_dangerous_goods/models/delivery_carrier.py
@@ -2,6 +2,7 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo import fields, models
+from odoo.exceptions import UserError
 
 
 class DeliveryCarrier(models.Model):
@@ -15,10 +16,16 @@ class DeliveryCarrier(models.Model):
         "limited amount.",
     )
 
-    def _match(self, partner, order):
-        return super()._match(partner, order) and self._match_dangerous_goods(
-            order.order_line.product_id
-        )
+    def _match(self, partner, source):
+        if source._name == "sale.order":
+            products = source.order_line.product_id
+        elif source._name == "stock.picking":
+            # with_prefetch is needed to avoid a MemoryError on move product fetch
+            # check https://github.com/OCA/OCB/commit/97919d6c28adc750d282a15f86320c576f3de872
+            products = source.move_ids.with_prefetch().product_id
+        else:
+            raise UserError(self.env._("Invalid source document type"))
+        return super()._match(partner, source) and self._match_dangerous_goods(products)
 
     def _match_picking(self, picking):
         return super()._match_picking(picking) and self._match_dangerous_goods(

--- a/delivery_carrier_picking_valid_dangerous_goods/tests/test_delivery_carrier_valid_dangerous_goods.py
+++ b/delivery_carrier_picking_valid_dangerous_goods/tests/test_delivery_carrier_valid_dangerous_goods.py
@@ -119,3 +119,41 @@ class TestPickingValid(Common):
         self.assertTrue(
             self.carrier_dangerous_goods._match_picking(picking_lq_restriction)
         )
+
+    def test_match_with_picking_source_dangerous_goods(self):
+        picking_no_limited_amount = self.picking
+        picking_dg_restriction = self.dangerous_goods_picking
+        picking_lq_restriction = self.limited_qty_picking
+
+        self.assertTrue(
+            self.carrier_limited_quantity._match(
+                picking_no_limited_amount.partner_id, picking_no_limited_amount
+            )
+        )
+        self.assertTrue(
+            self.carrier_dangerous_goods._match(
+                picking_no_limited_amount.partner_id, picking_no_limited_amount
+            )
+        )
+
+        self.assertFalse(
+            self.carrier_limited_quantity._match(
+                picking_lq_restriction.partner_id, picking_lq_restriction
+            )
+        )
+        self.assertFalse(
+            self.carrier_dangerous_goods._match(
+                picking_dg_restriction.partner_id, picking_dg_restriction
+            )
+        )
+
+        self.assertTrue(
+            self.carrier_limited_quantity._match(
+                picking_dg_restriction.partner_id, picking_dg_restriction
+            )
+        )
+        self.assertTrue(
+            self.carrier_dangerous_goods._match(
+                picking_lq_restriction.partner_id, picking_lq_restriction
+            )
+        )


### PR DESCRIPTION
…dangerous goods checks in _match() for stock pickings

Apply dangerous goods carrier filtering to generic source matching (sale order + picking)


Error triggered when using the smart button from a sale.order to access the linked picking
```
  File "/odoo/external-src/delivery-carrier/delivery_carrier_picking_valid_dangerous_goods/models/delivery_carrier.py", line 20, in _match
    order.order_line.product_id
    ^^^^^^^^^^^^^^^^
AttributeError: 'stock.picking' object has no attribute 'order_line'
```

Source method definition https://github.com/OCA/OCB/blob/19.0/addons/delivery/models/delivery_carrier.py#L182