### PR TITLE
[17.0][FIX] delivery_sendcloud_oca: stabilize API error assertions

### DIFF
--- a/delivery_sendcloud_oca/tests/test_delivery_sendcloud_oca.py
+++ b/delivery_sendcloud_oca/tests/test_delivery_sendcloud_oca.py
@@ -507,13 +507,9 @@ class TestDeliverySendCloud(TransactionCase):
             sale_order.picking_ids.cancel_shipment()["xml_id"],
             "delivery_sendcloud_oca.sendcloud_cancel_shipment_confirm_wizard",
         )
-        err_msg = (
-            "(?s)Sendcloud: (Invalid username/password|"
-            ".*[Aa]ccess credentials.*|.*invalid_client.*)"
-        )
-        with self.assertRaisesRegex(UserError, err_msg):
+        with self.assertRaisesRegex(UserError, "Sendcloud"):
             sale_order.action_cancel()
-        with self.assertRaisesRegex(UserError, err_msg):
+        with self.assertRaisesRegex(UserError, "Sendcloud"):
             sale_order.button_delete_sendcloud_order()
         sendcloud_cancel_shipment_confirm_wizard_form = Form(
             self.env["sendcloud.cancel.shipment.confirm.wizard"].with_context(
@@ -528,11 +524,11 @@ class TestDeliverySendCloud(TransactionCase):
         )
         with recorder.use_cassette("cancel_parcel"):
             sendcloud_cancel_shipment_confirm_wizard_form.do_cancel_shipment()
-        with self.assertRaisesRegex(UserError, err_msg):
+        with self.assertRaisesRegex(UserError, "Sendcloud"):
             sale_order.picking_ids.button_delete_sendcloud_picking()
-        with self.assertRaisesRegex(UserError, err_msg):
+        with self.assertRaisesRegex(UserError, "Sendcloud"):
             sale_order.picking_ids.action_cancel()
-        with self.assertRaisesRegex(UserError, err_msg):
+        with self.assertRaisesRegex(UserError, "Sendcloud"):
             sale_order.picking_ids.unlink()
 
     @mute_logger("py.warnings")


### PR DESCRIPTION
We face a build issue trying to merge another PR:
- [ ] https://github.com/OCA/delivery-carrier/pull/830
https://github.com/OCA/delivery-carrier/actions/runs/34332883846/job/102405366483

```
Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/misc.py", line 827, in deco
    return func(*args, **kwargs)
  File "/__w/delivery-carrier/delivery-carrier/delivery_sendcloud_oca/tests/test_delivery_sendcloud_oca.py", line 514, in test_10_auto_create_invoice
    with self.assertRaisesRegex(UserError, err_msg):
AssertionError: "(?s)Sendcloud: (Invalid username/password|.*[Aa]ccess credentials.*|.*invalid_client.*)" does not match "Sendcloud: The request could not be authorized"
```
The Sendcloud API returns a different authentication error message, causing `TestDeliverySendCloud.test_10_auto_create_invoice` to fail even though the expected `UserError` is correctly raised.

This PR backports the pattern already merged in 18.0, where the same operations use
`assertRaisesRegex(UserError, "Sendcloud")`
REF: https://github.com/OCA/delivery-carrier/blob/18.0/delivery_sendcloud_oca/tests/test_delivery_sendcloud_oca.py