### PR TITLE
[18.0][IMP] partner_delivery_schedule: get next reachable departures

### DIFF
--- a/partner_delivery_schedule/README.rst
+++ b/partner_delivery_schedule/README.rst
@@ -28,8 +28,13 @@ Partner Delivery Schedule
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module extends the functionality of delivery module to allow set
-delivery hours and days for partners.
+This module extends the functionality of the delivery module to allow
+setting delivery hours and days for partners.
+
+It also provides a ``get_next_schedule()`` helper on
+``delivery.schedule`` recordsets and on ``res.partner`` to compute the
+next reachable departure, respecting weekday flags, timezone conversions
+and a configurable search horizon set per company.
 
 **Table of contents**
 
@@ -48,6 +53,28 @@ To use this module you need to:
 
 You can set deliveries schedule directly in *Sales > Configuration >
 Delivery Schedule*
+
+To configure the search horizon for the next reachable departure:
+
+1. Go to *Settings > General Settings*.
+2. In the *Delivery Schedule* section, set **Delivery Departure
+   Horizon** to the number of days ahead to look for an available slot
+   (default: 8 days). This setting is per company.
+
+To find the next departure for a partner:
+
+.. code:: python
+
+   schedule, departure = partner.get_next_schedule()
+
+Or on a ``delivery.schedule`` recordset:
+
+.. code:: python
+
+   schedule, departure = schedules.get_next_schedule(
+       from_date=fields.Datetime.now(),
+       tz="Europe/Paris",
+   )
 
 Bug Tracker
 ===========
@@ -75,6 +102,10 @@ Contributors
   - Sergio Teruel
   - Juan Carlos Oñate
 
+- `ACSONE SA/NV <https://www.acsone.eu>`__:
+
+  - Stéphane Mangin stephane.mangin@acsone.eu
+
 Maintainers
 -----------
 
@@ -87,6 +118,14 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-StephaneMangin| image:: https://github.com/StephaneMangin.png?size=40px
+    :target: https://github.com/StephaneMangin
+    :alt: StephaneMangin
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-StephaneMangin| 
 
 This module is part of the `OCA/delivery-carrier <https://github.com/OCA/delivery-carrier/tree/18.0/partner_delivery_schedule>`_ project on GitHub.
 

--- a/partner_delivery_schedule/__manifest__.py
+++ b/partner_delivery_schedule/__manifest__.py
@@ -3,11 +3,12 @@
 {
     "name": "Partner Delivery Schedule",
     "summary": "Set on partners a schedule for delivery goods",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.1.0",
     "development_status": "Production/Stable",
     "category": "Delivery",
     "website": "https://github.com/OCA/delivery-carrier",
     "author": "Tecnativa, Odoo Community Association (OCA)",
+    "maintainers": ["StephaneMangin"],
     "license": "AGPL-3",
     "application": False,
     "installable": True,
@@ -16,6 +17,7 @@
         "security/ir.model.access.csv",
         "views/partner_delivery_schedule_view.xml",
         "views/res_partner_view.xml",
+        "views/res_config_settings_views.xml",
         "views/report_shipping.xml",
     ],
 }

--- a/partner_delivery_schedule/models/__init__.py
+++ b/partner_delivery_schedule/models/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import partner_delivery_schedule
+from . import res_company
+from . import res_config_settings
 from . import res_partner

--- a/partner_delivery_schedule/models/partner_delivery_schedule.py
+++ b/partner_delivery_schedule/models/partner_delivery_schedule.py
@@ -1,5 +1,9 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from datetime import datetime, timedelta
+
+import pytz
+
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -39,7 +43,6 @@ class DeliverySchedule(models.Model):
         "monday",
         "tuesday",
         "wednesday",
-        "wednesday",
         "thursday",
         "friday",
         "saturday",
@@ -50,7 +53,6 @@ class DeliverySchedule(models.Model):
             raise ValidationError(
                 self.env._("Error ! You must set one day to delivery.")
             )
