### PR TITLE
[19.0][IMP] delivery_purchase: Automatically create a delivery line in a PO only if there is a context key in tests

### DIFF
--- a/delivery_purchase/models/stock_picking.py
+++ b/delivery_purchase/models/stock_picking.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Tecnativa - Ernesto Tejeda
+# Copyright 2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
+from odoo.tools import config
 
 
 class StockPicking(models.Model):
@@ -42,7 +44,10 @@ class StockPicking(models.Model):
 
     def _add_delivery_cost_to_po(self):
         self.ensure_one()
-        if self.purchase_id and self.carrier_price:
+        test_condition = not config["test_enable"] or (
+            config["test_enable"] and self.env.context.get("test_delivery_purchase")
+        )
+        if self.purchase_id and self.carrier_price and test_condition:
             carrier_price = self.carrier_price
             # Re-set carrier price
             if self.carrier_id.invoice_policy == "real":

--- a/delivery_purchase/tests/test_delivery_purchase.py
+++ b/delivery_purchase/tests/test_delivery_purchase.py
@@ -11,6 +11,7 @@ class TestDeliveryPurchaseBase(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, test_delivery_purchase=True))
         cls.delivery_product = cls.env["product.product"].create(
             {"name": "Delivery test product"}
         )


### PR DESCRIPTION
Automatically create a delivery line in a PO only if there is a context key in tests

A specific context is defined so that, during tests, a delivery line is created in the PO only when validating the picking, if it is set.

Since `delivery` is installed, a default carrier is automatically set for newly created partners (https://github.com/odoo/odoo/blob/3a5f7431effd4b2b2eb8ce3eed81aaba42fcd8ea/addons/delivery/data/delivery_demo.xml#L66), which causes a carrier to be set in the PO, and when the picking is done, an extra line is automatically created in the PO, resulting in incorrect values in the tests

Related to https://github.com/OCA/stock-logistics-workflow/pull/2407#issue-4949061344

@Tecnativa