### PR TITLE
[18.0][IMP] delivery_postlogistics: use new API endpoints (since 2023)

### DIFF
--- a/delivery_postlogistics/models/delivery_carrier.py
+++ b/delivery_postlogistics/models/delivery_carrier.py
@@ -19,10 +19,10 @@ class DeliveryCarrier(models.Model):
         domain=[("package_carrier_type", "=", "postlogistics")],
         default=lambda self: self._default_postlogistics_default_package_type_id(),
     )
+    # postlogistics_endpoint_url deprecated, remove in migration to next major version
     postlogistics_endpoint_url = fields.Char(
         string="Endpoint URL",
-        default="https://wedecint.post.ch/",
-        required=True,
+        required=False,
     )
     postlogistics_client_id = fields.Char(
         string="Client ID", groups="base.group_system"
@@ -101,19 +101,6 @@ class DeliveryCarrier(models.Model):
             "delivery_postlogistics.postlogistics_default_package_type",
             raise_if_not_found=False,
         )
-
-    @api.onchange("prod_environment")
-    def onchange_prod_environment(self):
-        """
-        Auto change the end point url following the environment
-        - Test: https://wedecint.post.ch/
-        - Prod: https://wedec.post.ch/
-        """
-        for carrier in self:
-            if carrier.prod_environment:
-                carrier.postlogistics_endpoint_url = "https://wedec.post.ch/"
-            else:
-                carrier.postlogistics_endpoint_url = "https://wedecint.post.ch/"
 
     def _postlogistics_get_default_custom_package_code(self):
         # Used while changing the carrier on the stock.package.type Form

--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -6,7 +6,6 @@ import json
 import logging
 import re
 import threading
-import urllib.parse
 from datetime import datetime, timedelta
 from json import JSONDecodeError
 
@@ -19,8 +18,10 @@ _logger = logging.getLogger(__name__)
 
 _compile_itemid = re.compile(r"[^0-9A-Za-z+\-_]")
 _compile_itemnum = re.compile(r"[^0-9]")
-AUTH_PATH = "/WEDECOAuth/token"
-GENERATE_LABEL_PATH = "/api/barcode/v1/generateAddressLabel"
+AUTH_URL = "https://api.post.ch/OAuth/token"
+AUTH_TIMEOUT = 15  # seconds
+GENERATE_LABEL_URL = "https://dcapi.apis.post.ch/barcode/v1/generateAddressLabel"
+API_TIMEOUT = 15  # seconds
 
 DISALLOWED_CHARS_MAPPING = {
     "|": "",
@@ -52,9 +53,7 @@ class PostlogisticsWebService:
 
     Handbook available here:
     https://developer.post.ch/en/digital-commerce-api
-    https://wedec.post.ch/doc/swagger/index.html?
-        url=https://wedec.post.ch/doc/api/barcode/v1/swagger.yaml
-        #/Barcode/generateAddressLabel
+    https://developer.apis.post.ch/ui/apis/5cff6ab7-8325-4a05-bf6a-b783256a0552/pages/50fa2b65-2f67-4867-ba2b-652f6738676d
 
     Allows to generate labels
 
@@ -237,25 +236,13 @@ class PostlogisticsWebService:
             "printAddresses": "RECIPIENT_AND_CUSTOMER",
             "imageFileType": output_format,
             "imageResolution": image_resolution,
-            "printPreview": False,
+            "printPreview": not picking.carrier_id.prod_environment,
         }
 
     @classmethod
     def _request_access_token(cls, delivery_carrier):
-        if not delivery_carrier.postlogistics_endpoint_url:
-            raise UserError(
-                delivery_carrier.env._(
-                    "Missing Configuration\n\n"
-                    "Please verify postlogistics endpoint url in:\n"
-                    "Delivery Carrier (PostLogistics)."
-                )
-            )
-
         client_id = delivery_carrier.postlogistics_client_id
         client_secret = delivery_carrier.postlogistics_client_secret
-        authentication_url = urllib.parse.urljoin(
-            delivery_carrier.postlogistics_endpoint_url or "", AUTH_PATH
-        )
 
         if not (client_id and client_secret):
             raise UserError(
@@ -267,15 +254,15 @@ class PostlogisticsWebService:
             )
 
         response = requests.post(
-            url=authentication_url,
+            url=AUTH_URL,
             headers={"content-type": "application/x-www-form-urlencoded"},
             data={
                 "grant_type": "client_credentials",
                 "client_id": client_id,
                 "client_secret": client_secret,
-                "scope": "WEDEC_BARCODE_READ",
+                "scope": "DCAPI_BARCODE_READ",
             },
-            timeout=60,
+            timeout=AUTH_TIMEOUT,
         )
 
         try:
