### PR TITLE
[18.0][FIX] delivery_ups_oca: guard package weight against zero packages

### DIFF
--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -236,7 +236,7 @@ class UpsRequest:
                 self.default_packaging_id, picking, False
             )
             package_weight = round(
-                (picking.shipping_weight / picking.number_of_packages), 2
+                (picking.shipping_weight / (picking.number_of_packages or 1)), 2
             )
             for i in range(0, picking.number_of_packages):
                 package_item = package_info.copy()

--- a/delivery_ups_oca/tests/test_delivery_ups.py
+++ b/delivery_ups_oca/tests/test_delivery_ups.py
@@ -840,6 +840,20 @@ class TestDeliveryUps(TestDeliveryUpsBase):
             self.assertEqual(package["PackageWeight"]["Weight"], "10.0")  # 30/3 = 10
             self.assertEqual(package["Packaging"]["Code"], "02")
 
+    def test_ups_prepare_create_shipping_zero_packages(self):
+        """Guard against ZeroDivisionError when number_of_packages is 0."""
+        self.carrier.ups_use_packages_from_picking = False
+        ups_request = UpsRequest(self.carrier)
+        self.picking.name = "TEST0007"
+        self.picking.shipping_weight = 12.0
+        self.picking.number_of_packages = 0
+        # Must not raise ZeroDivisionError and must still build the request
+        result = ups_request._prepare_create_shipping(self.picking)
+        shipment = result["ShipmentRequest"]["Shipment"]
+        # range(0, 0) yields no packages, but the request is built successfully
+        self.assertEqual(shipment["Package"], [])
+        self.assertEqual(shipment["Service"]["Code"], "11")
+
     def test_ups_prepare_create_shipping_with_cash_on_delivery(self):
         """Test _prepare_create_shipping with cash on delivery"""
         # Enable cash on delivery


### PR DESCRIPTION
When a picking is shipped without using packages from the picking (ups_use_packages_from_picking disabled) and its number_of_packages is 0, computing the per-package weight as shipping_weight / number_of_packages raised a ZeroDivisionError. Fall back to the total shipping_weight in that case so the shipment request can still be built.