### PR TITLE
[18.0][IMP] delivery_ups_oca: add debug logging

### DIFF
--- a/delivery_ups_oca/models/ups_request.py
+++ b/delivery_ups_oca/models/ups_request.py
@@ -72,10 +72,22 @@ class UpsRequest:
         url = f"{self.url}/security/v1/oauth/token"
         headers = {"x-merchant-id": self.client_id}
         data = {"grant_type": "client_credentials"}
+        _logger.debug(
+            "UPS Token Request: URL=%s, Headers=%s, Data=%s", url, headers, data
+        )
         status = self._send_request(
             url, data=data, headers=headers, auth=(self.client_id, self.client_secret)
         )
+        status_code = status.status_code
         status = status.json()
+        debug_response = status.copy() if isinstance(status, dict) else status
+        if isinstance(debug_response, dict) and "access_token" in debug_response:
+            debug_response["access_token"] = "***MASKED***"
+        _logger.debug(
+            "UPS Token Response: Status=%s, Content=%s",
+            status_code,
+            debug_response,
+        )
         self._raise_for_status(status, False)
         token = status.get("access_token")
         self.token = token
@@ -106,15 +118,26 @@ class UpsRequest:
         }
         if headers_extra:
             headers = {**headers, **headers_extra}
+        debug_headers = {**headers, "Authorization": "***MASKED***"}
+        _logger.debug(
+            "UPS Request: URL=%s, Method=%s, Headers=%s, Body=%s",
+            url,
+            method,
+            debug_headers,
+            json or data,
+        )
         status = self._send_request(url, json, data, headers, method, timeout=timeout)
         # Generate a new token
         if status.status_code == 401:
             self._get_new_token()
             headers["Authorization"] = f"Bearer {self.token}"
+            _logger.debug("UPS request returned 401; retrying with a refreshed token")
             status = self._send_request(
                 url, json, data, headers, method, timeout=timeout
             )
+        status_code = status.status_code
         status = status.json()
+        _logger.debug("UPS Response: Status=%s, Content=%s", status_code, status)
         ups_last_request = f"URL: {self.url}\nData: {data}\nJSON: {json}"
         self.carrier.log_xml(ups_last_request, "ups_last_request")
         self.carrier.log_xml(status or "", "ups_last_response")

--- a/delivery_ups_oca/tests/test_delivery_ups.py
+++ b/delivery_ups_oca/tests/test_delivery_ups.py
@@ -733,6 +733,62 @@ class TestDeliveryUps(TestDeliveryUpsBase):
         mock_requests.post.assert_called_once()
         self.assertEqual(mock_requests.post.call_args.kwargs["timeout"], 10)
 
+    def test_ups_get_new_token_success(self):
+        self.carrier.ups_client_id = "test_id"
+        self.carrier.ups_client_secret = "test_secret"
+
+        ups_request = UpsRequest(self.carrier)
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "abc123",
+            "expires_in": 3600,
+        }
+
+        with mock.patch.object(
+            ups_request, "_send_request", return_value=mock_response
+        ):
+            before = datetime.now()
+            ups_request._get_new_token()
+
+        self.assertEqual(ups_request.token, "abc123")
+        self.assertEqual(self.carrier.ups_token, "abc123")
+        self.assertGreater(self.carrier.ups_token_expiration_date, before)
+
+    def test_ups_process_reply_401_retry(self):
+        future_date = datetime.now() + timedelta(hours=1)
+        self.carrier.ups_token = "valid_token_123"
+        self.carrier.ups_token_expiration_date = future_date
+
+        ups_request = UpsRequest(self.carrier)
+
+        unauthorized_response = mock.Mock()
+        unauthorized_response.status_code = 401
+
+        success_response = mock.Mock()
+        success_response.status_code = 200
+        success_response.json.return_value = {"success": True, "data": "test_data"}
+
+        with (
+            mock.patch.object(
+                ups_request,
+                "_send_request",
+                side_effect=[unauthorized_response, success_response],
+            ) as mock_send_request,
+            mock.patch.object(ups_request, "_get_new_token") as mock_get_new_token,
+            self._patch_carrier_log_xml(),
+        ):
+            result = ups_request._process_reply(
+                url="https://api.test.com/endpoint",
+                json={"key": "value"},
+                method="post",
+            )
+
+        self.assertEqual(result, {"success": True, "data": "test_data"})
+        self.assertEqual(mock_send_request.call_count, 2)
+        mock_get_new_token.assert_called_once()
+
     def test_ups_prepare_create_shipping_with_packages(self):
         """Test _prepare_create_shipping with packages from picking"""
         # Enable use packages from picking


### PR DESCRIPTION
Add debug-level logging around the UPS token exchange and API requests including token masking.