@@ -360,18 +347,15 @@ class PostlogisticsWebService:
 
             res = {"value": []}
 
-            generate_label_url = urllib.parse.urljoin(
-                picking_carrier.postlogistics_endpoint_url, GENERATE_LABEL_PATH
-            )
             response = requests.post(
-                url=generate_label_url,
+                url=GENERATE_LABEL_URL,
                 headers={
                     "Authorization": f"Bearer {access_token}",
                     "accept": "application/json",
                     "content-type": "application/json",
                 },
                 data=json.dumps(data),
-                timeout=60,
+                timeout=API_TIMEOUT,
             )
 
             if response.status_code != 200:

--- a/delivery_postlogistics/tests/common.py
+++ b/delivery_postlogistics/tests/common.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from contextlib import contextmanager
 from os.path import dirname, join
+from urllib.parse import urlparse
 
 import requests
 from requests import PreparedRequest, Session
@@ -14,9 +15,12 @@ from odoo.tools.safe_eval import json
 
 from odoo.addons.base.tests.common import BaseCommon
 
-from ..postlogistics.web_service import GENERATE_LABEL_PATH, PostlogisticsWebService
+from ..postlogistics.web_service import (
+    AUTH_URL,
+    GENERATE_LABEL_URL,
+    PostlogisticsWebService,
+)
 
-ENDPOINT_URL = "https://wedecint.post.ch/"
 CLIENT_ID = "XXX"
 CLIENT_SECRET = "XXX"
 LICENSE = "XXX"