-        return True
 
     def _days_of_week(self):
         return [
@@ -87,3 +89,53 @@ class DeliverySchedule(models.Model):
                 else self.env._("All days")
             )
             schedule.display_name = f"{hour_from}-{hour_to} ({days})"
+
+    def get_next_schedule(self, from_date=None, tz=None, horizon=None):
+        """Return the closiest schedule and departure datetime from date.
+
+        :param from_date: UTC-naive datetime anchor; defaults to now()
+        :param tz: IANA timezone string for local-time conversion
+        :param horizon: days ahead to search; defaults to company setting
+        """
+        pairs = self._scheduled_departures(from_date=from_date, tz=tz, horizon=horizon)
+        if not pairs:
+            return self.env["delivery.schedule"], False
+        return pairs[0]
+
+    def _scheduled_departures(self, from_date=None, tz=None, horizon=None):
+        """All (schedule, UTC-naive departure) pairs within horizon days, sorted.
+
+        Only departures strictly after from_date are included.
+        DST (Daylight Saving Time) transitions are handled correctly.
+
+        :param from_date: UTC-naive datetime anchor; defaults to now()
+        :param tz: IANA timezone string for local-time conversion
+        :param horizon: days ahead to search; defaults to company setting
+        """
+        if not from_date:
+            from_date = fields.Datetime.now()
+        if not horizon:
+            horizon = self.env.company.delivery_schedule_departure_horizon
+        if not tz:
+            tz = self.env.user.tz or self.env.company.tz or "UTC"
+        local_zone = pytz.timezone(tz)
+        local_reference = pytz.utc.localize(from_date).astimezone(local_zone)
+        candidates = []
+        for day_offset in range(horizon):
+            local_date = (local_reference + timedelta(days=day_offset)).date()
+            for schedule in self:
+                weekday_field = schedule._days_of_week()[local_date.weekday()][0]
+                if not schedule[weekday_field]:
+                    continue
+                local_naive = datetime(
+                    local_date.year, local_date.month, local_date.day
+                ) + timedelta(hours=schedule.hour_from)
+                departure = (
+                    local_zone.localize(local_naive)
+                    .astimezone(pytz.utc)
+                    .replace(tzinfo=None)
+                )
+                if departure > from_date:
+                    candidates.append((schedule, departure))
+        candidates.sort(key=lambda pair: pair[1])
+        return candidates

--- a/partner_delivery_schedule/models/res_company.py
+++ b/partner_delivery_schedule/models/res_company.py
@@ -1,0 +1,24 @@
+# Copyright 2026 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    delivery_schedule_departure_horizon = fields.Integer(
+        string="Delivery Departure Horizon (days)",
+        default=8,
+        help="Number of days ahead to search for the next reachable "
+        "departure when using delivery schedules.",
+    )
+
+    @api.constrains("delivery_schedule_departure_horizon")
+    def _check_departure_horizon(self):
+        for company in self:
+            if company.delivery_schedule_departure_horizon < 1:
+                raise ValidationError(
+                    self.env._("Delivery departure horizon must be at least 1 day.")
+                )

--- a/partner_delivery_schedule/models/res_config_settings.py
+++ b/partner_delivery_schedule/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright 2026 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    delivery_schedule_departure_horizon = fields.Integer(
+        related="company_id.delivery_schedule_departure_horizon",
+        readonly=False,
+        string="Delivery Departure Horizon (days)",
+    )

--- a/partner_delivery_schedule/models/res_partner.py
+++ b/partner_delivery_schedule/models/res_partner.py
@@ -30,3 +30,20 @@ class ResPartner(models.Model):
             )
         )
         return bool(delivery_records)
