### PR TITLE
[17.0][FIX] delivery_sendcloud_oca: fix test failure due to new Sendcloud API error format

### DIFF
--- a/delivery_sendcloud_oca/tests/test_delivery_sendcloud_oca.py
+++ b/delivery_sendcloud_oca/tests/test_delivery_sendcloud_oca.py
@@ -507,9 +507,13 @@ class TestDeliverySendCloud(TransactionCase):
             sale_order.picking_ids.cancel_shipment()["xml_id"],
             "delivery_sendcloud_oca.sendcloud_cancel_shipment_confirm_wizard",
         )
-        with self.assertRaisesRegex(UserError, "Sendcloud: Invalid username/password"):
+        err_msg = (
+            "(?s)Sendcloud: (Invalid username/password|"
+            ".*[Aa]ccess credentials.*|.*invalid_client.*)"
+        )
+        with self.assertRaisesRegex(UserError, err_msg):
             sale_order.action_cancel()
-        with self.assertRaisesRegex(UserError, "Sendcloud: Invalid username/password"):
+        with self.assertRaisesRegex(UserError, err_msg):
             sale_order.button_delete_sendcloud_order()
         sendcloud_cancel_shipment_confirm_wizard_form = Form(
             self.env["sendcloud.cancel.shipment.confirm.wizard"].with_context(
@@ -524,11 +528,11 @@ class TestDeliverySendCloud(TransactionCase):
         )
         with recorder.use_cassette("cancel_parcel"):
             sendcloud_cancel_shipment_confirm_wizard_form.do_cancel_shipment()
-        with self.assertRaisesRegex(UserError, "Sendcloud: Invalid username/password"):
+        with self.assertRaisesRegex(UserError, err_msg):
             sale_order.picking_ids.button_delete_sendcloud_picking()
-        with self.assertRaisesRegex(UserError, "Sendcloud: Invalid username/password"):
+        with self.assertRaisesRegex(UserError, err_msg):
             sale_order.picking_ids.action_cancel()
-        with self.assertRaisesRegex(UserError, "Sendcloud: Invalid username/password"):
+        with self.assertRaisesRegex(UserError, err_msg):
             sale_order.picking_ids.unlink()
 
     @mute_logger("py.warnings")


### PR DESCRIPTION
This PR fixes the failure in test_10_auto_create_invoice, which incorrectly asserts Sendcloud API authentication errors.
The issue is causing the CI failures in these PRs: https://github.com/OCA/delivery-carrier/pull/959, https://github.com/OCA/delivery-carrier/pull/951, https://github.com/OCA/delivery-carrier/pull/950
### What happened:
The live Sendcloud API recently updated the error response structure when invalid credentials are used, returning a multiline message. Since the test assertions were using regex matching without the DOTALL flag (`(?s)`), they failed to match the multiline output.
### Fix:
Updated the `assertRaisesRegex` patterns in `test_delivery_sendcloud_oca.py` to use `(?s)` so they can match across newlines and support the new API error format.