### PR TITLE
[19.0][FIX] delivery_multi_destination: Add uninstall_hook to avoid error when accessing Delivery Methods

### DIFF
--- a/delivery_multi_destination/README.rst
+++ b/delivery_multi_destination/README.rst
@@ -68,8 +68,8 @@ Usage
 Known issues / Roadmap
 ======================
 
-- Delivery prices for e-commerce (website_sale_delivery module) might
-  need an extra module for handling everything properly.
+-  Delivery prices for e-commerce (website_sale_delivery module) might
+   need an extra module for handling everything properly.
 
 Bug Tracker
 ===========
@@ -92,16 +92,16 @@ Authors
 Contributors
 ------------
 
-- \`Tecnativa <https://www.tecnativa.com>\_\_\`:
+-  \`Tecnativa <https://www.tecnativa.com>\_\_\`:
 
-  - Pedro M. Baeza
-  - Luis M. Ontalba
-  - Carlos Roca
-  - Carolina Fernandez
+   -  Pedro M. Baeza
+   -  Luis M. Ontalba
+   -  Carlos Roca
+   -  Carolina Fernandez
 
-- \`Dinamiche Aziendali <https://www.dinamicheaziendali.it>\_\_\`:
+-  \`Dinamiche Aziendali <https://www.dinamicheaziendali.it>\_\_\`:
 
-  - Gianmarco Conte
+   -  Gianmarco Conte
 
 Maintainers
 -----------

--- a/delivery_multi_destination/__init__.py
+++ b/delivery_multi_destination/__init__.py
@@ -1,3 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from . import models
+from .hooks import uninstall_hook

--- a/delivery_multi_destination/__manifest__.py
+++ b/delivery_multi_destination/__manifest__.py
@@ -12,6 +12,7 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
+    "uninstall_hook": "uninstall_hook",
     "depends": ["delivery"],
     "demo": ["demo/delivery_carrier_demo.xml"],
     "data": ["views/delivery_carrier_view.xml"],

--- a/delivery_multi_destination/hooks.py
+++ b/delivery_multi_destination/hooks.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def uninstall_hook(env):
+    # Remove custom data (domain + context)
+    act_window = env.ref("delivery.action_delivery_carrier_form")
+    act_window.write(
+        {
+            "domain": [],
+            "context": {"search_default_group_by_provider": True},
+        }
+    )


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/delivery-carrier/pull/1192

Add uninstall_hook to avoid error when accessing Delivery Methods

Example use case:
- Install stock + delivery_multi_destination
- Uninstall delivery_multi_destination
- An error occurs when accessing Delivery methods because the domain and context data are still defined

Please @pedrobaeza can you review it?

@Tecnativa