+
+    def get_next_schedule(self, from_date=None, tz=None, horizon=None):
+        """Next reachable (schedule, departure) for this partner.
+
+        Only departures strictly after from_date are included.
+        DST (Daylight Saving Time) transitions are handled correctly.
+
+        :param from_date: UTC-naive datetime anchor; defaults to now()
+        :param tz: IANA timezone string for local-time conversion
+        :param horizon: days ahead to search; defaults to company setting
+        """
+        self.ensure_one()
+        return self.delivery_schedule_ids.get_next_schedule(
+            from_date=from_date,
+            tz=tz or self.env.user.tz or self.env.company.tz,
+            horizon=horizon,
+        )

--- a/partner_delivery_schedule/readme/CONTRIBUTORS.md
+++ b/partner_delivery_schedule/readme/CONTRIBUTORS.md
@@ -1,3 +1,5 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Sergio Teruel
   - Juan Carlos Oñate
+- [ACSONE SA/NV](https://www.acsone.eu):
+  - Stéphane Mangin <stephane.mangin@acsone.eu>

--- a/partner_delivery_schedule/readme/DESCRIPTION.md
+++ b/partner_delivery_schedule/readme/DESCRIPTION.md
@@ -1,2 +1,7 @@
-This module extends the functionality of delivery module to allow set
+This module extends the functionality of the delivery module to allow setting
 delivery hours and days for partners.
+
+It also provides a ``get_next_schedule()`` helper on ``delivery.schedule``
+recordsets and on ``res.partner`` to compute the next reachable departure,
+respecting weekday flags, timezone conversions and a configurable search
+horizon set per company.

--- a/partner_delivery_schedule/readme/USAGE.md
+++ b/partner_delivery_schedule/readme/USAGE.md
@@ -8,3 +8,25 @@ To use this module you need to:
 
 You can set deliveries schedule directly in *Sales \> Configuration \>
 Delivery Schedule*
+
+To configure the search horizon for the next reachable departure:
+
+1.  Go to *Settings \> General Settings*.
+2.  In the *Delivery Schedule* section, set **Delivery Departure Horizon**
+    to the number of days ahead to look for an available slot
+    (default: 8 days). This setting is per company.
+
+To find the next departure for a partner:
+
+```python
+schedule, departure = partner.get_next_schedule()
+```
+
+Or on a ``delivery.schedule`` recordset:
+
+```python
+schedule, departure = schedules.get_next_schedule(
+    from_date=fields.Datetime.now(),
+    tz="Europe/Paris",
+)
+```

--- a/partner_delivery_schedule/static/description/index.html
+++ b/partner_delivery_schedule/static/description/index.html
@@ -370,8 +370,12 @@ ul.auto-toc {
 !! source digest: sha256:ceb07d2721421b23b565628586b1951b29235fe1b586bb5945f426fed001babf
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/delivery-carrier/tree/18.0/partner_delivery_schedule"><img alt="OCA/delivery-carrier" src="https://img.shields.io/badge/github-OCA%2Fdelivery--carrier-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/delivery-carrier-18-0/delivery-carrier-18-0-partner_delivery_schedule"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/delivery-carrier&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module extends the functionality of delivery module to allow set
-delivery hours and days for partners.</p>
+<p>This module extends the functionality of the delivery module to allow
+setting delivery hours and days for partners.</p>
+<p>It also provides a <tt class="docutils literal">get_next_schedule()</tt> helper on
+<tt class="docutils literal">delivery.schedule</tt> recordsets and on <tt class="docutils literal">res.partner</tt> to compute the
+next reachable departure, respecting weekday flags, timezone conversions
+and a configurable search horizon set per company.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -396,6 +400,24 @@ field.</li>
 </ol>
 <p>You can set deliveries schedule directly in <em>Sales &gt; Configuration &gt;
 Delivery Schedule</em></p>
+<p>To configure the search horizon for the next reachable departure:</p>
+<ol class="arabic simple">
+<li>Go to <em>Settings &gt; General Settings</em>.</li>
+<li>In the <em>Delivery Schedule</em> section, set <strong>Delivery Departure
+Horizon</strong> to the number of days ahead to look for an available slot
+(default: 8 days). This setting is per company.</li>
+</ol>
+<p>To find the next departure for a partner:</p>
+<pre class="code python literal-block">
+<span class="n">schedule</span><span class="p">,</span> <span class="n">departure</span> <span class="o">=</span> <span class="n">partner</span><span class="o">.</span><span class="n">get_next_schedule</span><span class="p">()</span>
+</pre>
+<p>Or on a <tt class="docutils literal">delivery.schedule</tt> recordset:</p>
+<pre class="code python literal-block">
+<span class="n">schedule</span><span class="p">,</span> <span class="n">departure</span> <span class="o">=</span> <span class="n">schedules</span><span class="o">.</span><span class="n">get_next_schedule</span><span class="p">(</span><span class="w">
+</span>    <span class="n">from_date</span><span class="o">=</span><span class="n">fields</span><span class="o">.</span><span class="n">Datetime</span><span class="o">.</span><span class="n">now</span><span class="p">(),</span><span class="w">
+</span>    <span class="n">tz</span><span class="o">=</span><span class="s2">&quot;Europe/Paris&quot;</span><span class="p">,</span><span class="w">
+</span><span class="p">)</span>
+</pre>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
@@ -421,6 +443,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Juan Carlos Oñate</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.acsone.eu">ACSONE SA/NV</a>:<ul>
+<li>Stéphane Mangin <a class="reference external" href="mailto:stephane.mangin&#64;acsone.eu">stephane.mangin&#64;acsone.eu</a></li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
@@ -432,6 +458,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/StephaneMangin"><img alt="StephaneMangin" src="https://github.com/StephaneMangin.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/delivery-carrier/tree/18.0/partner_delivery_schedule">OCA/delivery-carrier</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/partner_delivery_schedule/tests/__init__.py
+++ b/partner_delivery_schedule/tests/__init__.py
@@ -1,2 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import common
 from . import test_partner_delivery_schedule
+from . import test_get_next_schedule

--- a/partner_delivery_schedule/tests/common.py
+++ b/partner_delivery_schedule/tests/common.py
@@ -1,0 +1,60 @@
+# Copyright 2026 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class DeliveryScheduleCommon(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Force user timezone to UTC so test assertions on departure hours are
+        # environment-independent (get_next_schedule uses env.user.tz first).
+        cls.env.user.tz = "UTC"
+        cls._setup_schedules()
+        cls._setup_partners()
+
+    @classmethod
+    def _setup_schedules(cls):
+        Schedule = cls.env["delivery.schedule"]
+        cls.schedule_8h = Schedule.create(
+            {
+                "name": "08h00",
+                "hour_from": 8.0,
+                "hour_to": 10.0,
+            }
+        )
+        cls.schedule_14h = Schedule.create(
+            {
+                "name": "14h00",
+                "hour_from": 14.0,
+                "hour_to": 16.0,
+            }
+        )
+        cls.schedule_sat = Schedule.create(
+            {
+                "name": "Saturday",
+                "hour_from": 9.0,
+                "hour_to": 12.0,
+                "monday": False,
+                "tuesday": False,
+                "wednesday": False,
+                "thursday": False,
+                "friday": False,
+                "saturday": True,
+                "sunday": False,
+            }
+        )
+
+    @classmethod
+    def _setup_partners(cls):
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "tz": "UTC",
+                "delivery_schedule_ids": [
+                    (4, cls.schedule_8h.id),
+                    (4, cls.schedule_14h.id),
+                ],
+            }
+        )

