### PR TITLE
[18.0][FIX] delivery_ups_oca: convert rate price from response currency, not the reverse

### DIFF
--- a/delivery_ups_oca/models/delivery_carrier.py
+++ b/delivery_ups_oca/models/delivery_carrier.py
@@ -117,13 +117,11 @@ class DeliveryCarrier(models.Model):
         """We need to convert the price if the currency is different."""
         price = float(total_charges["MonetaryValue"])
         if total_charges["CurrencyCode"] != currency.name:
-            price = currency._convert(
-                price,
-                self.env["res.currency"].search(
-                    [("name", "=", total_charges["CurrencyCode"])]
-                ),
-                company,
-                fields.Date.today(),
+            response_currency = self.env["res.currency"].search(
+                [("name", "=", total_charges["CurrencyCode"])], limit=1
+            )
+            price = response_currency._convert(
+                price, currency, company, fields.Date.context_today(self)
             )
         return price
 

--- a/delivery_ups_oca/tests/test_delivery_ups.py
+++ b/delivery_ups_oca/tests/test_delivery_ups.py
@@ -1173,6 +1173,7 @@ class TestUpsNegotiatedRates(TestDeliveryUpsBase):
         """When negotiated rates are enabled, the rate request must ask for them
         and the returned price must be the negotiated one when available."""
         self.carrier.ups_negotiated_rates = True
+        self.sale.currency_id = self.env.ref("base.EUR")
         response_value = self.get_mock_rate_response_values(
             charges="16.49", negotiated_charges=True
         )
@@ -1192,6 +1193,7 @@ class TestUpsNegotiatedRates(TestDeliveryUpsBase):
     def test_rate_shipment_without_negotiated_rates(self):
         """When negotiated rates are disabled (default), the rate request must not
         ask for them and the standard price is used."""
+        self.sale.currency_id = self.env.ref("base.EUR")
         response_value = self.get_mock_rate_response_values(charges="16.49")
         with mock.patch(_provider_class + "._process_reply") as mock_process_reply:
             mock_process_reply.return_value = response_value


### PR DESCRIPTION
The rate tests added in #1224 fail on any database where the order currency isn't EUR: the mocked UPS response is in EUR, so the price gets converted and the hardcoded asserts break (AssertionError: 20.96 != 16.33). OCA CI doesn't catch it because EUR is inactive on a bare install.

While debugging it we found _ups_get_response_price() also converts in the wrong direction (order to response currency instead of the reverse).

This PR fixes the conversion direction following the delivery_easypost_oca pattern, and pins the order currency in those tests so they don't depend on the database currencies.

@tecnativa @carlos-lopez-tecnativa @pedrobaeza @jans23 