### PR TITLE
[18.0][FIX] delivery_ups_oca: add HTTP request timeout

### DIFF
--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -47,10 +47,17 @@ class UpsRequest:
                 raise UserError(msg)
 
     def _send_request(
-        self, url, json=None, data=None, headers=None, method="post", auth=None
+        self,
+        url,
+        json=None,
+        data=None,
+        headers=None,
+        method="post",
+        auth=None,
+        timeout=None,
     ):
         return getattr(requests, method)(
-            url, data=data, json=json, headers=headers, auth=auth
+            url, data=data, json=json, headers=headers, auth=auth, timeout=timeout
         )
 
     def _get_new_token(self):
@@ -84,6 +91,7 @@ class UpsRequest:
         data=None,
         method="post",
         headers_extra=None,
+        timeout=10,
     ):
         if (
             not self.token
@@ -97,12 +105,14 @@ class UpsRequest:
         }
         if headers_extra:
             headers = {**headers, **headers_extra}
-        status = self._send_request(url, json, data, headers, method)
+        status = self._send_request(url, json, data, headers, method, timeout=timeout)
         # Generate a new token
         if status.status_code == 401:
             self._get_new_token()
             headers["Authorization"] = f"Bearer {self.token}"
-            status = self._send_request(url, json, data, headers, method)
+            status = self._send_request(
+                url, json, data, headers, method, timeout=timeout
+            )
         status = status.json()
         ups_last_request = f"URL: {self.url}\nData: {data}\nJSON: {json}"
         self.carrier.log_xml(ups_last_request, "ups_last_request")

--- a/delivery_ups_oca/tests/test_delivery_ups.py
+++ b/delivery_ups_oca/tests/test_delivery_ups.py
@@ -716,6 +716,23 @@ class TestDeliveryUps(TestDeliveryUpsBase):
                 self.assertEqual(result, {"success": True, "data": "test_data"})
                 self.assertEqual(mock_log.call_count, 2)
 
+    def test_send_request_passes_timeout(self):
+        """The timeout must be forwarded to the underlying requests call."""
+        ups_request = UpsRequest(self.carrier)
+        mock_response = mock.Mock()
+        with mock.patch(
+            "odoo.addons.delivery_ups_oca.models.ups_request.requests"
+        ) as mock_requests:
+            mock_requests.post.return_value = mock_response
+            result = ups_request._send_request(
+                "https://api.test.com/endpoint",
+                json={"key": "value"},
+                timeout=10,
+            )
+        self.assertEqual(result, mock_response)
+        mock_requests.post.assert_called_once()
+        self.assertEqual(mock_requests.post.call_args.kwargs["timeout"], 10)
+
     def test_ups_prepare_create_shipping_with_packages(self):
         """Test _prepare_create_shipping with packages from picking"""
         # Enable use packages from picking


### PR DESCRIPTION
Pass a 10s timeout to the requests calls so a hung or slow UPS endpoint no longer blocks the Odoo worker indefinitely.