--- a/partner_delivery_schedule/tests/test_get_next_schedule.py
+++ b/partner_delivery_schedule/tests/test_get_next_schedule.py
@@ -1,0 +1,89 @@
+# Copyright 2026 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from freezegun import freeze_time
+
+from odoo.tests import tagged
+
+from .common import DeliveryScheduleCommon
+
+# Reference date: Wednesday 2026-06-17, 07:00 UTC
+# - schedule_8h  opens at 08:00 Mon-Fri  → reachable today at 08:00 UTC
+# - schedule_14h opens at 14:00 Mon-Fri  → reachable today at 14:00 UTC
+# - schedule_sat opens at 09:00 Sat only → next occurrence: 2026-06-20
+
+
+@tagged("post_install", "-at_install")
+class TestGetNextSchedule(DeliveryScheduleCommon):
+    @freeze_time("2026-06-17 07:00:00")
+    def test_earliest_slot_is_returned(self):
+        """Before 08:00, the 08:00 slot wins over 14:00."""
+        schedule, departure = (self.schedule_8h | self.schedule_14h).get_next_schedule()
+        self.assertEqual(schedule, self.schedule_8h)
+        self.assertEqual(departure.hour, 8)
+
+    @freeze_time("2026-06-17 10:00:00")
+    def test_past_slot_is_skipped(self):
+        """At 10:00, the 08:00 slot is in the past; 14:00 is returned."""
+        schedule, departure = (self.schedule_8h | self.schedule_14h).get_next_schedule()
+        self.assertEqual(schedule, self.schedule_14h)
+        self.assertEqual(departure.hour, 14)
+
+    @freeze_time("2026-06-17 07:00:00")
+    def test_timezone_shifts_opening_hours(self):
+        """08:00 Paris (CEST +2) = 06:00 UTC, already past at 07:00 UTC.
+        So 14:00 Paris = 12:00 UTC is the next reachable slot.
+        """
+        schedule, departure = (self.schedule_8h | self.schedule_14h).get_next_schedule(
+            tz="Europe/Paris"
+        )
+        self.assertEqual(schedule, self.schedule_14h)
+        self.assertEqual(departure.hour, 12)
+
+    def test_empty_recordset_returns_false(self):
+        """No schedules → no departure."""
+        schedule, departure = self.env["delivery.schedule"].get_next_schedule()
+        self.assertFalse(schedule)
+        self.assertFalse(departure)
+
+    @freeze_time("2026-06-17 07:00:00")
+    def test_closed_day_jumps_to_next_open_day(self):
+        """Saturday schedule skips Wed/Thu/Fri; next slot is Saturday 2026-06-20."""
+        # Wed 17 → Thu 18 → Fri 19 → Sat 20 (first open day)
+        schedule, departure = self.schedule_sat.get_next_schedule()
+        self.assertEqual(schedule, self.schedule_sat)
+        self.assertEqual(departure.day, 20)  # Saturday 2026-06-20
+        self.assertEqual(departure.hour, 9)  # opens at 09:00 UTC
+
+    @freeze_time("2026-06-17 07:00:00")
+    def test_horizon_too_short_returns_false(self):
+        """Horizon limits the search window: Saturday (offset 3) is out of range(2).
+
+        Default horizon is 8 days (company setting). Passing horizon=2 means
+        only Wed 17 (offset 0) and Thu 18 (offset 1) are checked — no Saturday.
+        """
+        schedule, departure = self.schedule_sat.get_next_schedule(horizon=2)
+        self.assertFalse(schedule)
+        self.assertFalse(departure)
+
+    @freeze_time("2026-06-17 07:00:00")
+    def test_partner_only_searches_its_own_schedules(self):
+        """Partner.get_next_schedule() is bounded by partner.delivery_schedule_ids.
+
+        self.partner has schedule_8h and schedule_14h, but NOT schedule_sat.
+        Even if schedule_sat exists in the system, it must never be returned
+        for this partner — only its explicitly assigned schedules are candidates.
+        """
+        # Sanity check: schedule_sat is not assigned to this partner
+        self.assertNotIn(self.schedule_sat, self.partner.delivery_schedule_ids)
+
+        schedule, departure = self.partner.get_next_schedule()
+        self.assertEqual(schedule, self.schedule_8h)
+
+    @freeze_time("2026-06-17 07:00:00")
+    def test_company_horizon_is_the_default(self):
+        """When horizon is not passed explicitly, the company setting is used."""
+        self.env.company.delivery_schedule_departure_horizon = 2
+        # Saturday is 3 days away — outside the company horizon of 2
+        _, departure = self.schedule_sat.get_next_schedule()
+        self.assertFalse(departure)