@@ -42,7 +46,7 @@ def check_generate_label_body(request, saved_request):
     """
     assert request.path == saved_request.path
 
-    if request.path == GENERATE_LABEL_PATH:
+    if request.path == urlparse(GENERATE_LABEL_URL).path:
         query_json = json.loads(request.body.decode("utf-8"))
         saved_json = json.loads(saved_request.body.decode("utf-8"))
         query_json["item"]["itemID"] = saved_json["item"]["itemID"]
@@ -61,7 +65,7 @@ class TestPostlogisticsCommon(BaseCommon):
     @classmethod
     def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
         # We need to override Odoo check to allow API testing
-        if r.url.startswith(ENDPOINT_URL):
+        if r.url in [AUTH_URL, GENERATE_LABEL_URL]:
             return _super_send(s, r, **kw)
         return super()._request_handler(s, r, **kw)
 
@@ -110,7 +114,6 @@ class TestPostlogisticsCommon(BaseCommon):
                 "name": "Postlogistics",
                 "delivery_type": "postlogistics",
                 "product_id": shipping_product.id,
-                "postlogistics_endpoint_url": ENDPOINT_URL,
                 "postlogistics_client_id": CLIENT_ID,
                 "postlogistics_client_secret": CLIENT_SECRET,
                 "postlogistics_license_id": self.license.id,

--- a/delivery_postlogistics/tests/fixtures/cassettes/test_missing_language.yaml
+++ b/delivery_postlogistics/tests/fixtures/cassettes/test_missing_language.yaml
@@ -1,6 +1,6 @@
 interactions:
   - request:
-      body: scope=WEDEC_BARCODE_READ&client_secret=c70e3696ae5146e7fe317434e50a90cd&grant_type=client_credentials&client_id=865783331e39e91e633c3916fe892d92
+      body: scope=DCAPI_BARCODE_READ&client_secret=c70e3696ae5146e7fe317434e50a90cd&grant_type=client_credentials&client_id=865783331e39e91e633c3916fe892d92
       headers:
         Accept:
           - "*/*"
@@ -15,7 +15,7 @@ interactions:
         content-type:
           - application/x-www-form-urlencoded
       method: POST
-      uri: https://wedecint.post.ch/WEDECOAuth/token
+      uri: https://api.post.ch/OAuth/token
     response:
       body:
         string: '{"access_token":"XXX","token_type":"Bearer","expires_in":60}'
@@ -67,10 +67,11 @@ interactions:
         content-type:
           - application/json
       method: POST
-      uri: https://wedecint.post.ch/api/barcode/v1/generateAddressLabel
+      uri: https://dcapi.apis.post.ch/barcode/v1/generateAddressLabel
     response:
       body:
-        string: "{\n  \"labelDefinition\" : {\n    \"labelLayout\" : \"A6\",\n    \"\
+        string:
+          "{\n  \"labelDefinition\" : {\n    \"labelLayout\" : \"A6\",\n    \"\
           printAddresses\" : \"RECIPIENT_AND_CUSTOMER\",\n    \"imageFileType\" : \"\
           pdf\",\n    \"imageResolution\" : 600,\n    \"printPreview\" : false,\n  \
           \  \"colorPrintRequired\" : true\n  },\n  \"item\" : {\n    \"itemID\" : \"\

--- a/delivery_postlogistics/tests/fixtures/cassettes/test_store_label.yaml
+++ b/delivery_postlogistics/tests/fixtures/cassettes/test_store_label.yaml
@@ -1,6 +1,6 @@
 interactions:
   - request:
-      body: scope=WEDEC_BARCODE_READ&client_secret=c70e3696ae5146e7fe317434e50a90cd&grant_type=client_credentials&client_id=865783331e39e91e633c3916fe892d92
+      body: scope=DCAPI_BARCODE_READ&client_secret=c70e3696ae5146e7fe317434e50a90cd&grant_type=client_credentials&client_id=865783331e39e91e633c3916fe892d92
       headers:
         Accept:
           - "*/*"
@@ -15,7 +15,7 @@ interactions:
         content-type:
           - application/x-www-form-urlencoded
       method: POST
-      uri: https://wedecint.post.ch/WEDECOAuth/token
+      uri: https://api.post.ch/OAuth/token
     response:
       body:
         string: '{"access_token":"XXX","token_type":"Bearer","expires_in":60}'
@@ -67,10 +67,11 @@ interactions:
         content-type:
           - application/json
       method: POST
-      uri: https://wedecint.post.ch/api/barcode/v1/generateAddressLabel
+      uri: https://dcapi.apis.post.ch/barcode/v1/generateAddressLabel
     response:
       body:
-        string: "{\n  \"labelDefinition\" : {\n    \"labelLayout\" : \"A6\",\n    \"\
+        string:
+          "{\n  \"labelDefinition\" : {\n    \"labelLayout\" : \"A6\",\n    \"\
           printAddresses\" : \"RECIPIENT_AND_CUSTOMER\",\n    \"imageFileType\" : \"\
           pdf\",\n    \"imageResolution\" : 600,\n    \"printPreview\" : false,\n  \
           \  \"colorPrintRequired\" : true\n  },\n  \"item\" : {\n    \"itemID\" : \"\

--- a/delivery_postlogistics/tests/fixtures/cassettes/test_token_error.yaml
+++ b/delivery_postlogistics/tests/fixtures/cassettes/test_token_error.yaml
@@ -15,7 +15,7 @@ interactions:
       content-type:
         - application/x-www-form-urlencoded
     method: POST
-    uri: https://wedecint.post.ch/WEDECOAuth/token
+    uri: https://api.post.ch/OAuth/token
   response:
     body:
       string: ''

--- a/delivery_postlogistics/tests/test_postlogistics.py
+++ b/delivery_postlogistics/tests/test_postlogistics.py
@@ -12,20 +12,6 @@ class TestPostlogistics(TestPostlogisticsCommon):
         super().setUp()
         self.picking = self.create_picking()
 
-    def test_misc(self):
-        self.assertFalse(self.carrier.prod_environment)
-        self.carrier.toggle_prod_environment()
-        self.carrier.onchange_prod_environment()
-        self.assertTrue(self.carrier.prod_environment)
-        self.carrier.toggle_prod_environment()
-        self.carrier.onchange_prod_environment()
-        self.assertFalse(self.carrier.prod_environment)
-        self.assertEqual(
-            self.carrier.get_tracking_link(self.picking),
-            "https://service.post.ch/EasyTrack/"
-            "submitParcelData.do?formattedParcelCodes=False",
-        )
-
     def test_prepare_recipient(self):
         partner_id = self.picking.partner_id
         partner_id.is_company = True

--- a/delivery_postlogistics/views/delivery.xml
+++ b/delivery_postlogistics/views/delivery.xml
@@ -15,10 +15,6 @@
                     <group>
                         <group string="Credentials">
                             <field
-                                name="postlogistics_endpoint_url"
-                                required="delivery_type == 'postlogistics'"
-                            />
-                            <field
                                 name="postlogistics_client_id"
                                 required="delivery_type == 'postlogistics'"
                             />


### PR DESCRIPTION
Since 2023, the endpoints for the API have changed:


Deprecated:
Authorization: https://wedec.post.ch/WEDECOAuth/token
Barcode: https://wedec.post.ch/api/barcode/v1/generateAddressLabel

 

New:
Authorization: https://api.post.ch/OAuth/token
Barcode: https://dcapi.apis.post.ch/barcode/v1/generateAddressLabel