### PR TITLE
[18.0][FIX] partner_delivery_zone: Change delivery_zone_id readonly domain

### DIFF
--- a/partner_delivery_zone/views/sale_order_view.xml
+++ b/partner_delivery_zone/views/sale_order_view.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='payment_term_id']" position="after">
-                <field name="delivery_zone_id" readonly="state in ['sale', 'cancel']" />
+                <field name="delivery_zone_id" readonly="state == 'cancel'" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
These changes allows to update the `delivery_zone_id` field when the sales order is in the "sale" status

@sergio-teruel @CarlosRoca13 ping

@Tecnativa
TT62890