--- a/partner_delivery_schedule/tests/test_partner_delivery_schedule.py
+++ b/partner_delivery_schedule/tests/test_partner_delivery_schedule.py
@@ -3,43 +3,14 @@
 from odoo.exceptions import ValidationError
 from odoo.tests import Form
 
-from odoo.addons.base.tests.common import BaseCommon
+from .common import DeliveryScheduleCommon
 
 
-class TestStockPikingReturnRefundOption(BaseCommon):
+class TestPartnerDeliverySchedule(DeliveryScheduleCommon):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.schedule = cls.env["delivery.schedule"].create(
-            {
-                "name": "test",
-                "hour_from": 8,
-                "hour_to": 10,
-                "monday": True,
-                "tuesday": True,
-                "wednesday": False,
-                "thursday": False,
-                "friday": False,
-            }
-        )
-        cls.schedule2 = cls.env["delivery.schedule"].create(
-            {
-                "name": "test2",
-                "hour_from": 10,
-                "hour_to": 12,
-                "monday": True,
-                "tuesday": True,
-                "wednesday": False,
-                "thursday": False,
-                "friday": False,
-            }
-        )
-        cls.partner = cls.env["res.partner"].create(
-            {
-                "name": "test",
-                "delivery_schedule_ids": [(6, 0, cls.schedule.ids + cls.schedule2.ids)],
-            }
-        )
+    def _setup_partners(cls):
+        res = super()._setup_partners()
+        # Extra fixtures needed for report tests only
         cls.report_model = cls.env["ir.actions.report"]
         cls.product = cls.env["product.product"].create(
             {"name": "Test product", "type": "consu", "is_storable": True}
@@ -47,6 +18,7 @@ class TestStockPikingReturnRefundOption(BaseCommon):
         cls.order = cls._create_sale_order(cls)
         cls.order.action_confirm()
         cls.picking = cls.order.picking_ids[0]
+        return res
 
     def _create_sale_order(self):
         order_form = Form(self.env["sale.order"])
@@ -57,30 +29,27 @@ class TestStockPikingReturnRefundOption(BaseCommon):
         return order_form.save()
 
     def test_partner_schedule_name(self):
-        self.assertEqual(self.schedule.display_name, "08:00-10:00 (Mo, Tu)")
-        day_update = {}
-        for day in self.schedule._days_of_week():
-            day_update[day[0]] = True
-        self.schedule.update(day_update)
-        self.assertEqual(self.schedule.display_name, "08:00-10:00 (All days)")
+        self.assertEqual(
+            self.schedule_8h.display_name, "08:00-10:00 (Mo, Tu, We, Th, Fr)"
+        )
+        day_update = {day[0]: True for day in self.schedule_8h._days_of_week()}
+        self.schedule_8h.update(day_update)
+        self.assertEqual(self.schedule_8h.display_name, "08:00-10:00 (All days)")
         with self.assertRaises(ValidationError):
-            self.schedule.update({"hour_from": 0, "hour_to": 25})
-        day_update = {}
-        for day in self.schedule._days_of_week():
-            day_update[day[0]] = False
+            self.schedule_8h.update({"hour_from": 0, "hour_to": 25})
+        day_update = {day[0]: False for day in self.schedule_8h._days_of_week()}
         with self.assertRaises(ValidationError):
-            self.schedule.update(day_update)
+            self.schedule_8h.update(day_update)
 
     def test_partner_allow_delivery(self):
+        # partner has schedule_8h (08:00-10:00) and schedule_14h (14:00-16:00), Mon-Fri
         self.assertTrue(self.partner.allow_delivery_date("2018-09-03 09:00:00"))
         self.assertTrue(self.partner.allow_delivery_date("2018-09-04 09:00:00"))
         self.assertFalse(self.partner.allow_delivery_date("2018-09-04 12:01:00"))
         self.assertFalse(self.partner.allow_delivery_date("2018-09-05 10:01:00"))
-        # Allow delivery in all days
-        day_update = {}
-        for day in self.schedule._days_of_week():
-            day_update[day[0]] = True
-        self.schedule.update(day_update)
+        # Allow delivery on all days
+        day_update = {day[0]: True for day in self.schedule_8h._days_of_week()}
+        self.schedule_8h.update(day_update)
         self.assertTrue(self.partner.allow_delivery_date("2018-09-09 09:00:00"))
 
     def test_report_picking(self):
@@ -88,11 +57,11 @@ class TestStockPikingReturnRefundOption(BaseCommon):
             "stock.report_picking", self.picking.ids, False
         )
         self.assertRegex(str(res[0]), "08:00-10:00")
