### PR TITLE
[14.0][IMP] delivery_state: Set delivery_state to no_update on invalid Pickings

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -89,18 +89,21 @@ class StockPicking(models.Model):
         defined in the model as:
             <my_provider>_tracking_state_update
         It can be triggered manually or by the cron."""
-        for picking in self.filtered("carrier_id"):
+        for picking in self:
             method = "%s_tracking_state_update" % picking.delivery_type
             carrier = picking.carrier_id
 
-            if hasattr(carrier, method):
-                try:
-                    with self.env.cr.savepoint():
-                        getattr(carrier, method)(picking)
-                except Exception as e:
-                    if not self.env.context.get("lastcall"):
-                        raise
-                    picking.pod_error = str(e)
+            if not carrier or not hasattr(carrier, method):
+                picking.delivery_state = DELIVERY_STATE_NO_UPDATE
+                continue
+
+            try:
+                with self.env.cr.savepoint():
+                    getattr(carrier, method)(picking)
+            except Exception as e:
+                if not self.env.context.get("lastcall"):
+                    raise
+                picking.pod_error = str(e)
 
             days = carrier.days_fetch_tracking_state_update
             if (

--- a/delivery_state/tests/test_delivery_state.py
+++ b/delivery_state/tests/test_delivery_state.py
@@ -130,6 +130,7 @@ class TestDeliveryState(SavepointCase):
         self.assertTrue(picking.date_shipped)
         self.assertFalse(picking.tracking_state_history)
         picking.tracking_state_update()
+        self.assertEqual(picking.delivery_state, DELIVERY_STATE_NO_UPDATE)
         picking.date_delivered = fields.Datetime.now()
         with self.assertRaises(NotImplementedError):
             picking.cancel_shipment()


### PR DESCRIPTION
As mentioned here: https://github.com/OCA/delivery-carrier/pull/1152#discussion_r3020087572

There is no reason to fetch a tracking state for a picking if the picking carrier provides no implementation for it.
In our system only Schenker provides it, all others not. The cron finds all of the non-Schenker pickings each run. With this change the cron will find the picking once and sets `delivery_state` to `no_update`.


One other solution would be to add a hook `_carriers_tracking_fetch_allowed` to the module. By default it returns an empty list. `delivery_schenker` overrides this and returns `super() + ["schenker"]`. The hook is used in the overridden `send_shipping` to immediately set it to `no_update` if the carrier is not in this list.


Yes, we can set `track_carrier_state` on all carriers. But the field didn't exist in 14.0 for some time until PR https://github.com/OCA/delivery-carrier/pull/844 and for carriers without a tracking state implementation this field should not have an effect anyway. Better to automatically remove the pickings from the cron run