### PR TITLE
[18.0][FIX] delivery_dropoff_site: restore partner name search

### DIFF
--- a/delivery_dropoff_site/models/res_partner.py
+++ b/delivery_dropoff_site/models/res_partner.py
@@ -11,7 +11,7 @@ from odoo.fields import first
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
-    _rec_names_search = ["dropoff_site_id"]
+    _rec_names_search = ["name", "dropoff_site_id"]
 
     dropoff_site_ids = fields.One2many(
         comodel_name="dropoff.site", inverse_name="partner_id"

--- a/delivery_dropoff_site/tests/test_delivery_dropoff_site.py
+++ b/delivery_dropoff_site/tests/test_delivery_dropoff_site.py
@@ -216,3 +216,8 @@ class TestDeliveryDropoffSite(BaseCommon):
         order_line = sale_order.order_line[0]
         values = order_line._prepare_procurement_values(None)
         self.assertEqual(values.get("final_shipping_partner_id"), self.customer.id)
+
+    def test_10_name_search_customer(self):
+        """Customer name search must still work on res.partner."""
+        results = self.env["res.partner"].name_search("Test Customer")
+        self.assertIn((self.customer.id, self.customer.display_name), results)


### PR DESCRIPTION
This pull request makes a small but important adjustment to how customer name searches work in the `res.partner` model and adds a related test to ensure the expected behavior. The main changes are:

Improvements to customer name search:

* Updated the `_rec_names_search` attribute in `res.partner.py` to include both `"name"` and `"dropoff_site_id"`, so searches will match on either field.

Testing:

* Added a test (`test_10_name_search_customer`) to verify that searching for a customer by name still works as expected in `res.partner`.