-        self.assertRegex(str(res[0]), "10:00-12:00")
+        self.assertRegex(str(res[0]), "14:00-16:00")
 
     def test_report_deliveryslip(self):
         res = self.report_model._render_qweb_html(
             "stock.report_deliveryslip", self.picking.ids, False
         )
         self.assertRegex(str(res[0]), "08:00-10:00")
-        self.assertRegex(str(res[0]), "10:00-12:00")
+        self.assertRegex(str(res[0]), "14:00-16:00")

--- a/partner_delivery_schedule/views/report_shipping.xml
+++ b/partner_delivery_schedule/views/report_shipping.xml
@@ -10,9 +10,9 @@
                     t-value="o.partner_id if o.partner_id.type == 'delivery' else o.partner_id.commercial_partner_id"
                 />
                 <strong>Delivery Schedule</strong>
-                <t t-foreach="partner.delivery_schedule_ids" t-as="horary">
+                <t t-foreach="partner.delivery_schedule_ids" t-as="schedule">
                     <div>
-                        <span t-field="horary.display_name" />
+                        <span t-field="schedule.display_name" />
                     </div>
                 </t>
             </div>
@@ -29,9 +29,9 @@
                     t-value="o.partner_id if o.partner_id.type == 'delivery' else o.partner_id.commercial_partner_id"
                 />
                 <strong>Delivery Schedule</strong>
-                <t t-foreach="partner.delivery_schedule_ids" t-as="horary">
+                <t t-foreach="partner.delivery_schedule_ids" t-as="schedule">
                     <div>
-                        <span t-field="horary.display_name" />
+                        <span t-field="schedule.display_name" />
                     </div>
                 </t>
             </div>

--- a/partner_delivery_schedule/views/res_config_settings_views.xml
+++ b/partner_delivery_schedule/views/res_config_settings_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.delivery.schedule</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@id='stock_move_email']" position="after">
+                <setting
+                    id="delivery_schedule_departure_horizon"
+                    string="Departure Search Horizon"
+                    help="Number of days ahead to search for the next reachable departure."
+                    groups="base.group_system"
+                >
+                    <field name="delivery_schedule_departure_horizon" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adding some helper method behaviors to manage next schedule search:

- Find the next delivery slot from a partner or a schedule set, respecting weekday restrictions and timezones (DST-safe)
- Configure a search horizon in days per company in General Settings (still available in parameters for customisation)
- Include some minor tests refactoring and variables renaming

Part of a set of modules that will need this search behavior, next incoming PR
 - https://github.com/OCA/delivery-carrier/pull/1208