### PR TITLE
[18.0]FIX] delivery_ups_oca: Map country codes for Ceuta and Melilla correctly

### DIFF
--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -167,9 +167,20 @@ class UpsRequest:
                 City=partner.city,
                 StateProvinceCode=partner.state_id.code,
                 PostalCode=partner.zip,
-                CountryCode=partner.country_id.code,
+                CountryCode=self._get_country_code(partner),
             ),
         )
+
+    def _get_country_code(self, partner):
+        country_code = partner.country_id.code
+        # The UPS API expects the country code to be XC for Ceuta and XL for Melilla
+        special_state_codes = {"CE": "XC", "ME": "XL"}
+        if (
+            partner.country_id.code == "ES"
+            and partner.state_id.code in special_state_codes
+        ):
+            country_code = special_state_codes[partner.state_id.code]
+        return country_code
 
     def _label_data(self):
         # When PDF is selected,


### PR DESCRIPTION
The UPS API expects the country code to be `XC` for `Ceuta` and `XL` for `Melilla`. Map these values accordingly to prevent error `128400: The destination postal code dest.postal is not a valid dest.country postal code.`

<img width="1147" height="642" alt="image" src="https://github.com/user-attachments/assets/d5f985b5-a55d-4d73-b852-8913a2b116b3" />
<img width="1147" height="642" alt="image" src="https://github.com/user-attachments/assets/314b2efd-3a97-42b7-a5c5-98e7e2755a5e" />

TT63454
@Tecnativa @pedrobaeza @carlosdauden could you please review this?