### PR TITLE
[19.0][IMP] delivery_state: Add fields to store the POD and logic to notify when retrieving the POD fails

### DIFF
--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -40,6 +40,16 @@ class StockPicking(models.Model):
         tracking=True,
         readonly=True,
     )
+    pod_file = fields.Binary(
+        string="Proof of Delivery File",
+        readonly=True,
+        copy=False,
+    )
+    pod_filename = fields.Char(
+        string="Proof of Delivery Filename",
+        readonly=True,
+        copy=False,
+    )
 
     def tracking_state_update(self):
         """Call to the service provider API which should have the method

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -18,6 +18,8 @@ class StockPicking(models.Model):
         string="Delivery Date",
         readonly=True,
     )
+    # Technical field to store raw tracking data from the carrier API
+    tracking_json = fields.Json(readonly=True, copy=False)
     tracking_state = fields.Char(
         readonly=True,
         index=True,

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -73,7 +73,13 @@ class StockPicking(models.Model):
         for picking in self.filtered("carrier_id"):
             method = f"{picking.delivery_type}_tracking_state_update"
             if hasattr(picking.carrier_id, method):
-                getattr(picking.carrier_id, method)(picking)
+                try:
+                    with self.env.cr.savepoint():
+                        getattr(picking.carrier_id, method)(picking)
+                except Exception as e:
+                    if not self.env.context.get("cron_id"):
+                        raise
+                    picking.pod_error = str(e)
         # Filter pickings with errors and notify
         pickings_with_errors = self.filtered("pod_error")
         if pickings_with_errors:

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -13,10 +13,12 @@ class StockPicking(models.Model):
     date_shipped = fields.Date(
         string="Shipment Date",
         readonly=True,
+        copy=False,
     )
     date_delivered = fields.Datetime(
         string="Delivery Date",
         readonly=True,
+        copy=False,
     )
     # Technical field to store raw tracking data from the carrier API
     tracking_json = fields.Json(readonly=True, copy=False)
@@ -24,9 +26,11 @@ class StockPicking(models.Model):
         readonly=True,
         index=True,
         tracking=True,
+        copy=False,
     )
     tracking_state_history = fields.Text(
         readonly=True,
+        copy=False,
     )
     delivery_state = fields.Selection(
         selection=[
@@ -41,6 +45,7 @@ class StockPicking(models.Model):
         string="Carrier State",
         tracking=True,
         readonly=True,
+        copy=False,
     )
     pod_file = fields.Binary(
         string="Proof of Delivery File",

--- a/delivery_state/models/stock_picking.py
+++ b/delivery_state/models/stock_picking.py
@@ -3,7 +3,9 @@
 # Copyright 2020 Tecnativa - David Vidal
 # Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from markupsafe import Markup
+
+from odoo import SUPERUSER_ID, api, fields, models
 from odoo.fields import Domain
 
 
@@ -57,6 +59,11 @@ class StockPicking(models.Model):
         readonly=True,
         copy=False,
     )
+    pod_error = fields.Char(
+        string="Proof of Delivery Error",
+        readonly=True,
+        copy=False,
+    )
 
     def tracking_state_update(self):
         """Call to the service provider API which should have the method
@@ -67,6 +74,10 @@ class StockPicking(models.Model):
             method = f"{picking.delivery_type}_tracking_state_update"
             if hasattr(picking.carrier_id, method):
                 getattr(picking.carrier_id, method)(picking)
+        # Filter pickings with errors and notify
+        pickings_with_errors = self.filtered("pod_error")
+        if pickings_with_errors:
+            pickings_with_errors._send_message_pod_error()
 
     @api.model
     def _update_delivery_state(self):
@@ -87,6 +98,29 @@ class StockPicking(models.Model):
         )
         pickings = self.search(domain)
         pickings.tracking_state_update()
+
+    def _send_message_pod_error(self):
+        channel_admin = self.env.ref("mail.channel_admin", raise_if_not_found=False)
+        if not channel_admin:
+            return
+        pickings_by_carrier = self.grouped("carrier_id")
+        for _carrier, pickings in pickings_by_carrier.items():
+            message = pickings._build_message_pod_error()
+            channel_admin.with_user(SUPERUSER_ID).message_post(body=Markup(message))
+
+    def _build_message_pod_error(self):
+        message = self.env._(
+            "<b>Errors while fetching POD for carrier %s:</b><br/>"
+            "Please review the details below "
+            "and take the necessary actions to resolve these issues.:<br/>",
+            self.carrier_id.name,
+        )
+        message += "<ul>"
+        for picking in self:
+            picking_url = picking._get_html_link()
+            message += f"<li>Picking {picking_url}: {picking.pod_error}</li>"
+        message += "</ul>"
+        return message
 
     def _send_delivery_state_delivered_email(self):
         for item in self.filtered(

--- a/delivery_state/views/stock_picking_views.xml
+++ b/delivery_state/views/stock_picking_views.xml
@@ -22,6 +22,8 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                     <field name="date_delivered" />
                     <field name="delivery_state" />
                     <field name="tracking_state" class="oe_inline" />
+                    <field name="pod_file" filename="pod_filename" />
+                    <field name="pod_filename" invisible="1" />
                     <button
                         name="tracking_state_update"
                         string="Update tracking state"

--- a/delivery_state/views/stock_picking_views.xml
+++ b/delivery_state/views/stock_picking_views.xml
@@ -24,6 +24,7 @@ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
                     <field name="tracking_state" class="oe_inline" />
                     <field name="pod_file" filename="pod_filename" />
                     <field name="pod_filename" invisible="1" />
+                    <field name="pod_error" invisible="not pod_error" />
                     <button
                         name="tracking_state_update"
                         string="Update tracking state"


### PR DESCRIPTION
FWP of 
https://github.com/OCA/delivery-carrier/pull/1107
https://github.com/OCA/delivery-carrier/pull/1108
https://github.com/OCA/delivery-carrier/pull/1124
https://github.com/OCA/delivery-carrier/pull/1139

I created a single PR containing all the changes related to the same module to avoid git conflicts. Please let me know if this approach is OK, or if I should create individual PRs instead.

@Tecnativa @sergio-teruel @pedrobaeza  @RicardCForgeFlow could you please review this?